### PR TITLE
refactor(localization): encapsulate IntlProvider configuration and dependencies into a component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,13 @@
 import React, { Component } from 'react';
 import logo from './logo.svg';
 import './App.css';
-import { addLocaleData, FormattedMessage, IntlProvider } from 'react-intl';
-import en from 'react-intl/locale-data/en';
-import es from 'react-intl/locale-data/es';
-import messages_es from './i18n/es.json';
-import messages_en from './i18n/en.json';
-import { flattenMessages } from './utils';
+import DopplerIntlProvider from './DopplerIntlProvider';
+import { FormattedMessage } from 'react-intl';
 import Header from './components/Header/Header';
 import Footer from './components/Footer/Footer';
 import axios from 'axios';
 import { HttpDopplerLegacyClient } from './services/doppler-legacy-client';
 import { OnlineSessionManager } from './services/session-manager';
-
-const messages = {
-  es: messages_es,
-  en: messages_en,
-};
-
-addLocaleData([...en, ...es]);
 
 class App extends Component {
   constructor(props) {
@@ -36,10 +25,7 @@ class App extends Component {
 
     this.state = {
       dopplerSession: this.sessionManager.session,
-      i18n: {
-        locale: props.locale,
-        messages: flattenMessages(messages[props.locale]),
-      },
+      i18nLocale: props.locale,
     };
   }
 
@@ -58,10 +44,10 @@ class App extends Component {
   render() {
     const {
       dopplerSession: { status: sessionStatus, userData },
-      i18n,
+      i18nLocale,
     } = this.state;
     return (
-      <IntlProvider locale={i18n.locale} messages={i18n.messages}>
+      <DopplerIntlProvider locale={i18nLocale}>
         {sessionStatus === 'authenticated' ? (
           <>
             <Header userData={userData} />
@@ -73,7 +59,7 @@ class App extends Component {
             <FormattedMessage id="loading" />
           </div>
         )}
-      </IntlProvider>
+      </DopplerIntlProvider>
     );
   }
 }

--- a/src/DopplerIntlProvider.double-with-ids-as-values.js
+++ b/src/DopplerIntlProvider.double-with-ids-as-values.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { addLocaleData, IntlProvider } from 'react-intl';
+import en from 'react-intl/locale-data/en';
+import messages_en from './i18n/en.json';
+import { flattenMessages } from './utils';
+
+addLocaleData([...en]);
+
+const messages = Object.keys(flattenMessages(messages_en)).reduce(
+  (accumulator, currentValue) => ({ ...accumulator, [currentValue]: currentValue }),
+  {},
+);
+
+export default ({ children }) => (
+  <IntlProvider locale="en" messages={messages}>
+    {children}
+  </IntlProvider>
+);

--- a/src/DopplerIntlProvider.js
+++ b/src/DopplerIntlProvider.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { addLocaleData, IntlProvider } from 'react-intl';
+import en from 'react-intl/locale-data/en';
+import es from 'react-intl/locale-data/es';
+import messages_es from './i18n/es.json';
+import messages_en from './i18n/en.json';
+import { flattenMessages } from './utils';
+
+const messages = {
+  es: messages_es,
+  en: messages_en,
+};
+
+addLocaleData([...en, ...es]);
+
+export default ({ locale, children }) => (
+  <IntlProvider locale={locale || 'en'} messages={flattenMessages(messages[locale || 'en'])}>
+    {children}
+  </IntlProvider>
+);

--- a/src/DopplerIntlProvider.test.js
+++ b/src/DopplerIntlProvider.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import DopplerIntlProvider from './DopplerIntlProvider';
+import { render, cleanup } from 'react-testing-library';
+import 'jest-dom/extend-expect';
+import { FormattedMessage } from 'react-intl';
+
+describe('DopplerIntlProvider', () => {
+  beforeEach(cleanup);
+
+  it('should render loading in English', () => {
+    const { getByText } = render(
+      <DopplerIntlProvider locale="en">
+        <FormattedMessage id="loading" />
+      </DopplerIntlProvider>,
+    );
+    getByText('Loading...');
+  });
+
+  it('should render loading in Spanish', () => {
+    const { getByText } = render(
+      <DopplerIntlProvider locale="es">
+        <FormattedMessage id="loading" />
+      </DopplerIntlProvider>,
+    );
+    getByText('Cargando...');
+  });
+});


### PR DESCRIPTION
Hi Team, I have another little refactoring...

When I tried to introduce a test for `UpgradePlanForm.js`, I realized that I need _IntlProvider_ scope.

Talking with @mvillaseco, first, we thought about having a helper for the test, but then we understood that the same helper could be useful for all the application.

It is not a nice module, it works as a singleton, with a state, but I think that for the moment it is fine, and in the future, we could refactor it.

When we need to test independent components, we could do something like this:

```js-jsx
describe('UpgradePlanForm', () => {
  it('should . . . ', () => {
    const { getByText } = render(
      <DopplerIntlProvider>
        <UpgradePlanForm isSubscriber={true} />
      </IntlProvider>);
    // . . .
```

Could you review it?

