### PR TITLE
Move UpgradePlanForm's AJAX calls to DopplerLegacyClient

### DIFF
--- a/src/components/Reports/ReportsService.js
+++ b/src/components/Reports/ReportsService.js
@@ -1,6 +1,4 @@
-function timeout(ms) {
-  return () => new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { timeout } from '../../utils';
 
 const fakeData = [
   {

--- a/src/components/UpgradePlanForm/UpgradePlanForm.js
+++ b/src/components/UpgradePlanForm/UpgradePlanForm.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import axios from 'axios';
 import { FormattedMessage } from 'react-intl';
+import { InjectAppServices } from '../../services/pure-di';
 
 class UpgradePlanForm extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor({ dependencies: { dopplerLegacyClient } }) {
+    super();
+
+    /** @type { import('../../services/doppler-legacy-client').DopplerLegacyClient } */
+    this.dopplerLegacyClient = dopplerLegacyClient;
 
     this.state = {
       userPlanModel: null,
@@ -15,34 +18,12 @@ class UpgradePlanForm extends React.Component {
   }
 
   async componentWillMount() {
-    const idUserType = this.props.isSubscriber ? 4 : 2;
-    const response = await axios.get(
-      process.env.REACT_APP_API_URL +
-        '/SendUpgradePlanContactEmail/GetUpgradePlanData?idUserType=' +
-        idUserType,
-      {
-        withCredentials: true,
-      },
-    );
-    this.setState({ userPlanModel: response.data.data });
+    const result = await this.dopplerLegacyClient.getUpgradePlanData(this.props.isSubscriber);
+    this.setState({ userPlanModel: result });
   }
 
   async submitForm() {
-    //TODO research axios cancel request
-
-    await fetch(
-      process.env.REACT_APP_API_URL + '/SendUpgradePlanContactEmail/SendEmailUpgradePlan',
-      {
-        method: 'post',
-        crossDomain: true,
-        body: JSON.stringify(this.state.userPlanModel),
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        credentials: 'include',
-      },
-    );
-
+    await this.dopplerLegacyClient.sendEmailUpgradePlan(this.state.userPlanModel);
     this.props.handleClose();
   }
 
@@ -124,4 +105,4 @@ class UpgradePlanForm extends React.Component {
   }
 }
 
-export default UpgradePlanForm;
+export default InjectAppServices(UpgradePlanForm);

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -1,10 +1,12 @@
 import { DopplerLegacyClient, mapHeaderDataJson } from './doppler-legacy-client';
 import headerDataJson from '../headerData.json';
+import { timeout } from '../utils';
 
 export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
   public constructor(public readonly email = 'hardcoded@email.com') {}
 
   public async getUserData() {
+    await timeout(3000);
     const { user, nav, alert } = mapHeaderDataJson(headerDataJson);
 
     return {

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -1,4 +1,8 @@
-import { DopplerLegacyClient, mapHeaderDataJson } from './doppler-legacy-client';
+import {
+  DopplerLegacyClient,
+  mapHeaderDataJson,
+  DopplerLegacyUpgradePlanContactModel,
+} from './doppler-legacy-client';
 import headerDataJson from '../headerData.json';
 import { timeout } from '../utils';
 
@@ -17,5 +21,41 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
       nav: nav,
       alert,
     };
+  }
+
+  public async getUpgradePlanData(isSubscriberPlan: boolean) {
+    await timeout(3000);
+    return {
+      ClientTypePlans: [
+        {
+          IdUserTypePlan: 1,
+          Description: 'Plan 1 Descripción',
+          EmailQty: 12345,
+          Fee: 678.9,
+          ExtraEmailCost: 0.0123,
+          SubscribersQty: 456,
+        },
+        {
+          IdUserTypePlan: 2,
+          Description: 'Plan 2 Descripción',
+          EmailQty: null,
+          Fee: 678.9,
+          ExtraEmailCost: null,
+          SubscribersQty: 456,
+        },
+        {
+          IdUserTypePlan: 3,
+          Description: 'Plan 3 Descripción',
+          EmailQty: 12345,
+          Fee: 678.9,
+          ExtraEmailCost: 0.0123,
+          SubscribersQty: null,
+        },
+      ],
+    };
+  }
+
+  public async sendEmailUpgradePlan(planModel: DopplerLegacyUpgradePlanContactModel) {
+    await timeout(3000);
   }
 }

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -1,6 +1,11 @@
 import { AxiosInstance, AxiosStatic } from 'axios';
 import { Color } from 'csstype';
 
+export interface DopplerLegacyClient {
+  getUserData(): Promise<DopplerLegacyUserData>;
+}
+
+/* #region DopplerLegacyUserData data types */
 interface NavEntry {
   isSelected: boolean;
   title: string;
@@ -55,11 +60,9 @@ export interface DopplerLegacyUserData {
   nav: MainNavEntry[];
   user: UserEntry;
 }
+/* #endregion */
 
-export interface DopplerLegacyClient {
-  getUserData(): Promise<DopplerLegacyUserData>;
-}
-
+/* #region DopplerLegacyUserData mappings */
 function mapPlanEntry(json: any): PlanEntry {
   return {
     buttonText: json.buttonText,
@@ -112,6 +115,7 @@ export function mapHeaderDataJson(json: any) {
     },
   };
 }
+/* #endregion */
 
 export class HttpDopplerLegacyClient implements DopplerLegacyClient {
   private readonly axios: AxiosInstance;

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -146,7 +146,7 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
   }
 
   public async getUserData() {
-    var response = await this.axios.get('/WebApp/GetUserData');
+    const response = await this.axios.get('/WebApp/GetUserData');
     if (!response || !response.data) {
       throw new Error('Empty Doppler response');
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,7 @@
+export function timeout(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export function flattenMessages(nestedMessages, prefix = '') {
   return Object.keys(nestedMessages).reduce((messages, key) => {
     let value = nestedMessages[key];


### PR DESCRIPTION
Finally, I am taking advantage of the dependency inversion in the following way:

![image](https://user-images.githubusercontent.com/1157864/54388467-899a7180-467c-11e9-9527-8ba7d6896ff0.png)

I have also added the test data to _doppler-legacy-client.doubles_, and done minor fixes as _timeout_ helper.

Could you review? (@cbernat and @fcoronelmakingsense I am looking you ;), you will need to use this)