### PR TITLE
Add signup page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build135/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build142/css/styles.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -44,6 +44,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build135/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build142/js/app.js"></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Reports from './components/Reports/Reports';
 import { InjectAppServices } from './services/pure-di';
 import Loading from './components/Loading/Loading';
 import Login from './components/Login/Login';
+import Signup from './components/Signup/Signup';
 
 class App extends Component {
   constructor({ locale, dependencies: { sessionManager } }) {
@@ -64,6 +65,7 @@ class App extends Component {
               sessionStatus={sessionStatus}
             />
             <Route path="/login/" exact component={Login} />
+            <Route path="/signup/" exact component={Signup} />
             {/* TODO: Implement NotFound page in place of redirect all to reports */}
             {/* <Route component={NotFound} /> */}
             <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { timeout } from '../../utils';
-import { Formik, Form, Field } from 'formik';
+import { Formik, Form } from 'formik';
+import { FieldGroup, InputFieldItem, CheckboxFieldItem } from '../form-helpers/form-helpers';
 
 const fieldNames = {
   firstname: 'firstname',
@@ -85,164 +86,63 @@ export default injectIntl(function({ intl }) {
         <h5>{_('signup.sign_up')}</h5>
         <p className="content-subtitle">{_('signup.sign_up_sub')}</p>
         <Formik initialValues={getFormInitialValues()} validate={validate} onSubmit={onSubmit}>
-          {({ errors, touched }) => (
           <Form className="signup-form">
             <fieldset>
-              <ul className="field-group">
-                <li
-                  className={
-                    'field-item field-item--50' +
-                    (touched[fieldNames.firstname] && errors[fieldNames.firstname]
-                      ? ' error'
-                      : '')
-                  }
-                >
-                  <label htmlFor={fieldNames.firstname}>{_('signup.label_firstname')}</label>
-                  <Field
-                    type="text"
-                    name={fieldNames.firstname}
-                    id={fieldNames.firstname}
-                    placeholder={_('signup.placeholder_firstname')}
-                  />
-                  {touched[fieldNames.firstname] && errors[fieldNames.firstname] ? (
-                    <div className="wrapper-errors">
-                      <p className="error-message">{errors[fieldNames.firstname]}</p>
-                    </div>
-                  ) : null}
-                </li>
-
-                <li
-                  className={
-                    'field-item field-item--50' +
-                    (touched[fieldNames.lastname] && errors[fieldNames.lastname] ? ' error' : '')
-                  }
-                >
-                  <label htmlFor={fieldNames.lastname}>{_('signup.label_lastname')}</label>
-                  <Field
-                    type="text"
-                    name={fieldNames.lastname}
-                    id={fieldNames.lastname}
-                    placeholder={_('signup.placeholder_lastname')}
-                  />
-                  {touched[fieldNames.lastname] && errors[fieldNames.lastname] ? (
-                    <div className="wrapper-errors">
-                      <p className="error-message">{errors[fieldNames.lastname]}</p>
-                    </div>
-                  ) : null}
-                </li>
-                <li
-                  className={
-                    'field-item' +
-                    (touched[fieldNames.phone] && errors[fieldNames.phone] ? ' error' : '')
-                  }
-                >
-                  <label htmlFor={fieldNames.phone}>{_('signup.label_phone')}</label>
-                  <Field
-                    type="tel"
-                    name={fieldNames.phone}
-                    id={fieldNames.phone}
-                    placeholder={_('signup.placeholder_phone')}
-                  />
-                  {touched[fieldNames.phone] && errors[fieldNames.phone] ? (
-                    <div className="wrapper-errors">
-                      <p className="error-message">{errors[fieldNames.phone]}</p>
-                    </div>
-                  ) : null}
-                </li>
-              </ul>
+              <FieldGroup>
+                <InputFieldItem
+                  className="field-item--50"
+                  fieldName={fieldNames.firstname}
+                  label={_('signup.label_firstname')}
+                  type="text"
+                  placeholder={_('signup.placeholder_firstname')}
+                />
+                <InputFieldItem
+                  className="field-item--50"
+                  fieldName={fieldNames.lastname}
+                  label={_('signup.label_lastname')}
+                  type="text"
+                  placeholder={_('signup.placeholder_lastname')}
+                />
+                <InputFieldItem
+                  fieldName={fieldNames.phone}
+                  label={_('signup.label_phone')}
+                  type="tel"
+                  placeholder={_('signup.placeholder_phone')}
+                />
+              </FieldGroup>
             </fieldset>
             <fieldset>
-              <ul className="field-group">
-                <li
-                  className={
-                    'field-item' +
-                    (touched[fieldNames.email] && errors[fieldNames.email] ? ' error' : '')
-                  }
-                >
-                  <label htmlFor={fieldNames.email}>{_('signup.label_email')}</label>
-                  <Field
-                    type="email"
-                    name={fieldNames.email}
-                    id={fieldNames.email}
-                    placeholder={_('signup.placeholder_email')}
-                  />
-                  {touched[fieldNames.email] && errors[fieldNames.email] ? (
-                    <div className="wrapper-errors">
-                      <p className="error-message">{errors[fieldNames.email]}</p>
-                    </div>
-                  ) : null}
-                </li>
-                <li
-                  className={
-                    'field-item' +
-                    (touched[fieldNames.password] && errors[fieldNames.password] ? ' error' : '')
-                  }
-                >
-                  <label htmlFor={fieldNames.password}>{_('signup.label_password')}</label>
-                  <Field
-                    type="password"
-                    name={fieldNames.password}
-                    id={fieldNames.password}
-                    placeholder={_('signup.placeholder_password')}
-                  />
-                  {touched[fieldNames.password] && errors[fieldNames.password] ? (
-                    <div className="wrapper-errors">
-                      <p className="error-message">{errors[fieldNames.password]}</p>
-                    </div>
-                  ) : null}
-                </li>
-              </ul>
+              <FieldGroup>
+                <InputFieldItem
+                  fieldName={fieldNames.email}
+                  label={_('signup.label_email')}
+                  type="email"
+                  placeholder={_('signup.placeholder_email')}
+                />
+                <InputFieldItem
+                  fieldName={fieldNames.password}
+                  label={_('signup.label_password')}
+                  type="password"
+                  placeholder={_('signup.placeholder_password')}
+                />
+              </FieldGroup>
             </fieldset>
             <fieldset>
-              <ul className="field-group">
-                <li
-                  className={
-                    'field-item field-item__checkbox' +
-                    (touched[fieldNames.accept_privacy_policies] &&
-                    errors[fieldNames.accept_privacy_policies]
-                      ? ' error'
-                      : '')
-                  }
-                >
-                  <Field
-                    type="checkbox"
-                    name={fieldNames.accept_privacy_policies}
-                    id={fieldNames.accept_privacy_policies}
-                  />
-                  <span className="checkmark" />
-                  <label htmlFor={fieldNames.accept_privacy_policies}>
-                    {' '}
-                    <FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />
-                  </label>
-                  {touched[fieldNames.password] && errors[fieldNames.accept_privacy_policies] ? (
-                    <div className="wrapper-errors">
-                      <p className="error-message">
-                        {errors[fieldNames.accept_privacy_policies]}
-                      </p>
-                    </div>
-                  ) : null}
-                </li>
-                <li className="field-item field-item__checkbox">
-                  <Field
-                    type="checkbox"
-                    name={fieldNames.accept_promotions}
-                    id={fieldNames.accept_promotions}
-                  />
-                  <span className="checkmark" />
-                  <label htmlFor={fieldNames.accept_promotions}>
-                    {_('signup.promotions_consent')}
-                  </label>
-                </li>
-              </ul>
-              <button
-                type="submit"
-                className="dp-button button--round button-medium primary-green"
-              >
+              <FieldGroup>
+                <CheckboxFieldItem
+                  fieldName={fieldNames.accept_privacy_policies}
+                  label={<FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />}
+                />
+                <CheckboxFieldItem
+                  fieldName={fieldNames.accept_promotions}
+                  label={_('signup.promotions_consent')}
+                />
+              </FieldGroup>
+              <button type="submit" className="dp-button button--round button-medium primary-green">
                 {_('signup.button_signup')}
               </button>
             </fieldset>
           </Form>
-          )}
         </Formik>
         <div className="content-legal">
           <FormattedHTMLMessage id="signup.legal_HTML" />

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -1,0 +1,173 @@
+import React from 'react';
+
+export default function() {
+  return (
+    <main className="panel-wrapper">
+      <article className="main-panel">
+        <header>
+          <img src="img/doppler-logo.svg" className="logo-doppler" alt="Doppler" />
+          <small className="content-signin">
+            ¿Ya tienes una cuenta?{' '}
+            <a href="/" className="link-green" target="_blank">
+              INGRESA
+            </a>
+          </small>
+        </header>
+        <h5>Regístrate</h5>
+        <p className="content-subtitle">Crea una cuenta GRATIS hasta 500 Suscriptores.</p>
+        <form className="signup-form">
+          <fieldset>
+            <legend>Datos personales</legend>
+            <ul className="field-group">
+              <li>
+                <ul className="field-group">
+                  <li className="field-item field-item--50 error">
+                    <label htmlFor="name">Nombre:</label>
+                    <input type="name" name="name" id="name" placeholder="Nombre" />
+                    <div className="wrapper-errors bounceIn">
+                      <p className="error-message">¡Ouch! Este campo está vacío</p>
+                    </div>
+                  </li>
+                  <li className="field-item field-item--50 error">
+                    <label htmlFor="lastname">Apellido:</label>
+                    <input type="lastname" name="name" id="lastname" placeholder="Apellido" />
+                    <div className="wrapper-errors bounceIn">
+                      <p className="error-message">¡Ouch! Este campo está vacío</p>
+                    </div>
+                  </li>
+                </ul>
+              </li>
+              <li className="field-item error">
+                <label htmlFor="phone">Teléfono:</label>
+                <input type="tel" name="phone" id="phone" placeholder="9 11 2345-6789" />
+                <div className="wrapper-errors bounceIn">
+                  <p className="error-message">¡Ouch! Este campo está vacío</p>
+                </div>
+              </li>
+            </ul>
+          </fieldset>
+          <fieldset>
+            <ul className="field-group">
+              <legend>Usuario y contraseña</legend>
+              <li className="field-item error">
+                <label htmlFor="email">Email:</label>
+                <input
+                  type="email"
+                  name="email"
+                  id="email"
+                  placeholder="Tu Email será tu nombre de usuario"
+                />
+                <div className="wrapper-errors bounceIn">
+                  <p className="error-message">¡Ouch! Este campo está vacío</p>
+                </div>
+              </li>
+              <li className="field-item">
+                <label htmlFor="password">Contraseña:</label>
+                <input
+                  type="password"
+                  name="password"
+                  id="password"
+                  placeholder="Escribe tu clave secreta"
+                />
+                <div className="wrapper-password">
+                  <p className="password-message">
+                    <span className="waiting-message">8 caracteres como mínimo</span>
+                    <span className="waiting-message">Un dígito</span>
+                  </p>
+                  <p className="password-message">
+                    <span className="lack-message">8 caracteres como mínimo</span>
+                    <span className="waiting-message">Un dígito</span>
+                  </p>
+                  <p className="password-message">
+                    <span className="complete-message">8 caracteres como mínimo</span>
+                    <span className="lack-message">Un dígito</span>
+                  </p>
+                  <p className="password-message">
+                    <span className="secure-message">¡Tu contraseña es segura!</span>
+                  </p>
+                </div>
+              </li>
+            </ul>
+          </fieldset>
+          <fieldset>
+            <legend>Política de privacidad y promociones</legend>
+            <ul className="field-group">
+              <li className="field-item field-item__checkbox error">
+                <input type="checkbox" name="acepto_politicas" />
+                <span className="checkmark" />
+                <label htmlFor="acepto_politicas">
+                  {' '}
+                  Acepto la{' '}
+                  <a className="link-green" href="/">
+                    Política de Privacidad
+                  </a>{' '}
+                  de Doppler.
+                </label>
+                <div className="wrapper-errors bounceIn">
+                  <p className="error-message">¡Ouch! Este campo está vacío</p>
+                </div>
+              </li>
+              <li className="field-item field-item__checkbox">
+                <input type="checkbox" name="acepto_promociones" />
+                <span className="checkmark" />
+                <label htmlFor="acepto_promociones">
+                  Acepto recibir las promociones de Doppler y sus aliados.
+                </label>
+              </li>
+            </ul>
+            <button type="button" className="dp-button button--round button-medium primary-green">
+              Crear cuenta
+            </button>
+          </fieldset>
+        </form>
+        <div className="content-legal">
+          <p>
+            Doppler te informa que los datos de carácter personal que nos proporciones al rellenar
+            el presente formulario serán tratados por Making Sense LLC (Doppler) como responsable de
+            esta web.
+          </p>
+          <p>
+            <strong>Finalidad:</strong> Darte de alta en nuestra plataforma y brindarte los
+            servicios que nos requieras.
+          </p>
+          <p>
+            <strong>Legitimación:</strong> Consentimiento del interesado.
+          </p>
+          <p>
+            <strong>Destinatarios:</strong> Tus datos serán guardados por Doppler, Zoho como CRM,
+            Digital Ocean, Cogeco Peer1 y Rackspace como empresas de hosting.
+          </p>
+          <p>
+            <strong>Información adicional:</strong> En la{' '}
+            <a href="/" className="link-green" target="_blank">
+              Política de Privacidad
+            </a>{' '}
+            de Doppler encontrarás información adicional sobre la recopilación y el uso de su
+            información personal por parte de Doppler, incluida información sobre acceso,
+            conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y
+            otros temas.
+          </p>
+        </div>
+        <p className="content-promotion">
+          Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.{' '}
+          <a href="/" className="link-green" target="_blank">
+            HELP
+          </a>
+        </p>
+        <footer>
+          <small>© 2019 Doppler LLC. Todos los derechos reservados.</small>
+        </footer>
+      </article>
+      <section className="feature-panel">
+        <article className="feature-content">
+          <h6>Editor de emails</h6>
+          <h3>Crea Emails en minutos y accede a nuestra Galería de Plantillas</h3>
+          <p>
+            Nuestras Plantillas para Email son totalmente Responsive y fácilmente editables desde
+            nuestro Editor HTML.
+          </p>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -3,7 +3,12 @@ import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { timeout } from '../../utils';
 import { Formik, Form } from 'formik';
-import { FieldGroup, InputFieldItem, CheckboxFieldItem } from '../form-helpers/form-helpers';
+import {
+  FieldGroup,
+  InputFieldItem,
+  CheckboxFieldItem,
+  PasswordFieldItem,
+} from '../form-helpers/form-helpers';
 
 const fieldNames = {
   firstname: 'firstname',
@@ -119,10 +124,9 @@ export default injectIntl(function({ intl }) {
                   type="email"
                   placeholder={_('signup.placeholder_email')}
                 />
-                <InputFieldItem
+                <PasswordFieldItem
                   fieldName={fieldNames.password}
                   label={_('signup.label_password')}
-                  type="password"
                   placeholder={_('signup.placeholder_password')}
                 />
               </FieldGroup>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -75,7 +75,7 @@ export default injectIntl(function({ intl }) {
     <main className="panel-wrapper">
       <article className="main-panel">
         <header>
-          <img src="img/doppler-logo.svg" className="logo-doppler" alt="Doppler" />
+          <h1 className="logo-doppler-new">Doppler</h1>
           <small className="content-signin">
             {_('signup.do_you_already_have_an_account')}{' '}
             <Link to="/login" className="link-green uppercase">

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -86,162 +86,162 @@ export default injectIntl(function({ intl }) {
         <p className="content-subtitle">{_('signup.sign_up_sub')}</p>
         <Formik initialValues={getFormInitialValues()} validate={validate} onSubmit={onSubmit}>
           {({ errors, touched }) => (
-            <Form className="signup-form">
-              <fieldset>
-                <ul className="field-group">
-                  <li
-                    className={
-                      'field-item field-item--50' +
-                      (touched[fieldNames.firstname] && errors[fieldNames.firstname]
-                        ? ' error'
-                        : '')
-                    }
-                  >
-                    <label htmlFor={fieldNames.firstname}>{_('signup.label_firstname')}</label>
-                    <Field
-                      type="text"
-                      name={fieldNames.firstname}
-                      id={fieldNames.firstname}
-                      placeholder={_('signup.placeholder_firstname')}
-                    />
-                    {touched[fieldNames.firstname] && errors[fieldNames.firstname] ? (
-                      <div className="wrapper-errors">
-                        <p className="error-message">{errors[fieldNames.firstname]}</p>
-                      </div>
-                    ) : null}
-                  </li>
-
-                  <li
-                    className={
-                      'field-item field-item--50' +
-                      (touched[fieldNames.lastname] && errors[fieldNames.lastname] ? ' error' : '')
-                    }
-                  >
-                    <label htmlFor={fieldNames.lastname}>{_('signup.label_lastname')}</label>
-                    <Field
-                      type="text"
-                      name={fieldNames.lastname}
-                      id={fieldNames.lastname}
-                      placeholder={_('signup.placeholder_lastname')}
-                    />
-                    {touched[fieldNames.lastname] && errors[fieldNames.lastname] ? (
-                      <div className="wrapper-errors">
-                        <p className="error-message">{errors[fieldNames.lastname]}</p>
-                      </div>
-                    ) : null}
-                  </li>
-                  <li
-                    className={
-                      'field-item' +
-                      (touched[fieldNames.phone] && errors[fieldNames.phone] ? ' error' : '')
-                    }
-                  >
-                    <label htmlFor={fieldNames.phone}>{_('signup.label_phone')}</label>
-                    <Field
-                      type="tel"
-                      name={fieldNames.phone}
-                      id={fieldNames.phone}
-                      placeholder={_('signup.placeholder_phone')}
-                    />
-                    {touched[fieldNames.phone] && errors[fieldNames.phone] ? (
-                      <div className="wrapper-errors">
-                        <p className="error-message">{errors[fieldNames.phone]}</p>
-                      </div>
-                    ) : null}
-                  </li>
-                </ul>
-              </fieldset>
-              <fieldset>
-                <ul className="field-group">
-                  <li
-                    className={
-                      'field-item' +
-                      (touched[fieldNames.email] && errors[fieldNames.email] ? ' error' : '')
-                    }
-                  >
-                    <label htmlFor={fieldNames.email}>{_('signup.label_email')}</label>
-                    <Field
-                      type="email"
-                      name={fieldNames.email}
-                      id={fieldNames.email}
-                      placeholder={_('signup.placeholder_email')}
-                    />
-                    {touched[fieldNames.email] && errors[fieldNames.email] ? (
-                      <div className="wrapper-errors">
-                        <p className="error-message">{errors[fieldNames.email]}</p>
-                      </div>
-                    ) : null}
-                  </li>
-                  <li
-                    className={
-                      'field-item' +
-                      (touched[fieldNames.password] && errors[fieldNames.password] ? ' error' : '')
-                    }
-                  >
-                    <label htmlFor={fieldNames.password}>{_('signup.label_password')}</label>
-                    <Field
-                      type="password"
-                      name={fieldNames.password}
-                      id={fieldNames.password}
-                      placeholder={_('signup.placeholder_password')}
-                    />
-                    {touched[fieldNames.password] && errors[fieldNames.password] ? (
-                      <div className="wrapper-errors">
-                        <p className="error-message">{errors[fieldNames.password]}</p>
-                      </div>
-                    ) : null}
-                  </li>
-                </ul>
-              </fieldset>
-              <fieldset>
-                <ul className="field-group">
-                  <li
-                    className={
-                      'field-item field-item__checkbox' +
-                      (touched[fieldNames.accept_privacy_policies] &&
-                      errors[fieldNames.accept_privacy_policies]
-                        ? ' error'
-                        : '')
-                    }
-                  >
-                    <Field
-                      type="checkbox"
-                      name={fieldNames.accept_privacy_policies}
-                      id={fieldNames.accept_privacy_policies}
-                    />
-                    <span className="checkmark" />
-                    <label htmlFor={fieldNames.accept_privacy_policies}>
-                      {' '}
-                      <FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />
-                    </label>
-                    {touched[fieldNames.password] && errors[fieldNames.accept_privacy_policies] ? (
-                      <div className="wrapper-errors">
-                        <p className="error-message">
-                          {errors[fieldNames.accept_privacy_policies]}
-                        </p>
-                      </div>
-                    ) : null}
-                  </li>
-                  <li className="field-item field-item__checkbox">
-                    <Field
-                      type="checkbox"
-                      name={fieldNames.accept_promotions}
-                      id={fieldNames.accept_promotions}
-                    />
-                    <span className="checkmark" />
-                    <label htmlFor={fieldNames.accept_promotions}>
-                      {_('signup.promotions_consent')}
-                    </label>
-                  </li>
-                </ul>
-                <button
-                  type="submit"
-                  className="dp-button button--round button-medium primary-green"
+          <Form className="signup-form">
+            <fieldset>
+              <ul className="field-group">
+                <li
+                  className={
+                    'field-item field-item--50' +
+                    (touched[fieldNames.firstname] && errors[fieldNames.firstname]
+                      ? ' error'
+                      : '')
+                  }
                 >
-                  {_('signup.button_signup')}
-                </button>
-              </fieldset>
-            </Form>
+                  <label htmlFor={fieldNames.firstname}>{_('signup.label_firstname')}</label>
+                  <Field
+                    type="text"
+                    name={fieldNames.firstname}
+                    id={fieldNames.firstname}
+                    placeholder={_('signup.placeholder_firstname')}
+                  />
+                  {touched[fieldNames.firstname] && errors[fieldNames.firstname] ? (
+                    <div className="wrapper-errors">
+                      <p className="error-message">{errors[fieldNames.firstname]}</p>
+                    </div>
+                  ) : null}
+                </li>
+
+                <li
+                  className={
+                    'field-item field-item--50' +
+                    (touched[fieldNames.lastname] && errors[fieldNames.lastname] ? ' error' : '')
+                  }
+                >
+                  <label htmlFor={fieldNames.lastname}>{_('signup.label_lastname')}</label>
+                  <Field
+                    type="text"
+                    name={fieldNames.lastname}
+                    id={fieldNames.lastname}
+                    placeholder={_('signup.placeholder_lastname')}
+                  />
+                  {touched[fieldNames.lastname] && errors[fieldNames.lastname] ? (
+                    <div className="wrapper-errors">
+                      <p className="error-message">{errors[fieldNames.lastname]}</p>
+                    </div>
+                  ) : null}
+                </li>
+                <li
+                  className={
+                    'field-item' +
+                    (touched[fieldNames.phone] && errors[fieldNames.phone] ? ' error' : '')
+                  }
+                >
+                  <label htmlFor={fieldNames.phone}>{_('signup.label_phone')}</label>
+                  <Field
+                    type="tel"
+                    name={fieldNames.phone}
+                    id={fieldNames.phone}
+                    placeholder={_('signup.placeholder_phone')}
+                  />
+                  {touched[fieldNames.phone] && errors[fieldNames.phone] ? (
+                    <div className="wrapper-errors">
+                      <p className="error-message">{errors[fieldNames.phone]}</p>
+                    </div>
+                  ) : null}
+                </li>
+              </ul>
+            </fieldset>
+            <fieldset>
+              <ul className="field-group">
+                <li
+                  className={
+                    'field-item' +
+                    (touched[fieldNames.email] && errors[fieldNames.email] ? ' error' : '')
+                  }
+                >
+                  <label htmlFor={fieldNames.email}>{_('signup.label_email')}</label>
+                  <Field
+                    type="email"
+                    name={fieldNames.email}
+                    id={fieldNames.email}
+                    placeholder={_('signup.placeholder_email')}
+                  />
+                  {touched[fieldNames.email] && errors[fieldNames.email] ? (
+                    <div className="wrapper-errors">
+                      <p className="error-message">{errors[fieldNames.email]}</p>
+                    </div>
+                  ) : null}
+                </li>
+                <li
+                  className={
+                    'field-item' +
+                    (touched[fieldNames.password] && errors[fieldNames.password] ? ' error' : '')
+                  }
+                >
+                  <label htmlFor={fieldNames.password}>{_('signup.label_password')}</label>
+                  <Field
+                    type="password"
+                    name={fieldNames.password}
+                    id={fieldNames.password}
+                    placeholder={_('signup.placeholder_password')}
+                  />
+                  {touched[fieldNames.password] && errors[fieldNames.password] ? (
+                    <div className="wrapper-errors">
+                      <p className="error-message">{errors[fieldNames.password]}</p>
+                    </div>
+                  ) : null}
+                </li>
+              </ul>
+            </fieldset>
+            <fieldset>
+              <ul className="field-group">
+                <li
+                  className={
+                    'field-item field-item__checkbox' +
+                    (touched[fieldNames.accept_privacy_policies] &&
+                    errors[fieldNames.accept_privacy_policies]
+                      ? ' error'
+                      : '')
+                  }
+                >
+                  <Field
+                    type="checkbox"
+                    name={fieldNames.accept_privacy_policies}
+                    id={fieldNames.accept_privacy_policies}
+                  />
+                  <span className="checkmark" />
+                  <label htmlFor={fieldNames.accept_privacy_policies}>
+                    {' '}
+                    <FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />
+                  </label>
+                  {touched[fieldNames.password] && errors[fieldNames.accept_privacy_policies] ? (
+                    <div className="wrapper-errors">
+                      <p className="error-message">
+                        {errors[fieldNames.accept_privacy_policies]}
+                      </p>
+                    </div>
+                  ) : null}
+                </li>
+                <li className="field-item field-item__checkbox">
+                  <Field
+                    type="checkbox"
+                    name={fieldNames.accept_promotions}
+                    id={fieldNames.accept_promotions}
+                  />
+                  <span className="checkmark" />
+                  <label htmlFor={fieldNames.accept_promotions}>
+                    {_('signup.promotions_consent')}
+                  </label>
+                </li>
+              </ul>
+              <button
+                type="submit"
+                className="dp-button button--round button-medium primary-green"
+              >
+                {_('signup.button_signup')}
+              </button>
+            </fieldset>
+          </Form>
           )}
         </Formik>
         <div className="content-legal">

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -1,9 +1,75 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
+import { timeout } from '../../utils';
+import { Formik, Form, Field } from 'formik';
+
+const fieldNames = {
+  firstname: 'firstname',
+  lastname: 'lastname',
+  phone: 'phone',
+  email: 'email',
+  password: 'password',
+  accept_privacy_policies: 'accept_privacy_policies',
+  accept_promotions: 'accept_promotions',
+};
+
+/** Prepare empty values for all fields
+ * It is required because in another way, the fields are not marked as touched.
+ */
+const getFormInitialValues = () =>
+  Object.keys(fieldNames).reduce(
+    (accumulator, currentValue) => ({ ...accumulator, [currentValue]: '' }),
+    {},
+  );
 
 export default injectIntl(function({ intl }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  const validate = (values) => {
+    const errors = {};
+    if (!values[fieldNames.firstname]) {
+      errors[fieldNames.firstname] = _('validation_messages.error_required_field');
+    }
+
+    if (!values[fieldNames.lastname]) {
+      errors[fieldNames.lastname] = _('validation_messages.error_required_field');
+    }
+
+    if (!values[fieldNames.phone]) {
+      errors[fieldNames.phone] = _('validation_messages.error_required_field');
+    } else {
+      // TODO: validate phone
+    }
+
+    if (!values[fieldNames.email]) {
+      errors[fieldNames.email] = _('validation_messages.error_required_field');
+    } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values[fieldNames.email])) {
+      // TODO: review if this is our desired validation
+      errors[fieldNames.email] = _('validation_messages.error_invalid_email_address');
+    }
+
+    if (!values[fieldNames.password]) {
+      // TODO: I think that password validation has a different format
+      errors[fieldNames.password] = _('validation_messages.error_required_field');
+    } else {
+      // TODO: validate password
+    }
+
+    if (!values[fieldNames.accept_privacy_policies]) {
+      // TODO: show the right message
+      errors[fieldNames.accept_privacy_policies] = _('validation_messages.error_required_field');
+    }
+
+    return errors;
+  };
+
+  const onSubmit = async (values, { setSubmitting }) => {
+    // TODO: implement it
+    await timeout(1500);
+    setSubmitting(false);
+  };
+
   return (
     <main className="panel-wrapper">
       <article className="main-panel">
@@ -18,81 +84,166 @@ export default injectIntl(function({ intl }) {
         </header>
         <h5>{_('signup.sign_up')}</h5>
         <p className="content-subtitle">{_('signup.sign_up_sub')}</p>
-            <form className="signup-form">
+        <Formik initialValues={getFormInitialValues()} validate={validate} onSubmit={onSubmit}>
+          {({ errors, touched }) => (
+            <Form className="signup-form">
               <fieldset>
                 <ul className="field-group">
-                  <li className="field-item field-item--50">
-                    <label htmlFor="name">{_('signup.label_firstname')}</label>
-                    <input
+                  <li
+                    className={
+                      'field-item field-item--50' +
+                      (touched[fieldNames.firstname] && errors[fieldNames.firstname]
+                        ? ' error'
+                        : '')
+                    }
+                  >
+                    <label htmlFor={fieldNames.firstname}>{_('signup.label_firstname')}</label>
+                    <Field
                       type="text"
-                      name="name"
-                      id="name"
+                      name={fieldNames.firstname}
+                      id={fieldNames.firstname}
                       placeholder={_('signup.placeholder_firstname')}
                     />
+                    {touched[fieldNames.firstname] && errors[fieldNames.firstname] ? (
+                      <div className="wrapper-errors">
+                        <p className="error-message">{errors[fieldNames.firstname]}</p>
+                      </div>
+                    ) : null}
                   </li>
-                  <li className="field-item field-item--50">
-                    <label htmlFor="lastname">{_('signup.label_lastname')}</label>
-                    <input
+
+                  <li
+                    className={
+                      'field-item field-item--50' +
+                      (touched[fieldNames.lastname] && errors[fieldNames.lastname] ? ' error' : '')
+                    }
+                  >
+                    <label htmlFor={fieldNames.lastname}>{_('signup.label_lastname')}</label>
+                    <Field
                       type="text"
-                      name="lastname"
-                      id="lastname"
+                      name={fieldNames.lastname}
+                      id={fieldNames.lastname}
                       placeholder={_('signup.placeholder_lastname')}
                     />
+                    {touched[fieldNames.lastname] && errors[fieldNames.lastname] ? (
+                      <div className="wrapper-errors">
+                        <p className="error-message">{errors[fieldNames.lastname]}</p>
+                      </div>
+                    ) : null}
                   </li>
-                  <li className="field-item error">
-                    <label htmlFor="phone">{_('signup.label_phone')}</label>
-                    <input
+                  <li
+                    className={
+                      'field-item' +
+                      (touched[fieldNames.phone] && errors[fieldNames.phone] ? ' error' : '')
+                    }
+                  >
+                    <label htmlFor={fieldNames.phone}>{_('signup.label_phone')}</label>
+                    <Field
                       type="tel"
-                      name="phone"
-                      id="phone"
+                      name={fieldNames.phone}
+                      id={fieldNames.phone}
                       placeholder={_('signup.placeholder_phone')}
                     />
+                    {touched[fieldNames.phone] && errors[fieldNames.phone] ? (
+                      <div className="wrapper-errors">
+                        <p className="error-message">{errors[fieldNames.phone]}</p>
+                      </div>
+                    ) : null}
                   </li>
                 </ul>
               </fieldset>
               <fieldset>
                 <ul className="field-group">
-                  <li className="field-item error">
-                    <label htmlFor="email">{_('signup.label_email')}</label>
-                    <input
+                  <li
+                    className={
+                      'field-item' +
+                      (touched[fieldNames.email] && errors[fieldNames.email] ? ' error' : '')
+                    }
+                  >
+                    <label htmlFor={fieldNames.email}>{_('signup.label_email')}</label>
+                    <Field
                       type="email"
-                      name="email"
-                      id="email"
+                      name={fieldNames.email}
+                      id={fieldNames.email}
                       placeholder={_('signup.placeholder_email')}
                     />
+                    {touched[fieldNames.email] && errors[fieldNames.email] ? (
+                      <div className="wrapper-errors">
+                        <p className="error-message">{errors[fieldNames.email]}</p>
+                      </div>
+                    ) : null}
                   </li>
-                  <li className="field-item">
-                    <label htmlFor="password">{_('signup.label_password')}</label>
-                    <input
+                  <li
+                    className={
+                      'field-item' +
+                      (touched[fieldNames.password] && errors[fieldNames.password] ? ' error' : '')
+                    }
+                  >
+                    <label htmlFor={fieldNames.password}>{_('signup.label_password')}</label>
+                    <Field
                       type="password"
-                      name="password"
-                      id="password"
+                      name={fieldNames.password}
+                      id={fieldNames.password}
                       placeholder={_('signup.placeholder_password')}
                     />
+                    {touched[fieldNames.password] && errors[fieldNames.password] ? (
+                      <div className="wrapper-errors">
+                        <p className="error-message">{errors[fieldNames.password]}</p>
+                      </div>
+                    ) : null}
                   </li>
                 </ul>
               </fieldset>
               <fieldset>
                 <ul className="field-group">
-                  <li className="field-item field-item__checkbox error">
-                    <input type="checkbox" name="accept_privacy_policies" />
+                  <li
+                    className={
+                      'field-item field-item__checkbox' +
+                      (touched[fieldNames.accept_privacy_policies] &&
+                      errors[fieldNames.accept_privacy_policies]
+                        ? ' error'
+                        : '')
+                    }
+                  >
+                    <Field
+                      type="checkbox"
+                      name={fieldNames.accept_privacy_policies}
+                      id={fieldNames.accept_privacy_policies}
+                    />
                     <span className="checkmark" />
-                    <label htmlFor="accept_privacy_policy">
+                    <label htmlFor={fieldNames.accept_privacy_policies}>
                       {' '}
                       <FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />
                     </label>
+                    {touched[fieldNames.password] && errors[fieldNames.accept_privacy_policies] ? (
+                      <div className="wrapper-errors">
+                        <p className="error-message">
+                          {errors[fieldNames.accept_privacy_policies]}
+                        </p>
+                      </div>
+                    ) : null}
                   </li>
                   <li className="field-item field-item__checkbox">
-                    <input type="checkbox" name="accept_promotions" />
+                    <Field
+                      type="checkbox"
+                      name={fieldNames.accept_promotions}
+                      id={fieldNames.accept_promotions}
+                    />
                     <span className="checkmark" />
-                    <label htmlFor="accept_promotions">{_('signup.promotions_consent')}</label>
+                    <label htmlFor={fieldNames.accept_promotions}>
+                      {_('signup.promotions_consent')}
+                    </label>
                   </li>
                 </ul>
-                <button type="button" className="dp-button button--round button-medium primary-green">
+                <button
+                  type="submit"
+                  className="dp-button button--round button-medium primary-green"
+                >
                   {_('signup.button_signup')}
                 </button>
               </fieldset>
-            </form>
+            </Form>
+          )}
+        </Formik>
         <div className="content-legal">
           <FormattedHTMLMessage id="signup.legal_HTML" />
         </div>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -18,81 +18,81 @@ export default injectIntl(function({ intl }) {
         </header>
         <h5>{_('signup.sign_up')}</h5>
         <p className="content-subtitle">{_('signup.sign_up_sub')}</p>
-        <form className="signup-form">
-          <fieldset>
-            <ul className="field-group">
-              <li className="field-item field-item--50">
-                <label htmlFor="name">{_('signup.label_firstname')}</label>
-                <input
-                  type="text"
-                  name="name"
-                  id="name"
-                  placeholder={_('signup.placeholder_firstname')}
-                />
-              </li>
-              <li className="field-item field-item--50">
-                <label htmlFor="lastname">{_('signup.label_lastname')}</label>
-                <input
-                  type="text"
-                  name="lastname"
-                  id="lastname"
-                  placeholder={_('signup.placeholder_lastname')}
-                />
-              </li>
-              <li className="field-item error">
-                <label htmlFor="phone">{_('signup.label_phone')}</label>
-                <input
-                  type="tel"
-                  name="phone"
-                  id="phone"
-                  placeholder={_('signup.placeholder_phone')}
-                />
-              </li>
-            </ul>
-          </fieldset>
-          <fieldset>
-            <ul className="field-group">
-              <li className="field-item error">
-                <label htmlFor="email">{_('signup.label_email')}</label>
-                <input
-                  type="email"
-                  name="email"
-                  id="email"
-                  placeholder={_('signup.placeholder_email')}
-                />
-              </li>
-              <li className="field-item">
-                <label htmlFor="password">{_('signup.label_password')}</label>
-                <input
-                  type="password"
-                  name="password"
-                  id="password"
-                  placeholder={_('signup.placeholder_password')}
-                />
-              </li>
-            </ul>
-          </fieldset>
-          <fieldset>
-            <ul className="field-group">
-              <li className="field-item field-item__checkbox error">
-                <input type="checkbox" name="accept_privacy_policies" />
-                <span className="checkmark" />
-                <label htmlFor="accept_privacy_policy">
-                  {' '}
-                  <FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />
-                </label>
-              </li>
-              <li className="field-item field-item__checkbox">
-                <input type="checkbox" name="accept_promotions" />
-                <span className="checkmark" />
-                <label htmlFor="accept_promotions">{_('signup.promotions_consent')}</label>
-              </li>
-            </ul>
-            <button type="button" className="dp-button button--round button-medium primary-green">
-              {_('signup.button_signup')}
-            </button>
-          </fieldset>
-        </form>
+            <form className="signup-form">
+              <fieldset>
+                <ul className="field-group">
+                  <li className="field-item field-item--50">
+                    <label htmlFor="name">{_('signup.label_firstname')}</label>
+                    <input
+                      type="text"
+                      name="name"
+                      id="name"
+                      placeholder={_('signup.placeholder_firstname')}
+                    />
+                  </li>
+                  <li className="field-item field-item--50">
+                    <label htmlFor="lastname">{_('signup.label_lastname')}</label>
+                    <input
+                      type="text"
+                      name="lastname"
+                      id="lastname"
+                      placeholder={_('signup.placeholder_lastname')}
+                    />
+                  </li>
+                  <li className="field-item error">
+                    <label htmlFor="phone">{_('signup.label_phone')}</label>
+                    <input
+                      type="tel"
+                      name="phone"
+                      id="phone"
+                      placeholder={_('signup.placeholder_phone')}
+                    />
+                  </li>
+                </ul>
+              </fieldset>
+              <fieldset>
+                <ul className="field-group">
+                  <li className="field-item error">
+                    <label htmlFor="email">{_('signup.label_email')}</label>
+                    <input
+                      type="email"
+                      name="email"
+                      id="email"
+                      placeholder={_('signup.placeholder_email')}
+                    />
+                  </li>
+                  <li className="field-item">
+                    <label htmlFor="password">{_('signup.label_password')}</label>
+                    <input
+                      type="password"
+                      name="password"
+                      id="password"
+                      placeholder={_('signup.placeholder_password')}
+                    />
+                  </li>
+                </ul>
+              </fieldset>
+              <fieldset>
+                <ul className="field-group">
+                  <li className="field-item field-item__checkbox error">
+                    <input type="checkbox" name="accept_privacy_policies" />
+                    <span className="checkmark" />
+                    <label htmlFor="accept_privacy_policy">
+                      {' '}
+                      <FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />
+                    </label>
+                  </li>
+                  <li className="field-item field-item__checkbox">
+                    <input type="checkbox" name="accept_promotions" />
+                    <span className="checkmark" />
+                    <label htmlFor="accept_promotions">{_('signup.promotions_consent')}</label>
+                  </li>
+                </ul>
+                <button type="button" className="dp-button button--round button-medium primary-green">
+                  {_('signup.button_signup')}
+                </button>
+              </fieldset>
+            </form>
         <div className="content-legal">
           <FormattedHTMLMessage id="signup.legal_HTML" />
         </div>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -1,173 +1,124 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 
-export default function() {
+export default injectIntl(function({ intl }) {
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
   return (
     <main className="panel-wrapper">
       <article className="main-panel">
         <header>
           <img src="img/doppler-logo.svg" className="logo-doppler" alt="Doppler" />
           <small className="content-signin">
-            ¿Ya tienes una cuenta?{' '}
-            <a href="/" className="link-green" target="_blank">
-              INGRESA
-            </a>
+            {_('signup.do_you_already_have_an_account')}{' '}
+            <Link to="/login" className="link-green uppercase">
+              {_('signup.log_in')}
+            </Link>
           </small>
         </header>
-        <h5>Regístrate</h5>
-        <p className="content-subtitle">Crea una cuenta GRATIS hasta 500 Suscriptores.</p>
+        <h5>{_('signup.sign_up')}</h5>
+        <p className="content-subtitle">{_('signup.sign_up_sub')}</p>
         <form className="signup-form">
           <fieldset>
-            <legend>Datos personales</legend>
             <ul className="field-group">
-              <li>
-                <ul className="field-group">
-                  <li className="field-item field-item--50 error">
-                    <label htmlFor="name">Nombre:</label>
-                    <input type="name" name="name" id="name" placeholder="Nombre" />
-                    <div className="wrapper-errors bounceIn">
-                      <p className="error-message">¡Ouch! Este campo está vacío</p>
-                    </div>
-                  </li>
-                  <li className="field-item field-item--50 error">
-                    <label htmlFor="lastname">Apellido:</label>
-                    <input type="lastname" name="name" id="lastname" placeholder="Apellido" />
-                    <div className="wrapper-errors bounceIn">
-                      <p className="error-message">¡Ouch! Este campo está vacío</p>
-                    </div>
-                  </li>
-                </ul>
+              <li className="field-item field-item--50">
+                <label htmlFor="name">{_('signup.label_firstname')}</label>
+                <input
+                  type="text"
+                  name="name"
+                  id="name"
+                  placeholder={_('signup.placeholder_firstname')}
+                />
+              </li>
+              <li className="field-item field-item--50">
+                <label htmlFor="lastname">{_('signup.label_lastname')}</label>
+                <input
+                  type="text"
+                  name="lastname"
+                  id="lastname"
+                  placeholder={_('signup.placeholder_lastname')}
+                />
               </li>
               <li className="field-item error">
-                <label htmlFor="phone">Teléfono:</label>
-                <input type="tel" name="phone" id="phone" placeholder="9 11 2345-6789" />
-                <div className="wrapper-errors bounceIn">
-                  <p className="error-message">¡Ouch! Este campo está vacío</p>
-                </div>
+                <label htmlFor="phone">{_('signup.label_phone')}</label>
+                <input
+                  type="tel"
+                  name="phone"
+                  id="phone"
+                  placeholder={_('signup.placeholder_phone')}
+                />
               </li>
             </ul>
           </fieldset>
           <fieldset>
             <ul className="field-group">
-              <legend>Usuario y contraseña</legend>
               <li className="field-item error">
-                <label htmlFor="email">Email:</label>
+                <label htmlFor="email">{_('signup.label_email')}</label>
                 <input
                   type="email"
                   name="email"
                   id="email"
-                  placeholder="Tu Email será tu nombre de usuario"
+                  placeholder={_('signup.placeholder_email')}
                 />
-                <div className="wrapper-errors bounceIn">
-                  <p className="error-message">¡Ouch! Este campo está vacío</p>
-                </div>
               </li>
               <li className="field-item">
-                <label htmlFor="password">Contraseña:</label>
+                <label htmlFor="password">{_('signup.label_password')}</label>
                 <input
                   type="password"
                   name="password"
                   id="password"
-                  placeholder="Escribe tu clave secreta"
+                  placeholder={_('signup.placeholder_password')}
                 />
-                <div className="wrapper-password">
-                  <p className="password-message">
-                    <span className="waiting-message">8 caracteres como mínimo</span>
-                    <span className="waiting-message">Un dígito</span>
-                  </p>
-                  <p className="password-message">
-                    <span className="lack-message">8 caracteres como mínimo</span>
-                    <span className="waiting-message">Un dígito</span>
-                  </p>
-                  <p className="password-message">
-                    <span className="complete-message">8 caracteres como mínimo</span>
-                    <span className="lack-message">Un dígito</span>
-                  </p>
-                  <p className="password-message">
-                    <span className="secure-message">¡Tu contraseña es segura!</span>
-                  </p>
-                </div>
               </li>
             </ul>
           </fieldset>
           <fieldset>
-            <legend>Política de privacidad y promociones</legend>
             <ul className="field-group">
               <li className="field-item field-item__checkbox error">
-                <input type="checkbox" name="acepto_politicas" />
+                <input type="checkbox" name="accept_privacy_policies" />
                 <span className="checkmark" />
-                <label htmlFor="acepto_politicas">
+                <label htmlFor="accept_privacy_policy">
                   {' '}
-                  Acepto la{' '}
-                  <a className="link-green" href="/">
-                    Política de Privacidad
-                  </a>{' '}
-                  de Doppler.
+                  <FormattedHTMLMessage id="signup.privacy_policy_consent_HTML" />
                 </label>
-                <div className="wrapper-errors bounceIn">
-                  <p className="error-message">¡Ouch! Este campo está vacío</p>
-                </div>
               </li>
               <li className="field-item field-item__checkbox">
-                <input type="checkbox" name="acepto_promociones" />
+                <input type="checkbox" name="accept_promotions" />
                 <span className="checkmark" />
-                <label htmlFor="acepto_promociones">
-                  Acepto recibir las promociones de Doppler y sus aliados.
-                </label>
+                <label htmlFor="accept_promotions">{_('signup.promotions_consent')}</label>
               </li>
             </ul>
             <button type="button" className="dp-button button--round button-medium primary-green">
-              Crear cuenta
+              {_('signup.button_signup')}
             </button>
           </fieldset>
         </form>
         <div className="content-legal">
-          <p>
-            Doppler te informa que los datos de carácter personal que nos proporciones al rellenar
-            el presente formulario serán tratados por Making Sense LLC (Doppler) como responsable de
-            esta web.
-          </p>
-          <p>
-            <strong>Finalidad:</strong> Darte de alta en nuestra plataforma y brindarte los
-            servicios que nos requieras.
-          </p>
-          <p>
-            <strong>Legitimación:</strong> Consentimiento del interesado.
-          </p>
-          <p>
-            <strong>Destinatarios:</strong> Tus datos serán guardados por Doppler, Zoho como CRM,
-            Digital Ocean, Cogeco Peer1 y Rackspace como empresas de hosting.
-          </p>
-          <p>
-            <strong>Información adicional:</strong> En la{' '}
-            <a href="/" className="link-green" target="_blank">
-              Política de Privacidad
-            </a>{' '}
-            de Doppler encontrarás información adicional sobre la recopilación y el uso de su
-            información personal por parte de Doppler, incluida información sobre acceso,
-            conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y
-            otros temas.
-          </p>
+          <FormattedHTMLMessage id="signup.legal_HTML" />
         </div>
         <p className="content-promotion">
-          Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.{' '}
-          <a href="/" className="link-green" target="_blank">
-            HELP
+          {' '}
+          {_('signup.promotion_code_reminder')}{' '}
+          <a
+            href={_('signup.promotion_code_help_url')}
+            className="link-green uppercase"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {_('common.help')}
           </a>
         </p>
         <footer>
-          <small>© 2019 Doppler LLC. Todos los derechos reservados.</small>
+          <small>{_('signup.copyright', { year: 2019 })}</small>
         </footer>
       </article>
       <section className="feature-panel">
         <article className="feature-content">
-          <h6>Editor de emails</h6>
-          <h3>Crea Emails en minutos y accede a nuestra Galería de Plantillas</h3>
-          <p>
-            Nuestras Plantillas para Email son totalmente Responsive y fácilmente editables desde
-            nuestro Editor HTML.
-          </p>
+          <h6>{_('feature_panel.email_editor')}</h6>
+          <h3>{_('feature_panel.email_editor_description')}</h3>
+          <p>{_('feature_panel.email_editor_remarks')}</p>
         </article>
       </section>
     </main>
   );
-}
+});

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { connect, Field } from 'formik';
+
+function concatClasses(...args) {
+  return args.filter((x) => x).join(' ');
+}
+
+export const FieldGroup = ({ className, children }) => (
+  <ul className={concatClasses('field-group', className)}>{children}</ul>
+);
+
+export const FieldItem = connect(
+  ({ className, fieldName, children, formik: { errors, touched } }) => (
+    <li
+      className={concatClasses(className, touched[fieldName] && errors[fieldName] ? 'error' : '')}
+    >
+      {children}
+      {touched[fieldName] && errors[fieldName] ? (
+        <div className="wrapper-errors">
+          <p className="error-message">{errors[fieldName]}</p>
+        </div>
+      ) : null}
+    </li>
+  ),
+);
+
+export const InputFieldItem = ({ className, fieldName, label, type, placeholder }) => (
+  <FieldItem className={concatClasses('field-item', className)} fieldName={fieldName}>
+    <label htmlFor={fieldName}>{label}</label>
+    <Field type={type} name={fieldName} id={fieldName} placeholder={placeholder} />
+  </FieldItem>
+);
+
+export const CheckboxFieldItem = ({ className, fieldName, label }) => (
+  <FieldItem
+    className={concatClasses('field-item field-item__checkbox', className)}
+    fieldName={fieldName}
+  >
+    <Field type="checkbox" name={fieldName} id={fieldName} />
+    <span className="checkmark" />
+    <label htmlFor={fieldName}> {label}</label>
+  </FieldItem>
+);

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { connect, Field } from 'formik';
 
 function concatClasses(...args) {
@@ -30,6 +30,40 @@ export const InputFieldItem = ({ className, fieldName, label, type, placeholder 
     <Field type={type} name={fieldName} id={fieldName} placeholder={placeholder} />
   </FieldItem>
 );
+
+export const PasswordFieldItem = ({ className, fieldName, label, placeholder }) => {
+  const [passVisible, setPassVisible] = useState(false);
+  const type = passVisible ? 'text' : 'password';
+  const autocomplete = passVisible ? 'off' : 'current-password';
+  const buttonClasses = passVisible ? 'show-hide icon-hide ms-icon' : 'show-hide ms-icon icon-view';
+
+  return (
+    <FieldItem className={concatClasses('field-item', className)} fieldName={fieldName}>
+      <label htmlFor={fieldName}>
+        {label}{' '}
+        <button
+          type="button"
+          className={buttonClasses}
+          onClick={() => {
+            setPassVisible((current) => !current);
+          }}
+        >
+          <span className="content-eye" />
+        </button>
+      </label>
+      <Field
+        type={type}
+        name={fieldName}
+        autoComplete={autocomplete}
+        id={fieldName}
+        placeholder={placeholder}
+        spellCheck="false"
+        badinput="false"
+        autoCapitalize="off"
+      />
+    </FieldItem>
+  );
+};
 
 export const CheckboxFieldItem = ({ className, fieldName, label }) => (
   <FieldItem

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,8 +1,14 @@
 {
   "common": {
     "cancel": "Cancel",
+    "help": "Help",
     "message": "Message",
     "send": "Send"
+  },
+  "feature_panel": {
+    "email_editor": "Emails Editor",
+    "email_editor_description": "Crea Emails en minutos y accede a nuestra Galería de Plantillas",
+    "email_editor_remarks": "Nuestras Plantillas para Email son totalmente Responsive y fácilmente editables desde nuestro Editor HTML."
   },
   "footer": {
     "allRightReserved": "All rights reserved",
@@ -33,6 +39,29 @@
     "verified_domain": "Verified domain"
   },
   "reports_title": "Doppler | Reports",
+  "signup": {
+    "button_signup": "Sign Up",
+    "copyright": "© {year} Doppler LLC. Todos los derechos reservados.",
+    "do_you_already_have_an_account": "Already have an account?",
+    "label_email": "Email: ",
+    "label_firstname": "Name: ",
+    "label_lastname": "Lastname: ",
+    "label_password": "Password: ",
+    "label_phone": "Phone: ",
+    "legal_HTML": "\n<p>Doppler te informa que los datos de carácter personal que nos proporciones al rellenar el presente formulario serán tratados por Making Sense LLC (Doppler) como responsable de esta web.</p>\n<p><strong>Finalidad:</strong> Darte de alta en nuestra plataforma y brindarte los servicios que nos requieras.</p>\n<p><strong>Legitimación:</strong> Consentimiento del interesado.</p>\n<p><strong>Destinatarios:</strong> Tus datos serán guardados por Doppler, Zoho como CRM, Digital Ocean, Cogeco Peer1 y Rackspace como empresas de hosting.</p>\n<p><strong>Información adicional:</strong> En la <a class=\"link-green\" href=\"https://www.fromdoppler.com/en/legal/privacy-policy\">Privacy Policy</a> de Doppler encontrarás información adicional sobre la recopilación y el uso de su información personal por parte de Doppler, incluida información sobre acceso, conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y otros temas.</p>",
+    "log_in": "Log In",
+    "placeholder_email": "Your Email will be your Username",
+    "placeholder_firstname": "Name",
+    "placeholder_lastname": "Lastname",
+    "placeholder_password": "Enter your secret key",
+    "placeholder_phone": "9 11 2345-6789",
+    "privacy_policy_consent_HTML": "I accept Doppler's <a class=\"link-green\" href=\"https://www.fromdoppler.com/en/legal/privacy-policy\">Privacy Policy</a>.",
+    "promotion_code_help_url": "https://help.fromdoppler.com/en/how-to-activate-my-promo-code",
+    "promotion_code_reminder": "Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.",
+    "promotions_consent": "Sign me up for promotions about Doppler and its partners.",
+    "sign_up": "Sign Up",
+    "sign_up_sub": "No contracts or credit cards required, up to 500 Subscribers."
+  },
   "upgradePlanForm": {
     "message_placeholder": "Your mensaje",
     "plan_select": "Select Plan",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -68,6 +68,7 @@
     "title": "Solicita una actualización de tu plan"
   },
   "validation_messages": {
+    "error_invalid_email_address": "Ouch! Invalid email address",
     "error_required_field": "Ouch! The field is empty."
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,8 +1,14 @@
 {
   "common": {
     "cancel": "Cancelar",
+    "help": "Ayuda",
     "message": "Mensaje",
     "send": "Enviar"
+  },
+  "feature_panel": {
+    "email_editor": "Editor de Emails",
+    "email_editor_description": "Crea Emails en minutos y accede a nuestra Galería de Plantillas",
+    "email_editor_remarks": "Nuestras Plantillas para Email son totalmente Responsive y fácilmente editables desde nuestro Editor HTML."
   },
   "footer": {
     "allRightReserved": "Todos los derechos reservados",
@@ -33,6 +39,29 @@
     "verified_domain": "Dominio verificado"
   },
   "reports_title": "Doppler | Reportes",
+  "signup": {
+    "button_signup": "Crear cuenta",
+    "copyright": "© {year} Doppler LLC. Todos los derechos reservados.",
+    "do_you_already_have_an_account": "¿Ya tienes una cuenta?",
+    "label_email": "Email: ",
+    "label_firstname": "Nombre: ",
+    "label_lastname": "Apellido: ",
+    "label_password": "Contraseña: ",
+    "label_phone": "Teléfono: ",
+    "legal_HTML": "\n<p>Doppler te informa que los datos de carácter personal que nos proporciones al rellenar el presente formulario serán tratados por Making Sense LLC (Doppler) como responsable de esta web.</p>\n<p><strong>Finalidad:</strong> Darte de alta en nuestra plataforma y brindarte los servicios que nos requieras.</p>\n<p><strong>Legitimación:</strong> Consentimiento del interesado.</p>\n<p><strong>Destinatarios:</strong> Tus datos serán guardados por Doppler, Zoho como CRM, Digital Ocean, Cogeco Peer1 y Rackspace como empresas de hosting.</p>\n<p><strong>Información adicional:</strong> En la <a class=\"link-green\" href=\"https://www.fromdoppler.com/legales/privacidad\">Política de Privacidad</a> de Doppler encontrarás información adicional sobre la recopilación y el uso de su información personal por parte de Doppler, incluida información sobre acceso, conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y otros temas.</p>",
+    "log_in": "Ingresa",
+    "placeholder_email": "Tu Email será tu nombre de usuario",
+    "placeholder_firstname": "Nombre",
+    "placeholder_lastname": "Apellido",
+    "placeholder_password": "Escribe tu clave secreta",
+    "placeholder_phone": "9 11 2345-6789",
+    "privacy_policy_consent_HTML": "Acepto la <a class=\"link-green\" href=\"https://www.fromdoppler.com/legales/privacidad\">Política de Privacidad</a> de Doppler.",
+    "promotion_code_help_url": "https://help.fromdoppler.com/es/como-activo-mi-descuento-en-doppler/",
+    "promotion_code_reminder": "Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.",
+    "promotions_consent": "Acepto recibir las promociones de Doppler y sus aliados.",
+    "sign_up": "Regístrate",
+    "sign_up_sub": "Crea una cuenta GRATIS hasta 500 Suscriptores."
+  },
   "upgradePlanForm": {
     "message_placeholder": "Tu mensaje",
     "plan_select": "Selecciona el Plan",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -68,6 +68,7 @@
     "title": "Solicita una actualización de tu plan"
   },
   "validation_messages": {
+    "error_invalid_email_address": "¡Ouch! El formato del email es incorrecto",
     "error_required_field": "¡Ouch! El campo está vacío."
   }
 }


### PR DESCRIPTION
Hi team,

This signup page has a lot of holes yet, but I think that it could be a nice start to continue working on related things in parallel, for example, validations, tests, backend, usability, etc.

Could you review?

I would really appreciate if HTML/CSS guys (@GusBaamonde, @IgnacioRodrigues, @damianmuti) take a look and give me feedback about commit _"chore: add form helpers following our conventions"_ (probably _"chore: add formik with basic validation"_ could help to understand), because I want to know if the structure makes sense to be reused.

~~You can see it working at https://cdn.fromdoppler.com/doppler-webapp/build213/#/signup~~

**UPDATE:** It is updated with the last @IgnacioRodrigues fixes and with a PasswordFieldItem component that allows show and hide the password. 

See it working in: https://cdn.fromdoppler.com/doppler-webapp/build223/#/signup