### PR TITLE
Use hash routes in place of slash ones

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import './App.css';
 import DopplerIntlProvider from './DopplerIntlProvider';
 import { FormattedMessage } from 'react-intl';
-import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
+import { HashRouter as Router, Route, Redirect } from 'react-router-dom';
 import Header from './components/Header/Header';
 import Footer from './components/Footer/Footer';
 import Reports from './components/Reports/Reports';


### PR DESCRIPTION
Sorry team, I know that it is not so fancy, but by the moment it will be a better option than slashes.

![2019-03-19_11-42-43 (1)](https://user-images.githubusercontent.com/1157864/54615761-66d1d980-4a3d-11e9-960c-f3b0eb2be0bd.gif)

It helps us to simplify server configuration, build, deploys and testing PRs in our CDN.