### PR TITLE
Fix index.html behavior in any CDN folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-scripts": "2.1.1",
     "react-testing-library": "^5.4.4"
   },
-  "homepage": "https://cdn.fromdoppler.com/doppler-webapp/latest",
+  "homepage": ".",
   "scripts": {
     "start": "react-scripts start",
     "build": "yarn prettier-check && react-scripts build && yarn eclint && yarn test",


### PR DESCRIPTION
Issue:

![issue](https://user-images.githubusercontent.com/1157864/52499717-c9bc8f00-2bba-11e9-9f72-2f60b4b8ae6d.png)

Maybe this approach is not the best since it limits us from some routing features, see https://facebook.github.io/create-react-app/docs/deployment#serving-the-same-build-from-different-paths

> If you are not using the HTML5 pushState history API or not using client-side routing at all, it is unnecessary to specify the URL from which your app will be served.

But, by the moment, it is fine. In the future, we could update _homepage_ property as part of the build process.