### PR TITLE
DBR-161 Datahub client

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{js,ts}]
+block_comment_start = /*
+block_comment_end = */

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:52191
+REACT_APP_DOPPLER_LEGACY_URL=http://localhost:52191

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 REACT_APP_DOPPLER_LEGACY_URL=http://localhost:52191
+REACT_APP_DATAHUB_URL=https://hubapisecint.fromdoppler.com

--- a/.env.int
+++ b/.env.int
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://appint.fromdoppler.net
+REACT_APP_DOPPLER_LEGACY_URL=https://appint.fromdoppler.net

--- a/.env.int
+++ b/.env.int
@@ -1,1 +1,2 @@
 REACT_APP_DOPPLER_LEGACY_URL=https://appint.fromdoppler.net
+REACT_APP_DATAHUB_URL=https://hubapisecint.fromdoppler.com

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 REACT_APP_DOPPLER_LEGACY_URL=https://app2.fromdoppler.com
+REACT_APP_DATAHUB_URL=https://hubapisec.fromdoppler.com

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://app2.fromdoppler.com
+REACT_APP_DOPPLER_LEGACY_URL=https://app2.fromdoppler.com

--- a/.env.qa
+++ b/.env.qa
@@ -1,1 +1,2 @@
 REACT_APP_DOPPLER_LEGACY_URL=https://appqa.fromdoppler.net
+REACT_APP_DATAHUB_URL=https://hubapisecqa.fromdoppler.com

--- a/.env.qa
+++ b/.env.qa
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://appqa.fromdoppler.net
+REACT_APP_DOPPLER_LEGACY_URL=https://appqa.fromdoppler.net

