### PR TITLE
Fix issues with date representation

### DIFF
--- a/src/components/Reports/Reports.test.js
+++ b/src/components/Reports/Reports.test.js
@@ -4,16 +4,19 @@ import 'jest-dom/extend-expect';
 import DopplerIntlProvider from '../../DopplerIntlProvider.double-with-ids-as-values';
 import Reports from './Reports';
 
+const verifiedDateAsEngString = '12/17/2017';
+const verifiedDateAsDate = new Date('2017-12-17');
+
 const fakeData = [
   {
     id: 1,
     name: 'www.fromdoppler.com',
-    verified_date: new Date('2017-12-17'),
+    verified_date: verifiedDateAsDate,
   },
   {
     id: 2,
     name: 'www.makingsense.com',
-    verified_date: new Date('2010-12-17'),
+    verified_date: verifiedDateAsDate,
   },
 ];
 
@@ -46,9 +49,9 @@ describe('Reports page', () => {
       </DopplerIntlProvider>,
     );
 
-    await wait(() => getByText(fakeData[0].verified_date));
+    await wait(() => getByText(verifiedDateAsEngString));
 
-    const verifiedDate = getByText(fakeData[0].verified_date);
+    const verifiedDate = getByText(verifiedDateAsEngString);
     const domain = getByText(fakeData[1].name);
 
     expect(verifiedDate).toBeDefined();

--- a/src/components/Reports/ReportsFilters/ReportsFilters.js
+++ b/src/components/Reports/ReportsFilters/ReportsFilters.js
@@ -39,7 +39,7 @@ const ReportsFilters = ({
             {domainSelected ? (
               <span className="verified--domain">
                 <FormattedMessage id="reports_filters.verified_domain" />{' '}
-                <FormattedDate value={domainSelected.verified_date} />
+                <FormattedDate value={domainSelected.verified_date} timeZone="UTC" />
               </span>
             ) : null}
           </fieldset>


### PR DESCRIPTION
Hi team, 

I do not know why the tests are passing in CI, but they started to fail in my local environment and it was because I was using Dates in _Reports.test.js_'s assertions.

I fixed that, and I saw that besides that, we were rendering a wrong date because _FormattedDate_ uses current timezone by default. 

In order to avoid this problem by the moment **we should use _timeZone_ parameter** in this way:

```
<FormattedDate value={domainSelected.verified_date} timeZone="UTC" />
``` 

I have also removed some redundant assertions.

Could you kindly review it?