### PR TITLE
[no-ticket] docker script fixes

### DIFF
--- a/build-w-docker.sh
+++ b/build-w-docker.sh
@@ -7,8 +7,11 @@ set -e
 # reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
 cd $(dirname $0)
 
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
 docker run --rm \
-    -v /`pwd`:/work \
+    -v `pwd`:/work \
     -w /work \
     node:8 \
     /bin/sh -c "\

--- a/watch-w-docker.sh
+++ b/watch-w-docker.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd $(dirname $0)
+
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+docker run --rm \
+    -p 3000:3000 \
+    -v `pwd`:/work \
+    -w /work \
+    node:8 \
+    /bin/sh -c "\
+        yarn \
+        && yarn start \
+    "


### PR DESCRIPTION
# Overview
We could use docker locally and avoid having all tools installed on our local machines. I've fixed the scripts to run on windows too.
 
### Changes
- Fixed script build-w-docker.sh to work on windows
- Added watch script with docker

### To run the scripts
With docker running locally, in git bash:
- Build: `sh build-w-docker.sh`  
- Watch: `sh watch-w-docker.sh` 