### PR TITLE
Public and private routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@types/node": "^11.10.4",
     "@types/react": "^16.8.6",
     "@types/react-dom": "^16.8.2",
+    "@types/react-router-dom": "^4.3.1",
     "axios": "^0.18.0",
     "eclint": "^2.8.1",
     "env-cmd": "^8.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,12 @@ import Footer from './components/Footer/Footer';
 import Reports from './components/Reports/Reports';
 import { InjectAppServices } from './services/pure-di';
 import Loading from './components/Loading/Loading';
+// If we want to use Internal Login
+// import { RedirectToInternalLogin as RedirectToLogin } from './components/RedirectToLogin';
+
+// If we want to use redirect to Doppler Legacy Login
+import { RedirectToLegacyLoginFactory } from './components/RedirectToLogin';
+const RedirectToLogin = RedirectToLegacyLoginFactory(process.env.REACT_APP_API_URL, window);
 
 class App extends Component {
   constructor({ locale, dependencies: { sessionManager } }) {
@@ -76,7 +82,7 @@ class App extends Component {
                 <Footer />
               </>
             ) : (
-              <this.RedirectToLogin from={props.location} />
+              <RedirectToLogin from={props.location} />
             )
           }
         />

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import './App.css';
 import DopplerIntlProvider from './DopplerIntlProvider';
-import { HashRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
+import { Route, Redirect, Switch } from 'react-router-dom';
 import PrivateRoute from './components/PrivateRoute';
 import Reports from './components/Reports/Reports';
 import { InjectAppServices } from './services/pure-di';
@@ -54,22 +54,20 @@ class App extends Component {
         {sessionStatus === 'unknown' ? (
           <Loading />
         ) : (
-          <Router>
-            <Switch>
-              <Route path="/" exact component={() => <Redirect to={{ pathname: '/reports' }} />} />
-              <PrivateRoute
-                path="/reports/"
-                exact
-                component={Reports}
-                userData={userData}
-                sessionStatus={sessionStatus}
-              />
-              <Route path="/login/" exact component={Login} />
-              {/* TODO: Implement NotFound page in place of redirect all to reports */}
-              {/* <Route component={NotFound} /> */}
-              <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />
-            </Switch>
-          </Router>
+          <Switch>
+            <Route path="/" exact component={() => <Redirect to={{ pathname: '/reports' }} />} />
+            <PrivateRoute
+              path="/reports/"
+              exact
+              component={Reports}
+              userData={userData}
+              sessionStatus={sessionStatus}
+            />
+            <Route path="/login/" exact component={Login} />
+            {/* TODO: Implement NotFound page in place of redirect all to reports */}
+            {/* <Route component={NotFound} /> */}
+            <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />
+          </Switch>
         )}
       </DopplerIntlProvider>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -2,23 +2,20 @@ import React, { Component } from 'react';
 import './App.css';
 import DopplerIntlProvider from './DopplerIntlProvider';
 import { HashRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
-import Header from './components/Header/Header';
-import Footer from './components/Footer/Footer';
+import PrivateRoute from './components/PrivateRoute';
 import Reports from './components/Reports/Reports';
 import { InjectAppServices } from './services/pure-di';
 import Loading from './components/Loading/Loading';
 import Login from './components/Login/Login';
 
 class App extends Component {
-  constructor({ locale, dependencies: { sessionManager, RedirectToLogin } }) {
+  constructor({ locale, dependencies: { sessionManager } }) {
     super();
 
     this.updateSession = this.updateSession.bind(this);
 
     /** @type { import('./services/session-manager').SessionManager } */
     this.sessionManager = sessionManager;
-    /** @type { import('./components/RedirectToLogin').RedirectToLogin } */
-    this.RedirectToLogin = RedirectToLogin;
 
     this.state = {
       dopplerSession: this.sessionManager.session,
@@ -52,25 +49,6 @@ class App extends Component {
       i18nLocale,
     } = this.state;
 
-    const PrivateRoute = ({ component: Component, ...rest }) => {
-      return (
-        <Route
-          {...rest}
-          render={(props) =>
-            sessionStatus === 'authenticated' ? (
-              <>
-                <Header userData={userData} />
-                <Component {...props} />
-                <Footer />
-              </>
-            ) : (
-              <this.RedirectToLogin from={props.location} />
-            )
-          }
-        />
-      );
-    };
-
     return (
       <DopplerIntlProvider locale={i18nLocale}>
         {sessionStatus === 'unknown' ? (
@@ -79,7 +57,13 @@ class App extends Component {
           <Router>
             <Switch>
               <Route path="/" exact component={() => <Redirect to={{ pathname: '/reports' }} />} />
-              <PrivateRoute path="/reports/" exact component={Reports} />
+              <PrivateRoute
+                path="/reports/"
+                exact
+                component={Reports}
+                userData={userData}
+                sessionStatus={sessionStatus}
+              />
               <Route path="/login/" exact component={Login} />
               {/* TODO: Implement NotFound page in place of redirect all to reports */}
               {/* <Route component={NotFound} /> */}

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import './App.css';
 import DopplerIntlProvider from './DopplerIntlProvider';
-import { HashRouter as Router, Route, Redirect } from 'react-router-dom';
+import { HashRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
 import Header from './components/Header/Header';
 import Footer from './components/Footer/Footer';
 import Reports from './components/Reports/Reports';
@@ -48,23 +48,56 @@ class App extends Component {
       dopplerSession: { status: sessionStatus, userData },
       i18nLocale,
     } = this.state;
-    const redirectToReports = () => <Redirect to={{ pathname: '/reports' }} />;
+
+    const Login = ({ location }) => (
+      <div>
+        {/* TODO: implement login */}
+        LOGIN. After login, redirect to{' '}
+        {location.state && location.state.from
+          ? `${location.state.from.pathname}${location.state.from.search}${
+              location.state.from.hash
+            }`
+          : '/'}
+        <code>
+          <pre>{JSON.stringify(location, null, 2)}</pre>
+        </code>
+      </div>
+    );
+
+    const PrivateRoute = ({ component: Component, ...rest }) => {
+      return (
+        <Route
+          {...rest}
+          render={(props) =>
+            sessionStatus === 'authenticated' ? (
+              <>
+                <Header userData={userData} />
+                <Component {...props} />
+                <Footer />
+              </>
+            ) : (
+              <this.RedirectToLogin from={props.location} />
+            )
+          }
+        />
+      );
+    };
 
     return (
       <DopplerIntlProvider locale={i18nLocale}>
         {sessionStatus === 'unknown' ? (
           <Loading />
-        ) : sessionStatus === 'authenticated' ? (
-          <Router>
-            <div>
-              <Header userData={userData} />
-              <Route path="/" exact component={redirectToReports} />
-              <Route path="/reports/" exact component={Reports} />
-              <Footer />
-            </div>
-          </Router>
         ) : (
-          <div>Not implemented</div>
+          <Router>
+            <Switch>
+              <Route path="/" exact component={() => <Redirect to={{ pathname: '/reports' }} />} />
+              <PrivateRoute path="/reports/" exact component={Reports} />
+              <Route path="/login/" exact component={Login} />
+              {/* TODO: Implement NotFound page in place of redirect all to reports */}
+              {/* <Route component={NotFound} /> */}
+              <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />
+            </Switch>
+          </Router>
         )}
       </DopplerIntlProvider>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Footer from './components/Footer/Footer';
 import Reports from './components/Reports/Reports';
 import { InjectAppServices } from './services/pure-di';
 import Loading from './components/Loading/Loading';
+import Login from './components/Login/Login';
 
 class App extends Component {
   constructor({ locale, dependencies: { sessionManager, RedirectToLogin } }) {
@@ -50,21 +51,6 @@ class App extends Component {
       dopplerSession: { status: sessionStatus, userData },
       i18nLocale,
     } = this.state;
-
-    const Login = ({ location }) => (
-      <div>
-        {/* TODO: implement login */}
-        LOGIN. After login, redirect to{' '}
-        {location.state && location.state.from
-          ? `${location.state.from.pathname}${location.state.from.search}${
-              location.state.from.hash
-            }`
-          : '/'}
-        <code>
-          <pre>{JSON.stringify(location, null, 2)}</pre>
-        </code>
-      </div>
-    );
 
     const PrivateRoute = ({ component: Component, ...rest }) => {
       return (

--- a/src/App.js
+++ b/src/App.js
@@ -7,21 +7,17 @@ import Footer from './components/Footer/Footer';
 import Reports from './components/Reports/Reports';
 import { InjectAppServices } from './services/pure-di';
 import Loading from './components/Loading/Loading';
-// If we want to use Internal Login
-// import { RedirectToInternalLogin as RedirectToLogin } from './components/RedirectToLogin';
-
-// If we want to use redirect to Doppler Legacy Login
-import { RedirectToLegacyLoginFactory } from './components/RedirectToLogin';
-const RedirectToLogin = RedirectToLegacyLoginFactory(process.env.REACT_APP_API_URL, window);
 
 class App extends Component {
-  constructor({ locale, dependencies: { sessionManager } }) {
+  constructor({ locale, dependencies: { sessionManager, RedirectToLogin } }) {
     super();
 
     this.updateSession = this.updateSession.bind(this);
 
     /** @type { import('./services/session-manager').SessionManager } */
     this.sessionManager = sessionManager;
+    /** @type { import('./components/RedirectToLogin').RedirectToLogin } */
+    this.RedirectToLogin = RedirectToLogin;
 
     this.state = {
       dopplerSession: this.sessionManager.session,
@@ -82,7 +78,7 @@ class App extends Component {
                 <Footer />
               </>
             ) : (
-              <RedirectToLogin from={props.location} />
+              <this.RedirectToLogin from={props.location} />
             )
           }
         />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -340,5 +340,58 @@ describe('App component', () => {
         expect(footerEl).toBeNull();
       });
     });
+
+    describe('authenticated user', () => {
+      it('should not be redirected after open /reports', () => {
+        const dependencies = {
+          RedirectToLogin: RedirectToInternalLogin,
+          sessionManager: createDoubleSessionManager(),
+        };
+
+        const currentRouteState = {};
+
+        const { getByText, container } = render(
+          <AppServicesProvider forcedServices={dependencies}>
+            <Router initialEntries={['/reports?param1=value1#hash']}>
+              <RouterInspector target={currentRouteState} />
+              <App locale="en" />
+            </Router>
+          </AppServicesProvider>,
+        );
+
+        expect(currentRouteState.location.pathname).toEqual('/reports');
+        expect(currentRouteState.location.search).toEqual('?param1=value1');
+        expect(currentRouteState.location.hash).toEqual('#hash');
+        getByText('Loading...');
+
+        // Act
+        dependencies.sessionManager.updateAppSession({
+          status: 'authenticated',
+          userData: {
+            user: {
+              lang: 'es',
+              avatar: {},
+              plan: {},
+              nav: [],
+            },
+            nav: [],
+          },
+        });
+
+        // Assert
+        expect(currentRouteState.location.pathname).toEqual('/reports');
+        expect(currentRouteState.location.search).toEqual('?param1=value1');
+        expect(currentRouteState.location.hash).toEqual('#hash');
+        expect(currentRouteState.location.state).toBeUndefined();
+        expect(currentRouteState.history.length).toEqual(1);
+        expect(currentRouteState.history.action).not.toEqual('REPLACE');
+        const headerEl = container.querySelector('.header-main');
+        expect(headerEl).not.toBeNull();
+        const menuEl = container.querySelector('.menu-main');
+        expect(menuEl).not.toBeNull();
+        const footerEl = container.querySelector('.footer-main');
+        expect(footerEl).not.toBeNull();
+      });
+    });
   });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,7 @@ import { render, cleanup, wait } from 'react-testing-library';
 import 'jest-dom/extend-expect';
 import App from './App';
 import { AppServicesProvider } from './services/pure-di';
+import { RedirectToInternalLogin } from './components/RedirectToLogin';
 import { MemoryRouter as Router, withRouter } from 'react-router-dom';
 
 function createDoubleSessionManager() {
@@ -17,6 +18,13 @@ function createDoubleSessionManager() {
   };
   return double;
 }
+
+const RouterInspector = withRouter(({ match, location, history, target }) => {
+  target.match = match;
+  target.location = location;
+  target.history = history;
+  return null;
+});
 
 describe('App component', () => {
   afterEach(cleanup);
@@ -208,6 +216,50 @@ describe('App component', () => {
         expect(dependencies.window.location.href).toEqual(
           'http://legacyUrl.localhost/SignIn/index?redirect=http://webapp.localhost/path1/path2/#/reports',
         );
+      });
+
+      it('should be redirected to Internal Login after open /reports (when using RedirectToInternalLogin)', () => {
+        const dependencies = {
+          RedirectToLogin: RedirectToInternalLogin,
+          sessionManager: createDoubleSessionManager(),
+        };
+
+        const currentRouteState = {};
+
+        const { getByText, container } = render(
+          <AppServicesProvider forcedServices={dependencies}>
+            <Router initialEntries={['/reports?param1=value1#hash']}>
+              <RouterInspector target={currentRouteState} />
+              <App locale="en" />
+            </Router>
+          </AppServicesProvider>,
+        );
+
+        expect(currentRouteState.location.pathname).toEqual('/reports');
+        expect(currentRouteState.location.search).toEqual('?param1=value1');
+        expect(currentRouteState.location.hash).toEqual('#hash');
+        getByText('Loading...');
+
+        // Act
+        dependencies.sessionManager.updateAppSession({
+          status: 'not-authenticated',
+        });
+
+        // Assert
+        expect(currentRouteState.location.pathname).toEqual('/login');
+        expect(currentRouteState.location.state).toBeDefined();
+        expect(currentRouteState.location.state.from).toBeDefined();
+        expect(currentRouteState.location.state.from.pathname).toEqual('/reports');
+        expect(currentRouteState.location.state.from.search).toEqual('?param1=value1');
+        expect(currentRouteState.location.state.from.hash).toEqual('#hash');
+        expect(currentRouteState.history.length).toEqual(1); // because the URL has been replaced in the redirect
+        expect(currentRouteState.history.action).toEqual('REPLACE');
+        const headerEl = container.querySelector('.header-main');
+        expect(headerEl).toBeNull();
+        const menuEl = container.querySelector('.menu-main');
+        expect(menuEl).toBeNull();
+        const footerEl = container.querySelector('.footer-main');
+        expect(footerEl).toBeNull();
       });
     });
   });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -261,6 +261,44 @@ describe('App component', () => {
         const footerEl = container.querySelector('.footer-main');
         expect(footerEl).toBeNull();
       });
+
+      it('should not be redirected after open /login', () => {
+        const dependencies = {
+          RedirectToLogin: RedirectToInternalLogin,
+          sessionManager: createDoubleSessionManager(),
+        };
+
+        const currentRouteState = {};
+
+        const { getByText, container } = render(
+          <AppServicesProvider forcedServices={dependencies}>
+            <Router initialEntries={['/login']}>
+              <RouterInspector target={currentRouteState} />
+              <App locale="en" />
+            </Router>
+          </AppServicesProvider>,
+        );
+
+        expect(currentRouteState.location.pathname).toEqual('/login');
+        getByText('Loading...');
+
+        // Act
+        dependencies.sessionManager.updateAppSession({
+          status: 'not-authenticated',
+        });
+
+        // Assert
+        expect(currentRouteState.location.pathname).toEqual('/login');
+        expect(currentRouteState.location.state).toBeUndefined();
+        expect(currentRouteState.history.length).toEqual(1);
+        expect(currentRouteState.history.action).not.toEqual('REPLACE');
+        const headerEl = container.querySelector('.header-main');
+        expect(headerEl).toBeNull();
+        const menuEl = container.querySelector('.menu-main');
+        expect(menuEl).toBeNull();
+        const footerEl = container.querySelector('.footer-main');
+        expect(footerEl).toBeNull();
+      });
     });
   });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -299,6 +299,46 @@ describe('App component', () => {
         const footerEl = container.querySelector('.footer-main');
         expect(footerEl).toBeNull();
       });
+
+      it('should be redirected to /login when route does not exists', () => {
+        const dependencies = {
+          RedirectToLogin: RedirectToInternalLogin,
+          sessionManager: createDoubleSessionManager(),
+        };
+
+        const currentRouteState = {};
+
+        const { getByText, container } = render(
+          <AppServicesProvider forcedServices={dependencies}>
+            <Router initialEntries={['/this/route/does/not/exist']}>
+              <RouterInspector target={currentRouteState} />
+              <App locale="en" />
+            </Router>
+          </AppServicesProvider>,
+        );
+
+        expect(currentRouteState.location.pathname).toEqual('/this/route/does/not/exist');
+        getByText('Loading...');
+
+        // Act
+        dependencies.sessionManager.updateAppSession({
+          status: 'not-authenticated',
+        });
+
+        // Assert
+        expect(currentRouteState.location.pathname).toEqual('/login');
+        expect(currentRouteState.location.state).toBeDefined();
+        expect(currentRouteState.location.state.from).toBeDefined();
+        expect(currentRouteState.location.state.from.pathname).toEqual('/reports'); // because before redirecting to login, it redirected to reports
+        expect(currentRouteState.history.length).toEqual(1); // because the URL has been replaced in the redirect
+        expect(currentRouteState.history.action).toEqual('REPLACE');
+        const headerEl = container.querySelector('.header-main');
+        expect(headerEl).toBeNull();
+        const menuEl = container.querySelector('.menu-main');
+        expect(menuEl).toBeNull();
+        const footerEl = container.querySelector('.footer-main');
+        expect(footerEl).toBeNull();
+      });
     });
   });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -130,39 +130,41 @@ describe('App component', () => {
     });
   });
 
-  it('updates content after successful authentication', async () => {
-    // Arrange
-    const expectedEmail = 'fcoronel@makingsense.com';
+  describe('authentication', () => {
+    it('updates content after successful authentication', async () => {
+      // Arrange
+      const expectedEmail = 'fcoronel@makingsense.com';
 
-    const dependencies = {
-      sessionManager: createDoubleSessionManager(),
-    };
+      const dependencies = {
+        sessionManager: createDoubleSessionManager(),
+      };
 
-    const { getByText } = render(
-      <AppServicesProvider forcedServices={dependencies}>
-        <App locale="en" />
-      </AppServicesProvider>,
-    );
+      const { getByText } = render(
+        <AppServicesProvider forcedServices={dependencies}>
+          <App locale="en" />
+        </AppServicesProvider>,
+      );
 
-    getByText('Loading...');
+      getByText('Loading...');
 
-    // Act
-    dependencies.sessionManager.updateAppSession({
-      status: 'authenticated',
-      userData: {
-        user: {
-          email: expectedEmail,
-          avatar: {},
-          plan: {},
+      // Act
+      dependencies.sessionManager.updateAppSession({
+        status: 'authenticated',
+        userData: {
+          user: {
+            email: expectedEmail,
+            avatar: {},
+            plan: {},
+            nav: [],
+            lang: 'en',
+          },
           nav: [],
-          lang: 'en',
         },
-        nav: [],
-      },
-    });
+      });
 
-    // Assert
-    getByText(expectedEmail);
-    // TODO: test session manager behavior
+      // Assert
+      getByText(expectedEmail);
+      // TODO: test session manager behavior
+    });
   });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -352,6 +352,57 @@ describe('App component', () => {
 
         const { getByText, container } = render(
           <AppServicesProvider forcedServices={dependencies}>
+            <Router initialEntries={['/this/route/does/not/exist?param1=value1#hash']}>
+              <RouterInspector target={currentRouteState} />
+              <App locale="en" />
+            </Router>
+          </AppServicesProvider>,
+        );
+
+        expect(currentRouteState.location.pathname).toEqual('/this/route/does/not/exist');
+        expect(currentRouteState.location.search).toEqual('?param1=value1');
+        expect(currentRouteState.location.hash).toEqual('#hash');
+        getByText('Loading...');
+
+        // Act
+        dependencies.sessionManager.updateAppSession({
+          status: 'authenticated',
+          userData: {
+            user: {
+              lang: 'es',
+              avatar: {},
+              plan: {},
+              nav: [],
+            },
+            nav: [],
+          },
+        });
+
+        // Assert
+        expect(currentRouteState.location.pathname).toEqual('/reports');
+        expect(currentRouteState.location.search).toEqual('');
+        expect(currentRouteState.location.hash).toEqual('');
+        expect(currentRouteState.location.state).toBeUndefined();
+        expect(currentRouteState.history.length).toEqual(1);
+        expect(currentRouteState.history.action).toEqual('REPLACE');
+        const headerEl = container.querySelector('.header-main');
+        expect(headerEl).not.toBeNull();
+        const menuEl = container.querySelector('.menu-main');
+        expect(menuEl).not.toBeNull();
+        const footerEl = container.querySelector('.footer-main');
+        expect(footerEl).not.toBeNull();
+      });
+
+      it('should be redirected to /reports when route does not exists', () => {
+        const dependencies = {
+          RedirectToLogin: RedirectToInternalLogin,
+          sessionManager: createDoubleSessionManager(),
+        };
+
+        const currentRouteState = {};
+
+        const { getByText, container } = render(
+          <AppServicesProvider forcedServices={dependencies}>
             <Router initialEntries={['/reports?param1=value1#hash']}>
               <RouterInspector target={currentRouteState} />
               <App locale="en" />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -166,5 +166,42 @@ describe('App component', () => {
       getByText(expectedEmail);
       // TODO: test session manager behavior
     });
+
+    describe('not authenticated user', () => {
+      it('should be redirected to Legacy Doppler Login after open /reports (when using RedirectToLegacyLoginFactory)', () => {
+        const dependencies = {
+          appConfiguration: {
+            dopplerLegacyUrl: 'http://legacyUrl.localhost',
+          },
+          window: {
+            location: {
+              protocol: 'http:',
+              host: 'webapp.localhost',
+              pathname: '/path1/path2/',
+              href: 'unset',
+            },
+          },
+          sessionManager: createDoubleSessionManager(),
+        };
+
+        const { getByText } = render(
+          <AppServicesProvider forcedServices={dependencies}>
+            <App locale="en" />
+          </AppServicesProvider>,
+        );
+
+        getByText('Loading...');
+
+        // Act
+        dependencies.sessionManager.updateAppSession({
+          status: 'not-authenticated',
+        });
+
+        // Assert
+        expect(dependencies.window.location.href).toEqual(
+          'http://legacyUrl.localhost/SignIn/index?redirect=http://webapp.localhost/path1/path2/#/reports',
+        );
+      });
+    });
   });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,7 @@ import { render, cleanup, wait } from 'react-testing-library';
 import 'jest-dom/extend-expect';
 import App from './App';
 import { AppServicesProvider } from './services/pure-di';
+import { MemoryRouter as Router, withRouter } from 'react-router-dom';
 
 function createDoubleSessionManager() {
   const double = {
@@ -63,7 +64,9 @@ describe('App component', () => {
 
       const { getByText } = render(
         <AppServicesProvider forcedServices={dependencies}>
-          <App locale="en" />
+          <Router>
+            <App locale="en" />
+          </Router>
         </AppServicesProvider>,
       );
 
@@ -141,7 +144,9 @@ describe('App component', () => {
 
       const { getByText } = render(
         <AppServicesProvider forcedServices={dependencies}>
-          <App locale="en" />
+          <Router>
+            <App locale="en" />
+          </Router>
         </AppServicesProvider>,
       );
 
@@ -186,7 +191,9 @@ describe('App component', () => {
 
         const { getByText } = render(
           <AppServicesProvider forcedServices={dependencies}>
-            <App locale="en" />
+            <Router>
+              <App locale="en" />
+            </Router>
           </AppServicesProvider>,
         );
 

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function({ location }) {
+  return (
+    <div>
+      {/* TODO: implement login */}
+      LOGIN. After login, redirect to{' '}
+      {location.state && location.state.from
+        ? `${location.state.from.pathname}${location.state.from.search}${location.state.from.hash}`
+        : '/'}
+      <code>
+        <pre>{JSON.stringify(location, null, 2)}</pre>
+      </code>
+    </div>
+  );
+}

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import Header from './Header/Header';
+import Footer from './Footer/Footer';
+import { InjectAppServices } from '../services/pure-di';
+
+export default InjectAppServices(function({
+  component: Component,
+  userData,
+  sessionStatus,
+  dependencies: { RedirectToLogin },
+  ...rest
+}) {
+  return (
+    <Route
+      {...rest}
+      render={(props) =>
+        sessionStatus === 'authenticated' ? (
+          <>
+            <Header userData={userData} />
+            <Component {...props} />
+            <Footer />
+          </>
+        ) : (
+          <RedirectToLogin from={props.location} />
+        )
+      }
+    />
+  );
+});

--- a/src/components/RedirectToLogin.tsx
+++ b/src/components/RedirectToLogin.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+interface ReactRouterLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export type RedirectToLogin = ({ from }: { from: ReactRouterLocation }) => JSX.Element;
+
+export function RedirectToInternalLogin({ from }: { from: ReactRouterLocation }) {
+  return (
+    <Redirect
+      to={{
+        pathname: '/login',
+        state: { from: from },
+      }}
+    />
+  );
+}
+
+export function RedirectToLegacyLoginFactory(dopplerLegacyUrl: string, { location }: Window) {
+  return ({ from }: { from: ReactRouterLocation }) => {
+    const basePath = `${location.protocol}//${location.host}${location.pathname}`;
+    const appPath = `${from.pathname}${from.search}${from.hash}`;
+    const currentUrlEncoded = encodeURI(`${basePath}#${appPath}`);
+    const loginUrl = `${dopplerLegacyUrl}/SignIn/index?redirect=${currentUrlEncoded}`;
+    location.href = loginUrl;
+    return <></>;
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { AppServicesProvider } from './services/pure-di';
+import { RedirectToInternalLogin } from './components/RedirectToLogin';
 
 // Only used in development environment, it does not affect production build
 import { HardcodedDopplerLegacyClient } from './services/doppler-legacy-client.doubles';
@@ -16,6 +17,7 @@ const forcedServices =
   process.env.NODE_ENV === 'development'
     ? {
         dopplerLegacyClient: new HardcodedDopplerLegacyClient(),
+        RedirectToLogin: RedirectToInternalLogin,
       }
     : {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { AppServicesProvider } from './services/pure-di';
 import { RedirectToInternalLogin } from './components/RedirectToLogin';
+import { HashRouter as Router } from 'react-router-dom';
 
 // Only used in development environment, it does not affect production build
 import { HardcodedDopplerLegacyClient } from './services/doppler-legacy-client.doubles';
@@ -23,7 +24,9 @@ const forcedServices =
 
 ReactDOM.render(
   <AppServicesProvider forcedServices={forcedServices}>
-    <App locale={locale} />
+    <Router>
+      <App locale={locale} />
+    </Router>
   </AppServicesProvider>,
   document.getElementById('root'),
 );

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -4,6 +4,11 @@ import { OnlineSessionManager, SessionManager } from './session-manager';
 import React, { createContext, ReactNode } from 'react';
 import { DatahubClient } from './datahub-client';
 import { HardcodedDatahubClient } from './datahub-client.doubles';
+import {
+  RedirectToLegacyLoginFactory,
+  RedirectToInternalLogin,
+  RedirectToLogin,
+} from '../components/RedirectToLogin';
 
 interface AppConfiguration {
   dopplerLegacyUrl: string;
@@ -14,11 +19,13 @@ interface AppConfiguration {
  * Services able to be injected
  */
 export interface AppServices {
+  window: Window;
   axiosStatic: AxiosStatic;
   appConfiguration: AppConfiguration;
   datahubClient: DatahubClient;
   dopplerLegacyClient: DopplerLegacyClient;
   sessionManager: SessionManager;
+  RedirectToLogin: RedirectToLogin;
 }
 
 /**
@@ -72,6 +79,22 @@ export class AppCompositionRoot implements AppServices {
           this.dopplerLegacyClient,
           this.appConfiguration.dopplerLegacyKeepAliveMilliseconds,
         ),
+    );
+  }
+
+  get window() {
+    return this.singleton('window', () => window);
+  }
+
+  // To Setup Internal Login
+  // get RedirectToLogin() {
+  //   return this.singleton('RedirectToLogin', () => RedirectToInternalLogin);
+  // }
+
+  // To Setup Doppler Legacy Login
+  get RedirectToLogin() {
+    return this.singleton('RedirectToLogin', () =>
+      RedirectToLegacyLoginFactory(this.appConfiguration.dopplerLegacyUrl, this.window),
     );
   }
 }

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -61,14 +61,7 @@ export class OnlineSessionManager implements SessionManager {
         userData: dopplerUserData,
       });
     } catch (error) {
-      this.redirectToLogin();
+      this.updateSession({ status: 'non-authenticated' });
     }
-  }
-
-  // TODO: move into a dependency
-  private redirectToLogin() {
-    const currentUrlEncoded = encodeURI(window.location.href);
-    const loginUrl = `${process.env.REACT_APP_API_URL}/SignIn/index?redirect=${currentUrlEncoded}`;
-    window.location.href = loginUrl;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,6 +982,11 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
+"@types/history@*":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
+  integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
@@ -1024,6 +1029,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.2.tgz#9bd7d33f908b243ff0692846ef36c81d4941ad12"
   integrity sha512-MX7n1wq3G/De15RGAAqnmidzhr2Y9O/ClxPxyqaNg96pGyeXUYPSvujgzEVpLo9oIP4Wn1UETl+rxTN02KEpBw==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.1.tgz#71fe2918f8f60474a891520def40a63997dafe04"
+  integrity sha512-GbztJAScOmQ/7RsQfO4cd55RuH1W4g6V1gDW3j4riLlt+8yxYLqqsiMzmyuXBLzdFmDtX/uU2Bpcm0cmudv44A==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.5.tgz#1166997dc7eef2917b5ebce890ebecb32ee5c1b3"
+  integrity sha512-12+VOu1+xiC8RPc9yrgHCyLI79VswjtuqeS2gPrMcywH6tkc8rGIUhs4LaL3AJPqo5d+RPnfRpNKiJ7MK2Qhcg==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.8.6":


### PR DESCRIPTION
Hi team, 

I am still working on it because I need to add some tests.

But, I think that, besides that, it is ready to be merged. I finally resolved how to deal with many problems:
* Public and private routes
* Two different login pages (internal one and in Legacy Doppler)
* The layout that changes based on the route, redirect

I think that it is easy to review it if you read commit by commit, maybe it is difficult to understand DI related commit because I am using our DI system to inject a React component, but I think that it is the most consistent way to do that. Let me know if you need any clarification on this.

Pending tests:

- [x] not authenticated user should be redirected to Legacy Doppler Login after open /reports (when using RedirectToLegacyLoginFactory)
- [x] not authenticated user should be redirected to Internal Login after open /reports (when using RedirectToInternalLogin)
- [x] not authenticated user should not be redirected after open /login
- [x] not authenticated user should be redirected to /login when the route does not exist
- [x] ~~not authenticated user should be redirected to original page after login~~ It is not possible testing it, because it is a _login page_ responsibility, and it is not created yet.
- [x] authenticated user should not be redirected after open /reports
- [x] authenticated user should be redirected to /reports when the route does not exist