--- a/src/App.js
+++ b/src/App.js
@@ -73,14 +73,11 @@ class App extends Component {
   }
 
   render() {
-    const {
-      dopplerSession: { status: sessionStatus, userData },
-      i18nLocale,
-    } = this.state;
+    const { dopplerSession, i18nLocale } = this.state;
 
     return (
       <DopplerIntlProvider locale={i18nLocale}>
-        {sessionStatus === 'unknown' ? (
+        {dopplerSession.status === 'unknown' ? (
           <Loading page />
         ) : (
           <Switch>
@@ -88,9 +85,9 @@ class App extends Component {
             <PrivateRoute
               path="/reports/"
               exact
+              requireDatahub
               component={Reports}
-              userData={userData}
-              sessionStatus={sessionStatus}
+              dopplerSession={dopplerSession}
             />
             <Route path="/login/" exact component={Login} />
             <Route path="/signup/" exact component={Signup} />

--- a/src/App.js
+++ b/src/App.js
@@ -12,16 +12,20 @@ import ForgotPassword from './components/ForgotPassword/ForgotPassword';
 import queryString from 'query-string';
 
 class App extends Component {
-  constructor({ locale, dependencies: { sessionManager } }) {
+  /**
+   * @param { Object } props - props
+   * @param { string } props.locale - locale
+   * @param { import('./services/pure-di').AppServices } props.dependencies - dependencies
+   */
+  constructor({ locale, dependencies: { appSessionRef, sessionManager } }) {
     super();
 
     this.updateSession = this.updateSession.bind(this);
 
-    /** @type { import('./services/session-manager').SessionManager } */
     this.sessionManager = sessionManager;
 
     this.state = {
-      dopplerSession: this.sessionManager.session,
+      dopplerSession: appSessionRef.current,
       i18nLocale: locale,
     };
   }

--- a/src/components/DatahubRequired/DatahubRequired.js
+++ b/src/components/DatahubRequired/DatahubRequired.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { InjectAppServices } from '../../services/pure-di';
+import { FormattedHTMLMessage } from 'react-intl';
+
+/**
+ * @param { Object } props
+ * @param { import('../../services/pure-di').AppServices } props.dependencies
+ */
+function DatahubRequired({
+  dependencies: {
+    appConfiguration: { dopplerLegacyUrl },
+  },
+}) {
+  return (
+    <section className="container-reports">
+      <div className="wrapper-kpi">
+        {/* TODO: review this solution, probably styles, content and behavior are wrong */}
+        <FormattedHTMLMessage
+          id="reports.datahub_not_active_HTML"
+          values={{ dopplerBaseUrl: dopplerLegacyUrl }}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default InjectAppServices(DatahubRequired);

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -3,11 +3,19 @@ import { Route } from 'react-router-dom';
 import Header from './Header/Header';
 import Footer from './Footer/Footer';
 import { InjectAppServices } from '../services/pure-di';
+import DatahubRequired from './DatahubRequired/DatahubRequired';
 
-export default InjectAppServices(function({
+/**
+ * @param { Object } props
+ * @param { React.Component } props.component
+ * @param { Boolean } props.requireDatahub
+ * @param { import('../services/app-session').AppSession } props.dopplerSession
+ * @param { import('../services/pure-di').AppServices } props.dependencies
+ */
+function PrivateRoute({
   component: Component,
-  userData,
-  sessionStatus,
+  requireDatahub,
+  dopplerSession,
   dependencies: { RedirectToLogin },
   ...rest
 }) {
@@ -15,10 +23,14 @@ export default InjectAppServices(function({
     <Route
       {...rest}
       render={(props) =>
-        sessionStatus === 'authenticated' ? (
+        dopplerSession.status === 'authenticated' ? (
           <>
-            <Header userData={userData} />
-            <Component {...props} />
+            <Header userData={dopplerSession.userData} />
+            {!requireDatahub || dopplerSession.datahubCustomerId ? (
+              <Component {...props} />
+            ) : (
+              <DatahubRequired />
+            )}
             <Footer />
           </>
         ) : (
@@ -27,4 +39,6 @@ export default InjectAppServices(function({
       }
     />
   );
-});
+}
+
+export default InjectAppServices(PrivateRoute);

--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -6,10 +6,13 @@ import { InjectAppServices } from '../../services/pure-di';
 import { FormattedMessage } from 'react-intl';
 
 class Reports extends React.Component {
+  /**
+   * @param { Object } props
+   * @param { import('../../services/pure-di').AppServices } props.dependencies
+   */
   constructor({ dependencies: { datahubClient } }) {
     super();
 
-    /** @type { import('../../services/datahub-client').DatahubClient } */
     this.datahubClient = datahubClient;
 
     this.state = {

--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -94,13 +94,13 @@ class Reports extends React.Component {
                 periodSelectedDays={this.state.periodSelectedDays}
                 dateTo={this.state.dateTo}
                 dateFrom={this.state.dateFrom}
-                isVisitsWithEmail={false}
+                withoutEmail
               />
               <ReportsBox
                 domainName={this.state.domainSelected.name}
                 dateTo={this.state.dateTo}
                 dateFrom={this.state.dateFrom}
-                isVisitsWithEmail={true}
+                withEmail
               />
             </div>
             <ReportsPageRanking

--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -31,7 +31,7 @@ class Reports extends React.Component {
     const domains = await this.datahubClient.getAccountDomains();
     if (domains.length) {
       const domainSelected = domains[0];
-      const pages = await this.datahubClient.getPagesByDomainId(domainSelected.id);
+      const pages = [];
       const pageSelected = pages.length ? pages[0] : null;
       let dateFrom = new Date();
       dateFrom.setDate(dateFrom.getDate() - parseInt(this.state.periodSelectedDays));
@@ -47,7 +47,7 @@ class Reports extends React.Component {
 
   changeDomain = async (id) => {
     const domainFound = this.state.domains.find((item) => item.id === id);
-    const pages = await this.datahubClient.getPagesByDomainId(id);
+    const pages = [];
     const pageSelected = pages.length ? pages[0] : null;
     this.setState({ domainSelected: domainFound, pages: pages, pageSelected: pageSelected });
   };

--- a/src/components/Reports/Reports.test.js
+++ b/src/components/Reports/Reports.test.js
@@ -43,7 +43,6 @@ describe('Reports page', () => {
   it('should render domains without pages', async () => {
     const datahubClientDouble = {
       getAccountDomains: async () => fakeData,
-      getPagesByDomainId: async () => [],
       getVisitsByPeriod: async () => 0,
       getPagesRankingByPeriod: async () => [],
     };
@@ -63,28 +62,5 @@ describe('Reports page', () => {
 
     expect(verifiedDate).toBeDefined();
     expect(domain).toBeDefined();
-  });
-
-  it('should render domains with pages', async () => {
-    const datahubClientDouble = {
-      getAccountDomains: async () => fakeData,
-      getPagesByDomainId: async () => fakePages,
-      getVisitsByPeriod: async () => 0,
-      getPagesRankingByPeriod: async () => [],
-    };
-
-    const { getByText } = render(
-      <AppServicesProvider forcedServices={{ datahubClient: datahubClientDouble }}>
-        <DopplerIntlProvider>
-          <Reports />
-        </DopplerIntlProvider>
-      </AppServicesProvider>,
-    );
-
-    await wait(() => getByText(fakePages[0].name));
-
-    const page = getByText(fakePages[0].name);
-
-    expect(page).toBeDefined();
   });
 });

--- a/src/components/Reports/ReportsBox/ReportsBox.js
+++ b/src/components/Reports/ReportsBox/ReportsBox.js
@@ -3,10 +3,13 @@ import { InjectAppServices } from '../../../services/pure-di';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 
 class ReportsBox extends React.Component {
+  /**
+   * @param { Object } props - props
+   * @param { import('../../../services/pure-di').AppServices } props.dependencies
+   */
   constructor({ dependencies: { datahubClient } }) {
     super();
 
-    /** @type { import('../../services/datahub-client').DatahubClient } */
     this.datahubClient = datahubClient;
 
     this.state = {

--- a/src/components/Reports/ReportsBox/ReportsBox.js
+++ b/src/components/Reports/ReportsBox/ReportsBox.js
@@ -17,11 +17,11 @@ class ReportsBox extends React.Component {
   }
 
   async fetchVisitsByPeriod(domainName, dateFrom) {
-    this.asyncRequest = this.datahubClient.getVisitsByPeriod(
-      domainName,
-      dateFrom,
-      this.props.isVisitsWithEmail,
-    );
+    this.asyncRequest = this.datahubClient.getVisitsByPeriod({
+      domainName: domainName,
+      dateFrom: dateFrom,
+      isVisitsWithEmail: this.props.isVisitsWithEmail,
+    });
     const visits = await this.asyncRequest;
     this.asyncRequest = null;
     this.setState({

--- a/src/components/Reports/ReportsBox/ReportsBox.js
+++ b/src/components/Reports/ReportsBox/ReportsBox.js
@@ -20,7 +20,11 @@ class ReportsBox extends React.Component {
     this.asyncRequest = this.datahubClient.getVisitsByPeriod({
       domainName: domainName,
       dateFrom: dateFrom,
-      isVisitsWithEmail: this.props.isVisitsWithEmail,
+      emailFilter: this.props.withEmail
+        ? 'with_email'
+        : this.props.withoutEmail
+        ? 'without_email'
+        : null,
     });
     const visits = await this.asyncRequest;
     this.asyncRequest = null;
@@ -76,10 +80,12 @@ class ReportsBox extends React.Component {
           <>
             <h3 className="number-kpi">{visits}</h3>
             <h6 className="subtitle-kpi">
-              {this.props.isVisitsWithEmail ? (
+              {this.props.withEmail ? (
                 <FormattedMessage id="reports_box.visits_with_email" />
-              ) : (
+              ) : this.props.withoutEmail ? (
                 <FormattedMessage id="reports_box.visits_without_emails" />
+              ) : (
+                <span>Unexpected error</span>
               )}
             </h6>
             <small className="date-range">

--- a/src/components/Reports/ReportsPageRanking/ReportsPageRanking.js
+++ b/src/components/Reports/ReportsPageRanking/ReportsPageRanking.js
@@ -17,7 +17,10 @@ class ReportsPageRanking extends React.Component {
   }
 
   async fetchPagesRankingByPeriod(domainName, dateFrom) {
-    this.asyncRequest = this.datahubClient.getPagesRankingByPeriod(domainName, dateFrom);
+    this.asyncRequest = this.datahubClient.getPagesRankingByPeriod({
+      domainName: domainName,
+      dateFrom: dateFrom,
+    });
     const pages = await this.asyncRequest;
     this.asyncRequest = null;
     this.setState({

--- a/src/headerData.json
+++ b/src/headerData.json
@@ -187,5 +187,7 @@
       "type": "warning",
       "message": "Estamos verificando el origen de tus Suscriptores. Te contactaremos para que puedas continuar con tu Campaña."
     }
-  }
+  },
+  "datahubCustomerId": "1057",
+  "jwtToken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjpmYWxzZSwiY3VzdG9tZXJJZCI6IjEwNTciLCJpYXQiOjE1NTM3ODQ3MjUsImV4cCI6MTU2OTMzNjcyNX0.NNLt0BWHkAqOd2Nd8xH7nDcrfSTmq8MuAMRdIXTUU9FcTnlGy66Lwst8HSmVH1y4qoluNtCi0ZeuUddRFRUrzA"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -34,6 +34,9 @@
     "signup": "Sign up free",
     "you_want_create_account": "Do not you have an account yet?"
   },
+  "reports": {
+    "datahub_not_active_HTML": "This feature is not enabled, please check <a href=\"{dopplerBaseUrl}/ControlPanel/CampaignsPreferences/SiteTrackingSettings\">On-Site Tracking preferences</a>."
+  },
   "reports_box": {
     "to": "to",
     "visits_description": "This report shows the total number of visits in the selected time period",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -34,6 +34,9 @@
     "signup": "Régistrate gratis",
     "you_want_create_account": "¿Aún no tienes una cuenta?"
   },
+  "reports": {
+    "datahub_not_active_HTML": "Esta funcionalidad no está habilitada, por favor revisa las <a href=\"{dopplerBaseUrl}/ControlPanel/CampaignsPreferences/SiteTrackingSettings\">preferencias de Seguimiento en Sitio</a>."
+  },
   "reports_box": {
     "to": "a",
     "visits_description": "Este reporte muestra el total de visitas en el período de tiempo seleccionado",

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { HashRouter as Router } from 'react-router-dom';
 
 // Only used in development environment, it does not affect production build
 import { HardcodedDopplerLegacyClient } from './services/doppler-legacy-client.doubles';
+import { HardcodedDatahubClient } from './services/datahub-client.doubles';
 
 // TODO: this hardcoded data will depend by the app language
 const locale = navigator.language.toLowerCase().split(/[_-]+/)[0] || 'en';
@@ -18,6 +19,7 @@ const forcedServices =
   process.env.NODE_ENV === 'development'
     ? {
         dopplerLegacyClient: new HardcodedDopplerLegacyClient(),
+        datahubClient: new HardcodedDatahubClient(),
         RedirectToLogin: RedirectToInternalLogin,
       }
     : {};

--- a/src/services/app-session.ts
+++ b/src/services/app-session.ts
@@ -1,13 +1,30 @@
 import { DopplerLegacyUserData } from './doppler-legacy-client';
 import { RefObject } from 'react';
 
+interface AuthenticatedAppSession {
+  status: 'authenticated';
+  userData: DopplerLegacyUserData;
+  jwtToken: string;
+}
+
+interface AuthenticatedAppSessionWithoutDatahub extends AuthenticatedAppSession {
+  datahubCustomerId?: null;
+}
+
+export interface DatahubConnectionData {
+  datahubCustomerId: string;
+  jwtToken: string;
+}
+
+interface AuthenticatedAppSessionWithDatahub
+  extends DatahubConnectionData,
+    AuthenticatedAppSession {}
+
 export type AppSession =
   | { status: 'unknown' }
   | { status: 'non-authenticated' }
-  | {
-      status: 'authenticated';
-      userData: DopplerLegacyUserData;
-    };
+  | AuthenticatedAppSessionWithoutDatahub
+  | AuthenticatedAppSessionWithDatahub;
 
 export function createAppSessionRef(): RefObject<AppSession> {
   return { current: { status: 'unknown' } };

--- a/src/services/app-session.ts
+++ b/src/services/app-session.ts
@@ -1,0 +1,14 @@
+import { DopplerLegacyUserData } from './doppler-legacy-client';
+import { RefObject } from 'react';
+
+export type AppSession =
+  | { status: 'unknown' }
+  | { status: 'non-authenticated' }
+  | {
+      status: 'authenticated';
+      userData: DopplerLegacyUserData;
+    };
+
+export function createAppSessionRef(): RefObject<AppSession> {
+  return { current: { status: 'unknown' } };
+}

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -46,6 +46,8 @@ const fakePagesData = [
   },
 ];
 
+type emailFilterOptions = 'with_email' | 'without_email' | null;
+
 export class HardcodedDatahubClient implements DatahubClient {
   public async getAccountDomains() {
     console.log('getAccountDomains');
@@ -56,13 +58,13 @@ export class HardcodedDatahubClient implements DatahubClient {
   public async getVisitsByPeriod({
     domainName,
     dateFrom,
-    isVisitsWithEmail,
+    emailFilter,
   }: {
     domainName: number;
     dateFrom: Date;
-    isVisitsWithEmail: boolean;
+    emailFilter: emailFilterOptions;
   }) {
-    console.log('getVisitsByPeriod', { domainName, dateFrom, isVisitsWithEmail });
+    console.log('getVisitsByPeriod', { domainName, dateFrom, emailFilter });
     await timeout(1500);
     const visits = Math.round(Math.random() * (100 - 1) + 1);
     return visits;

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -53,14 +53,28 @@ export class HardcodedDatahubClient implements DatahubClient {
     return fakeData.map((x) => ({ id: x.id, name: x.name, verified_date: x.verified_date }));
   }
 
-  public async getVisitsByPeriod(domainName: number, dateFrom: Date, isVisitsWithEmail: boolean) {
+  public async getVisitsByPeriod({
+    domainName,
+    dateFrom,
+    isVisitsWithEmail,
+  }: {
+    domainName: number;
+    dateFrom: Date;
+    isVisitsWithEmail: boolean;
+  }) {
     console.log('getVisitsByPeriod', { domainName, dateFrom, isVisitsWithEmail });
     await timeout(1500);
     const visits = Math.round(Math.random() * (100 - 1) + 1);
     return visits;
   }
 
-  public async getPagesRankingByPeriod(domainName: number, dateFrom: Date) {
+  public async getPagesRankingByPeriod({
+    domainName,
+    dateFrom,
+  }: {
+    domainName: number;
+    dateFrom: Date;
+  }) {
     console.log('getPagesRankingByPeriod', { domainName, dateFrom });
     await timeout(1500);
     return fakePagesData.map((x) => ({ name: x.name, totalVisits: x.totalVisits }));

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -1,4 +1,4 @@
-import { DatahubClient } from './datahub-client';
+import { DatahubClient, emailFilterOptions, DomainEntry } from './datahub-client';
 import { timeout } from '../utils';
 
 // TODO: use more realistic data
@@ -46,10 +46,8 @@ const fakePagesData = [
   },
 ];
 
-type emailFilterOptions = 'with_email' | 'without_email' | null;
-
 export class HardcodedDatahubClient implements DatahubClient {
-  public async getAccountDomains() {
+  public async getAccountDomains(): Promise<DomainEntry[]> {
     console.log('getAccountDomains');
     await timeout(1500);
     return fakeData.map((x) => ({ id: x.id, name: x.name, verified_date: x.verified_date }));
@@ -63,7 +61,7 @@ export class HardcodedDatahubClient implements DatahubClient {
     domainName: number;
     dateFrom: Date;
     emailFilter: emailFilterOptions;
-  }) {
+  }): Promise<number> {
     console.log('getVisitsByPeriod', { domainName, dateFrom, emailFilter });
     await timeout(1500);
     const visits = Math.round(Math.random() * (100 - 1) + 1);
@@ -76,7 +74,7 @@ export class HardcodedDatahubClient implements DatahubClient {
   }: {
     domainName: number;
     dateFrom: Date;
-  }) {
+  }): Promise<{ name: string; totalVisits: number }[]> {
     console.log('getPagesRankingByPeriod', { domainName, dateFrom });
     await timeout(1500);
     return fakePagesData.map((x) => ({ name: x.name, totalVisits: x.totalVisits }));

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -53,16 +53,6 @@ export class HardcodedDatahubClient implements DatahubClient {
     return fakeData.map((x) => ({ id: x.id, name: x.name, verified_date: x.verified_date }));
   }
 
-  public async getPagesByDomainId(domainId: number) {
-    console.log('getPagesByDomainId', { domainId });
-    await timeout(1500);
-    const domain = fakeData.find((x) => x.id === domainId);
-    if (!domain) {
-      throw new Error(`Domain with id ${domainId} does not exist`);
-    }
-    return domain.pages;
-  }
-
   public async getVisitsByPeriod(domainName: number, dateFrom: Date, isVisitsWithEmail: boolean) {
     console.log('getVisitsByPeriod', { domainName, dateFrom, isVisitsWithEmail });
     await timeout(1500);

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -2,11 +2,6 @@ import { AxiosInstance, AxiosStatic } from 'axios';
 import { RefObject } from 'react';
 import { DatahubConnectionData } from './app-session';
 
-interface PageEntry {
-  id: number;
-  name: string;
-}
-
 interface DomainEntry {
   id: number;
   name: string;
@@ -16,8 +11,6 @@ interface DomainEntry {
 export interface DatahubClient {
   // See: https://github.com/MakingSense/Customer-Data-Hub/blob/0f28f0906b22198622f71867e1cdaf00abd41af1/apisec/swaggerDef.js#L74
   getAccountDomains(): Promise<DomainEntry[]>;
-  // TODO: verify what Datahub's service exposes this information, is it based in domain id or domain name?
-  getPagesByDomainId(domainId: number): Promise<PageEntry[]>;
 }
 
 const fakeData = [
@@ -38,29 +31,6 @@ const fakeData = [
     name: 'www.google.com',
     verified_date: new Date('2017-12-17'),
     pages: [],
-  },
-];
-
-const fakePagesData = [
-  {
-    name: 'https://www.fromdoppler.com/email-marketing',
-    totalVisits: 10122,
-  },
-  {
-    name: 'https://www.fromdoppler.com/precios',
-    totalVisits: 9000,
-  },
-  {
-    name: 'https://www.fromdoppler.com/login',
-    totalVisits: 5001,
-  },
-  {
-    name: 'https://www.fromdoppler.com/productos',
-    totalVisits: 3800,
-  },
-  {
-    name: 'https://www.fromdoppler.com/servicios',
-    totalVisits: 1023,
   },
 ];
 
@@ -90,14 +60,5 @@ export class HttpDatahubClient implements DatahubClient {
   public async getAccountDomains(): Promise<DomainEntry[]> {
     console.log('getAccountDomains');
     return fakeData.map((x) => ({ id: x.id, name: x.name, verified_date: x.verified_date }));
-  }
-
-  public async getPagesByDomainId(domainId: number): Promise<PageEntry[]> {
-    console.log('getPagesByDomainId', { domainId });
-    const domain = fakeData.find((x) => x.id === domainId);
-    if (!domain) {
-      throw new Error(`Domain with id ${domainId} does not exist`);
-    }
-    return domain.pages;
   }
 }

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -1,17 +1,15 @@
-import { AxiosInstance, AxiosStatic } from 'axios';
+import { AxiosInstance, AxiosStatic, AxiosPromise } from 'axios';
 import { RefObject } from 'react';
-import { DatahubConnectionData } from './app-session';
+import { AppSession, DatahubConnectionData } from './app-session';
 
 export interface DomainEntry {
-  id: number;
   name: string;
-  verified_date: Date;
+  verified_date: Date | null;
 }
 
 export type emailFilterOptions = 'with_email' | 'without_email' | null;
 
 export interface DatahubClient {
-  // See: https://github.com/MakingSense/Customer-Data-Hub/blob/0f28f0906b22198622f71867e1cdaf00abd41af1/apisec/swaggerDef.js#L74
   getAccountDomains(): Promise<DomainEntry[]>;
   getVisitsByPeriod(query: {
     domainName: number;
@@ -24,54 +22,10 @@ export interface DatahubClient {
   }): Promise<{ name: string; totalVisits: number }[]>;
 }
 
-const fakeData = [
-  {
-    id: 1,
-    name: 'www.fromdoppler.com',
-    verified_date: new Date('2017-12-17'),
-    pages: [],
-  },
-  {
-    id: 2,
-    name: 'www.makingsense.com',
-    verified_date: new Date('2010-12-17'),
-    pages: [],
-  },
-  {
-    id: 3,
-    name: 'www.google.com',
-    verified_date: new Date('2017-12-17'),
-    pages: [],
-  },
-];
-
-const fakePagesData = [
-  {
-    name: 'https://www.fromdoppler.com/email-marketing',
-    totalVisits: 10122,
-  },
-  {
-    name: 'https://www.fromdoppler.com/precios',
-    totalVisits: 9000,
-  },
-  {
-    name: 'https://www.fromdoppler.com/login',
-    totalVisits: 5001,
-  },
-  {
-    name: 'https://www.fromdoppler.com/productos',
-    totalVisits: 3800,
-  },
-  {
-    name: 'https://www.fromdoppler.com/servicios',
-    totalVisits: 1023,
-  },
-];
-
 export class HttpDatahubClient implements DatahubClient {
   private readonly axios: AxiosInstance;
   private readonly baseUrl: string;
-  private readonly connectionDataRef: RefObject<DatahubConnectionData>;
+  private readonly connectionDataRef: RefObject<AppSession>;
 
   constructor({
     axiosStatic,
@@ -80,20 +34,46 @@ export class HttpDatahubClient implements DatahubClient {
   }: {
     axiosStatic: AxiosStatic;
     baseUrl: string;
-    connectionDataRef: RefObject<DatahubConnectionData>;
+    connectionDataRef: RefObject<AppSession>;
   }) {
     this.baseUrl = baseUrl;
     this.axios = axiosStatic.create({
-      baseURL: baseUrl,
-      withCredentials: true,
+      baseURL: this.baseUrl,
     });
     this.connectionDataRef = connectionDataRef;
   }
 
-  // TODO: implement this class
+  private getDatahubConnectionData(): DatahubConnectionData {
+    const connectionData = this.connectionDataRef.current;
+    if (
+      !connectionData ||
+      connectionData.status !== 'authenticated' ||
+      !connectionData.jwtToken ||
+      !connectionData.datahubCustomerId
+    ) {
+      throw new Error('DataHub connection data is not available');
+    }
+    return connectionData;
+  }
+
+  private customerGet<T>(subUrl: string, params?: any): AxiosPromise<T> {
+    const { datahubCustomerId: customerId, jwtToken } = this.getDatahubConnectionData();
+    return this.axios.request<T>({
+      method: 'GET',
+      url: `/cdhapi/customers/${customerId}/${subUrl}`,
+      params: params,
+      headers: { Authorization: `Bearer ${jwtToken}` },
+    });
+  }
+
   public async getAccountDomains(): Promise<DomainEntry[]> {
-    console.log('getAccountDomains');
-    return fakeData.map((x) => ({ id: x.id, name: x.name, verified_date: x.verified_date }));
+    const response = await this.customerGet<{ items: any[] }>('domains');
+    return response.data.items
+      .filter((x) => x.enabled)
+      .map((x) => ({
+        name: x.domainName,
+        verified_date: (x.lastNavigationEventTime && new Date(x.lastNavigationEventTime)) || null,
+      }));
   }
 
   public async getVisitsByPeriod({
@@ -105,9 +85,14 @@ export class HttpDatahubClient implements DatahubClient {
     dateFrom: Date;
     emailFilter: emailFilterOptions;
   }): Promise<number> {
-    console.log('getVisitsByPeriod', { domainName, dateFrom, emailFilter });
-    const visits = Math.round(Math.random() * (100 - 1) + 1);
-    return visits;
+    const response = await this.customerGet<{ visitors_quantity: number }>(
+      `domains/${domainName}/visitors/quantity`,
+      {
+        startDate: dateFrom.toISOString(),
+        emailFilterBy: emailFilter,
+      },
+    );
+    return response.data.visitors_quantity;
   }
 
   public async getPagesRankingByPeriod({
@@ -117,7 +102,12 @@ export class HttpDatahubClient implements DatahubClient {
     domainName: number;
     dateFrom: Date;
   }): Promise<{ name: string; totalVisits: number }[]> {
-    console.log('getPagesRankingByPeriod', { domainName, dateFrom });
-    return fakePagesData.map((x) => ({ name: x.name, totalVisits: x.totalVisits }));
+    const response = await this.customerGet<{ items: { page: string; count: number }[] }>(
+      `domains/${domainName}/events/summarized-by-page`,
+      {
+        startDate: dateFrom.toISOString(),
+      },
+    );
+    return response.data.items.map((x) => ({ name: x.page, totalVisits: x.count }));
   }
 }

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -2,15 +2,26 @@ import { AxiosInstance, AxiosStatic } from 'axios';
 import { RefObject } from 'react';
 import { DatahubConnectionData } from './app-session';
 
-interface DomainEntry {
+export interface DomainEntry {
   id: number;
   name: string;
   verified_date: Date;
 }
 
+export type emailFilterOptions = 'with_email' | 'without_email' | null;
+
 export interface DatahubClient {
   // See: https://github.com/MakingSense/Customer-Data-Hub/blob/0f28f0906b22198622f71867e1cdaf00abd41af1/apisec/swaggerDef.js#L74
   getAccountDomains(): Promise<DomainEntry[]>;
+  getVisitsByPeriod(query: {
+    domainName: number;
+    dateFrom: Date;
+    emailFilter: emailFilterOptions;
+  }): Promise<number>;
+  getPagesRankingByPeriod(query: {
+    domainName: number;
+    dateFrom: Date;
+  }): Promise<{ name: string; totalVisits: number }[]>;
 }
 
 const fakeData = [
@@ -31,6 +42,29 @@ const fakeData = [
     name: 'www.google.com',
     verified_date: new Date('2017-12-17'),
     pages: [],
+  },
+];
+
+const fakePagesData = [
+  {
+    name: 'https://www.fromdoppler.com/email-marketing',
+    totalVisits: 10122,
+  },
+  {
+    name: 'https://www.fromdoppler.com/precios',
+    totalVisits: 9000,
+  },
+  {
+    name: 'https://www.fromdoppler.com/login',
+    totalVisits: 5001,
+  },
+  {
+    name: 'https://www.fromdoppler.com/productos',
+    totalVisits: 3800,
+  },
+  {
+    name: 'https://www.fromdoppler.com/servicios',
+    totalVisits: 1023,
   },
 ];
 
@@ -60,5 +94,30 @@ export class HttpDatahubClient implements DatahubClient {
   public async getAccountDomains(): Promise<DomainEntry[]> {
     console.log('getAccountDomains');
     return fakeData.map((x) => ({ id: x.id, name: x.name, verified_date: x.verified_date }));
+  }
+
+  public async getVisitsByPeriod({
+    domainName,
+    dateFrom,
+    emailFilter,
+  }: {
+    domainName: number;
+    dateFrom: Date;
+    emailFilter: emailFilterOptions;
+  }): Promise<number> {
+    console.log('getVisitsByPeriod', { domainName, dateFrom, emailFilter });
+    const visits = Math.round(Math.random() * (100 - 1) + 1);
+    return visits;
+  }
+
+  public async getPagesRankingByPeriod({
+    domainName,
+    dateFrom,
+  }: {
+    domainName: number;
+    dateFrom: Date;
+  }): Promise<{ name: string; totalVisits: number }[]> {
+    console.log('getPagesRankingByPeriod', { domainName, dateFrom });
+    return fakePagesData.map((x) => ({ name: x.name, totalVisits: x.totalVisits }));
   }
 }

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -1,3 +1,7 @@
+import { AxiosInstance, AxiosStatic } from 'axios';
+import { RefObject } from 'react';
+import { DatahubConnectionData } from './app-session';
+
 interface PageEntry {
   id: number;
   name: string;
@@ -16,13 +20,84 @@ export interface DatahubClient {
   getPagesByDomainId(domainId: number): Promise<PageEntry[]>;
 }
 
-export class HttpDatahubClient {
-  // TODO: implement this class
-  public async getAccountDomains() {
-    throw new Error('Not implemented');
+const fakeData = [
+  {
+    id: 1,
+    name: 'www.fromdoppler.com',
+    verified_date: new Date('2017-12-17'),
+    pages: [],
+  },
+  {
+    id: 2,
+    name: 'www.makingsense.com',
+    verified_date: new Date('2010-12-17'),
+    pages: [],
+  },
+  {
+    id: 3,
+    name: 'www.google.com',
+    verified_date: new Date('2017-12-17'),
+    pages: [],
+  },
+];
+
+const fakePagesData = [
+  {
+    name: 'https://www.fromdoppler.com/email-marketing',
+    totalVisits: 10122,
+  },
+  {
+    name: 'https://www.fromdoppler.com/precios',
+    totalVisits: 9000,
+  },
+  {
+    name: 'https://www.fromdoppler.com/login',
+    totalVisits: 5001,
+  },
+  {
+    name: 'https://www.fromdoppler.com/productos',
+    totalVisits: 3800,
+  },
+  {
+    name: 'https://www.fromdoppler.com/servicios',
+    totalVisits: 1023,
+  },
+];
+
+export class HttpDatahubClient implements DatahubClient {
+  private readonly axios: AxiosInstance;
+  private readonly baseUrl: string;
+  private readonly connectionDataRef: RefObject<DatahubConnectionData>;
+
+  constructor({
+    axiosStatic,
+    baseUrl,
+    connectionDataRef,
+  }: {
+    axiosStatic: AxiosStatic;
+    baseUrl: string;
+    connectionDataRef: RefObject<DatahubConnectionData>;
+  }) {
+    this.baseUrl = baseUrl;
+    this.axios = axiosStatic.create({
+      baseURL: baseUrl,
+      withCredentials: true,
+    });
+    this.connectionDataRef = connectionDataRef;
   }
 
-  getPagesByDomainId(domainId: number) {
-    throw new Error('Not implemented');
+  // TODO: implement this class
+  public async getAccountDomains(): Promise<DomainEntry[]> {
+    console.log('getAccountDomains');
+    return fakeData.map((x) => ({ id: x.id, name: x.name, verified_date: x.verified_date }));
+  }
+
+  public async getPagesByDomainId(domainId: number): Promise<PageEntry[]> {
+    console.log('getPagesByDomainId', { domainId });
+    const domain = fakeData.find((x) => x.id === domainId);
+    if (!domain) {
+      throw new Error(`Domain with id ${domainId} does not exist`);
+    }
+    return domain.pages;
   }
 }

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -12,7 +12,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
   public async getUserData() {
     console.log('getUserData');
     await timeout(1500);
-    const { user, nav, alert } = mapHeaderDataJson(headerDataJson);
+    const { user, nav, alert, datahubCustomerId, jwtToken } = mapHeaderDataJson(headerDataJson);
 
     return {
       user: {
@@ -21,6 +21,8 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
       },
       nav: nav,
       alert,
+      datahubCustomerId,
+      jwtToken,
     };
   }
 

--- a/src/services/doppler-legacy-client.test.js
+++ b/src/services/doppler-legacy-client.test.js
@@ -68,7 +68,10 @@ describe('Doppler legacy client', () => {
 
   it('should throw error, when receives an error from doppler', async () => {
     // Arrange
-    const sut = new HttpDopplerLegacyClient(axios, 'http://localhost:52191');
+    const sut = new HttpDopplerLegacyClient({
+      axiosStatic: axios,
+      baseUrl: 'http://localhost:52191',
+    });
     axios.get.mockImplementation(() => ({
       data: {
         success: false,
@@ -84,7 +87,10 @@ describe('Doppler legacy client', () => {
 
   it('should throw error, when response is empty', async () => {
     // Arrange
-    const sut = new HttpDopplerLegacyClient(axios, 'http://localhost:52191');
+    const sut = new HttpDopplerLegacyClient({
+      axiosStatic: axios,
+      baseUrl: 'http://localhost:52191',
+    });
     axios.get.mockImplementation(() => {});
     // Act
     const action = async () => {
@@ -96,7 +102,10 @@ describe('Doppler legacy client', () => {
 
   it('should return data, when logged into doppler and there are no errors', async () => {
     // Arrange
-    const sut = new HttpDopplerLegacyClient(axios, 'http://localhost:52191');
+    const sut = new HttpDopplerLegacyClient({
+      axiosStatic: axios,
+      baseUrl: 'http://localhost:52191',
+    });
     axios.get.mockImplementation(() => userData);
     // Act
     const action = await sut.getUserData();

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -136,7 +136,7 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
   private readonly axios: AxiosInstance;
   private readonly baseUrl: string;
 
-  constructor(axiosStatic: AxiosStatic, baseUrl: string) {
+  constructor({ axiosStatic, baseUrl }: { axiosStatic: AxiosStatic; baseUrl: string }) {
     this.baseUrl = baseUrl;
     this.axios = axiosStatic.create({
       baseURL: baseUrl,

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -61,6 +61,8 @@ export interface DopplerLegacyUserData {
   alert: AlertEntry | undefined;
   nav: MainNavEntry[];
   user: UserEntry;
+  jwtToken: string;
+  datahubCustomerId: string | null;
 }
 /* #endregion */
 
@@ -116,6 +118,8 @@ export function mapHeaderDataJson(json: any) {
       nav: (json.user.nav && json.user.nav.map(mapNavEntry)) || [],
       plan: mapPlanEntry(json.user.plan),
     },
+    jwtToken: json.jwtToken,
+    datahubCustomerId: json.datahubCustomerId || null,
   };
 }
 /* #endregion */

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -60,7 +60,7 @@ export class AppCompositionRoot implements AppServices {
 
   get appConfiguration() {
     return this.singleton('appConfiguration', () => ({
-      dopplerLegacyUrl: process.env.REACT_APP_API_URL as string,
+      dopplerLegacyUrl: process.env.REACT_APP_DOPPLER_LEGACY_URL as string,
       dopplerLegacyKeepAliveMilliseconds: parseInt(process.env
         .REACT_APP_DOPPLER_LEGACY_KEEP_ALIVE_MS as string),
     }));

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -73,7 +73,11 @@ export class AppCompositionRoot implements AppServices {
   get dopplerLegacyClient() {
     return this.singleton(
       'dopplerLegacyClient',
-      () => new HttpDopplerLegacyClient(this.axiosStatic, this.appConfiguration.dopplerLegacyUrl),
+      () =>
+        new HttpDopplerLegacyClient({
+          axiosStatic: this.axiosStatic,
+          baseUrl: this.appConfiguration.dopplerLegacyUrl,
+        }),
     );
   }
 
@@ -81,12 +85,12 @@ export class AppCompositionRoot implements AppServices {
     return this.singleton(
       'sessionManager',
       () =>
-        new OnlineSessionManager(
+        new OnlineSessionManager({
           // Casting because only he will be allowed to update session
-          this.appSessionRef as MutableRefObject<AppSession>,
-          this.dopplerLegacyClient,
-          this.appConfiguration.dopplerLegacyKeepAliveMilliseconds,
-        ),
+          appSessionRef: this.appSessionRef as MutableRefObject<AppSession>,
+          dopplerLegacyClient: this.dopplerLegacyClient,
+          keepAliveMilliseconds: this.appConfiguration.dopplerLegacyKeepAliveMilliseconds,
+        }),
     );
   }
 

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -54,13 +54,14 @@ export class OnlineSessionManager implements SessionManager {
   private async update() {
     try {
       const dopplerUserData = await this.dopplerLegacyClient.getUserData();
-      // TODO: deal with JWT Token
-      this.updateSession({
-        status: 'authenticated',
-        userData: dopplerUserData,
-        datahubCustomerId: 'NOT IMPLEMENTED',
-        jwtToken: 'NOT IMPLEMENTED',
-      });
+      this.updateSession(
+        {
+          status: 'authenticated',
+          userData: dopplerUserData,
+          datahubCustomerId: dopplerUserData.datahubCustomerId,
+          jwtToken: dopplerUserData.jwtToken,
+        } as AppSession, // Cast required because TS cannot resolve datahubCustomerId complexity
+      );
     } catch (error) {
       this.updateSession({ status: 'non-authenticated' });
     }

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -1,36 +1,23 @@
 import { DopplerLegacyClient, DopplerLegacyUserData } from './doppler-legacy-client';
-
-type AppSession =
-  | { status: 'unknown' }
-  | { status: 'non-authenticated' }
-  | {
-      status: 'authenticated';
-      userData: DopplerLegacyUserData;
-    };
+import { AppSession } from './app-session';
+import { MutableRefObject } from 'react';
 
 const noop = () => {};
 
-const defaultSession: AppSession = { status: 'unknown' };
-
 export interface SessionManager {
-  session: AppSession;
   initialize: (handler: (s: AppSession) => void) => void;
   finalize: () => void;
 }
 
 export class OnlineSessionManager implements SessionManager {
-  private currentSession: AppSession = { ...defaultSession };
   private handler: (s: AppSession) => void = noop;
   private dopplerInterval: number | null = null;
 
   constructor(
+    private appSessionRef: MutableRefObject<AppSession>,
     private dopplerLegacyClient: DopplerLegacyClient,
     private keepAliveMilliseconds: number,
   ) {}
-
-  public get session() {
-    return this.currentSession;
-  }
 
   public initialize(handler: (s: AppSession) => void) {
     this.handler = handler;
@@ -48,8 +35,8 @@ export class OnlineSessionManager implements SessionManager {
   }
 
   private updateSession(session: AppSession) {
-    this.currentSession = session;
-    this.handler(this.currentSession);
+    this.appSessionRef.current = session;
+    this.handler(session);
   }
 
   private async update() {

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -10,14 +10,26 @@ export interface SessionManager {
 }
 
 export class OnlineSessionManager implements SessionManager {
+  private readonly appSessionRef: MutableRefObject<AppSession>;
+  private readonly dopplerLegacyClient: DopplerLegacyClient;
+  private readonly keepAliveMilliseconds: number;
+
   private handler: (s: AppSession) => void = noop;
   private dopplerInterval: number | null = null;
 
-  constructor(
-    private appSessionRef: MutableRefObject<AppSession>,
-    private dopplerLegacyClient: DopplerLegacyClient,
-    private keepAliveMilliseconds: number,
-  ) {}
+  constructor({
+    appSessionRef,
+    dopplerLegacyClient,
+    keepAliveMilliseconds,
+  }: {
+    appSessionRef: MutableRefObject<AppSession>;
+    dopplerLegacyClient: DopplerLegacyClient;
+    keepAliveMilliseconds: number;
+  }) {
+    this.appSessionRef = appSessionRef;
+    this.dopplerLegacyClient = dopplerLegacyClient;
+    this.keepAliveMilliseconds = keepAliveMilliseconds;
+  }
 
   public initialize(handler: (s: AppSession) => void) {
     this.handler = handler;

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -58,6 +58,8 @@ export class OnlineSessionManager implements SessionManager {
       this.updateSession({
         status: 'authenticated',
         userData: dopplerUserData,
+        datahubCustomerId: 'NOT IMPLEMENTED',
+        jwtToken: 'NOT IMPLEMENTED',
       });
     } catch (error) {
       this.updateSession({ status: 'non-authenticated' });


### PR DESCRIPTION
Hi team, 

This is again a big PR, I am really sorry.

I have refactoring a little some Reports' components to make them more friendly with the actual backend.

I have also moved AppSession outside of SessionManager to allow inject it in DatahubClient, refactored it to describe sessions with Datahub information and sessions without it, and improved _PrivateRoute_ to take this account.

There are some loose ends:

* What should we do when someone open Reports page and he does not have Datahub information?
* Deal with not verified domains (null verification date)
* Failure when domain list is empty

Could you kindly review it? (I encourage review it commit by commit)