### PR TITLE
Npm script for run tests in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:int": "env-cmd .env.int yarn build",
     "build:development": "env-cmd .env.development yarn build",
     "test": "react-scripts test --watchAll=false",
+    "test:watch": "react-scripts test",
     "eject": "react-scripts eject",
     "eclint": "eclint check  src/**/*.js",
     "prettier": "prettier --write src/**/*.js src/**/*.ts",


### PR DESCRIPTION
![2019-03-02_08-28-53 1](https://user-images.githubusercontent.com/1157864/53681253-a66e9680-3cc5-11e9-8c51-08af33f0c09d.gif)

In Mac was necessary to install _Watchman Homebrew package_ (`brew install watchman`), I do not know if something similar is necessary for other OS.