### PR TITLE
Include header data in session object

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,14 +57,14 @@ class App extends Component {
 
   render() {
     const {
-      dopplerSession: { status: sessionStatus },
+      dopplerSession: { status: sessionStatus, userData },
       i18n,
     } = this.state;
     return (
       <IntlProvider locale={i18n.locale} messages={i18n.messages}>
         {sessionStatus === 'authenticated' ? (
           <>
-            <Header />
+            <Header userData={userData} />
             <img src={logo} alt="logo" />
             <Footer />
           </>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -58,7 +58,18 @@ describe('App component', () => {
     getByText('Loading...');
 
     // Act
-    dependencies.sessionManager.updateAppSession({ status: 'authenticated' });
+    dependencies.sessionManager.updateAppSession({
+      status: 'authenticated',
+      userData: {
+        user: {
+          email: expectedEmail,
+          avatar: {},
+          plan: {},
+          nav: [],
+        },
+        nav: [],
+      },
+    });
 
     // Assert
     getByText(expectedEmail);

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,19 +2,18 @@ import React from 'react';
 import HeaderNav from './HeaderNav/HeaderNav';
 import HeaderMessages from './HeaderMessages/HeaderMessages';
 import HeaderUserMenu from './HeaderUserMenu/HeaderUserMenu';
-import headerData from '../../headerData.json';
 import { FormattedMessage } from 'react-intl';
 
-const Header = () => {
+const Header = ({ userData: { user, nav, alert } }) => {
   return (
     <div>
-      {headerData.alert ? <HeaderMessages alert={headerData.alert} /> : null}
+      {alert ? <HeaderMessages alert={alert} /> : null}
       <header className="header-main">
         <div className="header-wrapper">
           <div className="logo">
             <span className="ms-icon icon-doppler-logo" />
           </div>
-          <HeaderNav nav={headerData.nav} />
+          <HeaderNav nav={nav} />
           <nav className="nav-right-main">
             <ul className="nav-right-main--list">
               <li>
@@ -32,7 +31,7 @@ const Header = () => {
                 </FormattedMessage>
               </li>
               <li>
-                <HeaderUserMenu user={headerData.user} />
+                <HeaderUserMenu user={user} />
               </li>
             </ul>
             <span id="open-menu" className="ms-icon icon-menu desktop-hd-hidden" />

--- a/src/components/Header/HeaderUserMenu/HeaderUserMenu.js
+++ b/src/components/Header/HeaderUserMenu/HeaderUserMenu.js
@@ -35,7 +35,7 @@ class HeaderUserMenu extends React.Component {
           </header>
           <div className="user-plan--container">
             <div className="user-plan--type">
-              {user.plan.isSubscribers === 'true' || user.plan.isMonthlyByEmail === 'true' ? (
+              {user.plan.isSubscribers || user.plan.isMonthlyByEmail ? (
                 <p className="user-plan--monthly-text">
                   <span>{user.plan.planName}</span> |{' '}
                   <strong>
@@ -50,25 +50,21 @@ class HeaderUserMenu extends React.Component {
                 {user.plan.description}
               </p>
             </div>
-            {user.clientManager &&
-            user.plan.buttonUrl &&
-            user.plan.pendingFreeUpgrade !== 'true' ? (
+            {user.hasClientManager && user.plan.buttonUrl && !user.plan.pendingFreeUpgrade ? (
               <a className="buy-plan" href={user.plan.buttonUrl}>
                 {user.plan.buttonText}
               </a>
             ) : (
               ''
             )}
-            {!user.clientManager &&
-            user.plan.buttonUrl &&
-            user.plan.pendingFreeUpgrade !== 'true' ? (
+            {!user.hasClientManager && user.plan.buttonUrl && !user.plan.pendingFreeUpgrade ? (
               <button onClick={this.handleOpenBuyModal} className="user-plan">
                 {user.plan.buttonText}
               </button>
             ) : (
               ''
             )}
-            {!user.clientManager && !user.plan.buttonUrl ? (
+            {!user.hasClientManager && !user.plan.buttonUrl ? (
               <button onClick={this.handleOpenBuyModal} className="user-plan">
                 {user.plan.buttonText}
               </button>
@@ -90,7 +86,7 @@ class HeaderUserMenu extends React.Component {
           handleClose={this.handleCloseBuyModal}
         >
           <UpgradePlanForm
-            isSubscriber={user.plan.isSubscribers === 'true'}
+            isSubscriber={user.plan.isSubscribers}
             handleClose={this.handleCloseBuyModal}
           />
         </Modal>

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -1,11 +1,19 @@
-import { DopplerLegacyClient } from './doppler-legacy-client';
+import { DopplerLegacyClient, mapHeaderDataJson } from './doppler-legacy-client';
+import headerDataJson from '../headerData.json';
 
 export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
+  public constructor(public readonly email = 'hardcoded@email.com') {}
+
   public async getUserData() {
+    const { user, nav, alert } = mapHeaderDataJson(headerDataJson);
+
     return {
       user: {
-        email: 'hardcoded@email.com',
+        ...user,
+        email: this.email,
       },
+      nav: nav,
+      alert,
     };
   }
 }

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -3,7 +3,9 @@ import { DopplerLegacyClient } from './doppler-legacy-client';
 export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
   public async getUserData() {
     return {
-      email: 'hardcoded@email.com',
+      user: {
+        email: 'hardcoded@email.com',
+      },
     };
   }
 }

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -1,7 +1,10 @@
 import { AxiosInstance, AxiosStatic } from 'axios';
 
-export interface DopplerLegacyUserData {
+interface UserEntry {
   email: string;
+}
+export interface DopplerLegacyUserData {
+  user: UserEntry;
 }
 
 export interface DopplerLegacyClient {
@@ -25,7 +28,9 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
     }
 
     return {
-      email: response.data.Email,
+      user: {
+        email: response.data.Email,
+      },
     };
   }
 }

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -1,14 +1,117 @@
 import { AxiosInstance, AxiosStatic } from 'axios';
+import { Color } from 'csstype';
+import headerDataJson from '../headerData.json';
+
+interface NavEntry {
+  isSelected: boolean;
+  title: string;
+  url: string;
+}
+
+interface SubNavEntry extends NavEntry {}
+
+interface MainNavEntry extends NavEntry {
+  subNav: SubNavEntry[];
+}
+
+interface PlanEntry {
+  buttonText: string;
+  buttonUrl: string;
+  description: string;
+  isMonthlyByEmail: boolean;
+  isSubscribers: boolean;
+  itemDescription: string;
+  maxSubscribers: number;
+  pendingFreeUpgrade: boolean;
+  planName: string;
+  remainingCredits: number;
+}
+
+interface AvatarEntry {
+  color: Color;
+  text: string;
+}
 
 interface UserEntry {
+  avatar: AvatarEntry;
   email: string;
+  fullname: string;
+  hasClientManager: boolean;
+  lang: string;
+  nav: NavEntry[];
+  plan: PlanEntry;
 }
+
+interface AlertEntry {
+  button: {
+    text: string;
+    url: string;
+  };
+  message: string;
+  type: string;
+}
+
 export interface DopplerLegacyUserData {
+  alert: AlertEntry | undefined;
+  nav: MainNavEntry[];
   user: UserEntry;
 }
 
 export interface DopplerLegacyClient {
   getUserData(): Promise<DopplerLegacyUserData>;
+}
+
+function mapPlanEntry(json: any): PlanEntry {
+  return {
+    buttonText: json.buttonText,
+    buttonUrl: json.buttonUrl,
+    description: json.description,
+    isMonthlyByEmail: JSON.parse(json.isMonthlyByEmail),
+    isSubscribers: JSON.parse(json.isSubscribers),
+    itemDescription: json.itemDescription,
+    maxSubscribers: JSON.parse(json.maxSubscribers),
+    pendingFreeUpgrade: JSON.parse(json.pendingFreeUpgrade),
+    planName: json.planName,
+    remainingCredits: JSON.parse(json.remainingCredits),
+  };
+}
+
+function mapNavEntry(json: any): NavEntry {
+  return {
+    isSelected: json.isSelected,
+    title: json.title,
+    url: json.url,
+  };
+}
+
+function mapNavMainEntry(json: any): MainNavEntry {
+  return {
+    ...mapNavEntry(json),
+    subNav: (json.subNav && json.subNav.map(mapNavEntry)) || [],
+  };
+}
+
+export function mapHeaderDataJson(json: any) {
+  return {
+    alert: json.alert && {
+      button: json.alert.button && {
+        text: json.alert.button.text,
+        url: json.alert.button.url,
+      },
+      message: json.alert.type,
+      type: json.alert.type,
+    },
+    nav: (json.nav && json.nav.map(mapNavMainEntry)) || [],
+    user: {
+      avatar: json.user.avatar,
+      email: json.email,
+      fullname: json.user.fullname,
+      hasClientManager: !!json.clientManager,
+      lang: json.user.lang,
+      nav: (json.user.nav && json.user.nav.map(mapNavEntry)) || [],
+      plan: mapPlanEntry(json.user.plan),
+    },
+  };
 }
 
 export class HttpDopplerLegacyClient implements DopplerLegacyClient {
@@ -27,9 +130,15 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
       throw new Error('Empty Doppler response');
     }
 
+    // TODO: get this data from backend
+    const { alert, nav, user } = mapHeaderDataJson(headerDataJson);
+
     return {
+      alert: alert,
+      nav: nav,
       user: {
-        email: response.data.Email,
+        ...user,
+        email: response.data.email,
       },
     };
   }

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -1,11 +1,11 @@
-import { DopplerLegacyClient } from './doppler-legacy-client';
+import { DopplerLegacyClient, DopplerLegacyUserData } from './doppler-legacy-client';
 
 type AppSession =
   | { status: 'unknown' }
   | { status: 'non-authenticated' }
   | {
       status: 'authenticated';
-      // TODO: add here more data for authenticated session
+      userData: DopplerLegacyUserData;
     };
 
 const noop = () => {};
@@ -60,7 +60,10 @@ export class OnlineSessionManager implements SessionManager {
 
       // TODO: deal with JWT Token
       // TODO: get other data related to user
-      this.updateSession({ status: 'authenticated' });
+      this.updateSession({
+        status: 'authenticated',
+        userData: dopplerUserData,
+      });
     } catch (error) {
       this.logOut();
     }


### PR DESCRIPTION
Hi team,

I am moving headers data inside session object and using it in header components.

I have also refined some header components in order to use a sanitized version of _DopplerLegacy's HeaderData_ object. 

In the way, I have detected that we are not paying attention to all _HeaderData_ properties, so, I changed the mappers to map only used properties so we could detect when we need something else.

Could you review it, please?

Next steps:

* Add tests.
* [DBR-94](http://jira.makingsense.com/browse/DBR-94) - Pay attention to _HeaderData_ language to translate the App.
* [DBR-81](http://jira.makingsense.com/browse/DBR-81) - Read _HeaderData_ from backend.
* [DBR-95](http://jira.makingsense.com/browse/DBR-95) - Move more AJAX calls to doppler-legacy-client
* Add tests (more yet).