### PR TITLE
Unify submit buttons behavior

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { timeout } from '../../utils';
 import { Formik, Form } from 'formik';
-import { EmailFieldItem, FieldGroup } from '../form-helpers/form-helpers';
+import { EmailFieldItem, FieldGroup, SubmitButton } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 
 const fieldNames = {
@@ -57,9 +57,7 @@ const ForgotPassword = ({ intl }) => {
               </FieldGroup>
             </fieldset>
             <fieldset>
-              <button type="submit" className="dp-button button--round button-medium primary-green">
-                {_('login.button_login')}
-              </button>
+              <SubmitButton>{_('login.button_login')}</SubmitButton>
               <Link to="/login" className="forgot-link">
                 <span className="triangle-right" />
                 {_('forgot_password.back_login')}

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -3,7 +3,12 @@ import { Link, Redirect } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { timeout } from '../../utils';
 import { Formik, Form } from 'formik';
-import { EmailFieldItem, FieldGroup, PasswordFieldItem } from '../form-helpers/form-helpers';
+import {
+  EmailFieldItem,
+  FieldGroup,
+  PasswordFieldItem,
+  SubmitButton,
+} from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 
 const fieldNames = {
@@ -77,9 +82,7 @@ const Login = ({ intl, location }) => {
               </FieldGroup>
             </fieldset>
             <fieldset>
-              <button type="submit" className="dp-button button--round button-medium primary-green">
-                {_('login.button_login')}
-              </button>
+              <SubmitButton>{_('login.button_login')}</SubmitButton>
               <Link to="/forgot-password" className="forgot-link">
                 {_('login.forgot_password')}
               </Link>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -10,6 +10,7 @@ import {
   CheckboxFieldItem,
   ValidatedPasswordFieldItem,
   PhoneFieldItem,
+  SubmitButton,
 } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 
@@ -110,9 +111,7 @@ export default injectIntl(function({ intl }) {
                   label={_('signup.promotions_consent')}
                 />
               </FieldGroup>
-              <button type="submit" className="dp-button button--round button-medium primary-green">
-                {_('signup.button_signup')}
-              </button>
+              <SubmitButton>{_('signup.button_signup')}</SubmitButton>
             </fieldset>
           </Form>
         </Formik>

--- a/src/components/UpgradePlanForm/UpgradePlanForm.js
+++ b/src/components/UpgradePlanForm/UpgradePlanForm.js
@@ -3,6 +3,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { Formik, Form, Field, ErrorMessage } from 'formik';
 import { InjectAppServices } from '../../services/pure-di';
 import Loading from '../../components/Loading/Loading';
+import { SubmitButton } from '../form-helpers/form-helpers';
 
 const fieldNames = {
   selectedPlanId: 'selectedPlanId',
@@ -126,16 +127,9 @@ class UpgradePlanForm extends React.Component {
                   <button className="dp-button button-medium primary-grey" onClick={handleClose}>
                     <FormattedMessage id="common.cancel" />
                   </button>
-                  <button
-                    type="submit"
-                    className={
-                      'dp-button button-medium primary-green' +
-                      ((isSubmitting && ' button--loading') || '')
-                    }
-                    disabled={isSubmitting}
-                  >
+                  <SubmitButton>
                     <FormattedMessage id="common.send" />
-                  </button>
+                  </SubmitButton>
                 </fieldset>
               </Form>
             )}

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -341,3 +341,23 @@ export const CheckboxFieldItem = ({ className, fieldName, label, checkRequired, 
     <label htmlFor={fieldName}> {label}</label>
   </FieldItem>
 );
+
+/**
+ * Submit Button Component
+ * @param { Object } props
+ * @param { import('formik').FormikProps<Values> } props.formik
+ * @param { string } props.className
+ */
+const _SubmitButton = ({ children, formik: { isSubmitting } }) => (
+  <button
+    type="submit"
+    disabled={isSubmitting}
+    className={
+      'dp-button button-medium primary-green' + ((isSubmitting && ' button--loading') || '')
+    }
+  >
+    {children}
+  </button>
+);
+
+export const SubmitButton = connect(_SubmitButton);


### PR DESCRIPTION
Hi team, 

I forgot to apply the defined submit button behavior in Signup page and then the same happened with the rest of public pages.

These changes apply the same style with a spinner in Signup, Login and Forgot Password pages, but more important: disable the button in order to avoid multiple submits.

Could you review?