### PR TITLE
Add signup methods to Doppler Legacy Client and signup confirmation page

### DIFF
--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { timeout } from '../../utils';
 import { Formik, Form } from 'formik';
+import { InjectAppServices } from '../../services/pure-di';
 import {
   EmailFieldItem,
   FieldGroup,
@@ -33,7 +34,7 @@ const getFormInitialValues = () =>
     {},
   );
 
-const Signup = function({ intl }) {
+const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
   const onSubmit = async (values, { setSubmitting }) => {
@@ -145,4 +146,4 @@ const Signup = function({ intl }) {
   );
 };
 
-export default injectIntl(Signup);
+export default InjectAppServices(injectIntl(Signup));

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -33,7 +33,7 @@ const getFormInitialValues = () =>
     {},
   );
 
-export default injectIntl(function({ intl }) {
+const Signup = function({ intl }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
   const onSubmit = async (values, { setSubmitting }) => {
@@ -143,4 +143,6 @@ export default injectIntl(function({ intl }) {
       </section>
     </main>
   );
-});
+};
+
+export default injectIntl(Signup);

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -34,6 +34,12 @@ const getFormInitialValues = () =>
     {},
   );
 
+/**
+ * Signup Page
+ * @param { Object } props
+ * @param { import('react-intl').InjectedIntl } props.intl
+ * @param { import('../../services/pure-di').AppServices } props.dependencies
+ */
 const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { Formik, Form } from 'formik';
@@ -13,6 +13,7 @@ import {
   SubmitButton,
 } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
+import SignupConfirmation from './SignupConfirmation';
 
 const fieldNames = {
   firstname: 'firstname',
@@ -42,9 +43,20 @@ const getFormInitialValues = () =>
 const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
+  const [registeredUser, setRegisteredUser] = useState(null);
+
+  if (registeredUser) {
+    const resend = () => dopplerLegacyClient.resendRegistrationEmail(registeredUser);
+    return <SignupConfirmation resend={resend} />;
+  }
+
   const onSubmit = async (values, { setSubmitting }) => {
     try {
       await dopplerLegacyClient.registerUser(values);
+      // TODO: deal with returned errors, we can get, for example:
+      // setErrors({email: "Already exists an account with that name."});
+      // If there are no errors:
+      setRegisteredUser(values[fieldNames.email]);
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
-import { timeout } from '../../utils';
 import { Formik, Form } from 'formik';
 import { InjectAppServices } from '../../services/pure-di';
 import {
@@ -44,9 +43,13 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
   const onSubmit = async (values, { setSubmitting }) => {
-    // TODO: implement it
-    await timeout(1500);
-    setSubmitting(false);
+    try {
+      await dopplerLegacyClient.registerUser(values);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (

--- a/src/components/Signup/SignupConfirmation.js
+++ b/src/components/Signup/SignupConfirmation.js
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { injectIntl } from 'react-intl';
 
 /**
  * Signup Confirmation Page
  * @param { Object } props
  * @param { import('react-intl').InjectedIntl } props.intl
+ * @param { Function } props.resend - Function to resend registration email.
  */
-const SignupConfirmation = function({ intl }) {
+const SignupConfirmation = function({ resend, intl }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const [resentTimes, setResentTimes] = useState(0);
+  const incrementAndResend = function() {
+    setResentTimes((times) => times + 1);
+    resend();
+  };
   return (
     <main className="confirmation-wrapper">
       <header className="confirmation-header">
@@ -22,6 +28,18 @@ const SignupConfirmation = function({ intl }) {
           </span>
           <p className="text-italic">{_('signup.activate_account_instructions')}</p>
         </article>
+        {resentTimes === 0 ? (
+          <p>
+            {_('signup.email_not_received')}{' '}
+            <button className="link-green" onClick={incrementAndResend}>
+              {_('signup.resend_email')}
+            </button>
+            .
+          </p>
+        ) : (
+          // TODO: review content
+          <p>{_('signup.no_more_resend')}</p>
+        )}
         <div className="background bg-c" />
       </main>
       <footer className="confirmation-footer">

--- a/src/components/Signup/SignupConfirmation.js
+++ b/src/components/Signup/SignupConfirmation.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { injectIntl } from 'react-intl';
+
+/**
+ * Signup Confirmation Page
+ * @param { Object } props
+ * @param { import('react-intl').InjectedIntl } props.intl
+ */
+const SignupConfirmation = function({ intl }) {
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  return (
+    <main className="confirmation-wrapper">
+      <header className="confirmation-header">
+        <h1 className="logo-doppler-new">Doppler</h1>
+      </header>
+      <main className="confirmation-main">
+        <article className="confirmation-article">
+          <h2>{_('signup.thanks_for_registering')}</h2>
+          <p>{_('signup.check_inbox')}</p>
+          <span className="icon-registration m-bottom--lv6">
+            {_('signup.check_inbox_icon_description')}
+          </span>
+          <p className="text-italic">{_('signup.activate_account_instructions')}</p>
+        </article>
+        <div className="background bg-c" />
+      </main>
+      <footer className="confirmation-footer">
+        <p>{_('signup.copyright', { year: 2019 })}</p>
+        <div className="background bg-b" />
+      </footer>
+    </main>
+  );
+};
+
+export default injectIntl(SignupConfirmation);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -70,6 +70,7 @@
     "check_inbox_icon_description": "Check your inbox",
     "copyright": "© {year} Doppler LLC. All rights reserved.",
     "do_you_already_have_an_account": "Already have an account?",
+    "email_not_received": "Haven't you received the Email?",
     "label_email": "Email: ",
     "label_firstname": "Name: ",
     "label_lastname": "Lastname: ",
@@ -77,6 +78,7 @@
     "label_phone": "Phone: ",
     "legal_HTML": "\n<p>Doppler te informa que los datos de carácter personal que nos proporciones al rellenar el presente formulario serán tratados por Making Sense LLC (Doppler) como responsable de esta web.</p>\n<p><strong>Finalidad:</strong> Darte de alta en nuestra plataforma y brindarte los servicios que nos requieras.</p>\n<p><strong>Legitimación:</strong> Consentimiento del interesado.</p>\n<p><strong>Destinatarios:</strong> Tus datos serán guardados por Doppler, Zoho como CRM, Digital Ocean, Cogeco Peer1 y Rackspace como empresas de hosting.</p>\n<p><strong>Información adicional:</strong> En la <a class=\"link-green\" href=\"https://www.fromdoppler.com/en/legal/privacy-policy\">Privacy Policy</a> de Doppler encontrarás información adicional sobre la recopilación y el uso de su información personal por parte de Doppler, incluida información sobre acceso, conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y otros temas.</p>",
     "log_in": "Log In",
+    "no_more_resend": "You haven't received the Email yet? We have already forwarded it to you, if it doesn't arrive in the next few minutes, please contact support",
     "placeholder_email": "Your Email will be your Username",
     "placeholder_firstname": "Name",
     "placeholder_lastname": "Lastname",
@@ -86,6 +88,7 @@
     "promotion_code_help_url": "https://help.fromdoppler.com/en/how-to-activate-my-promo-code",
     "promotion_code_reminder": "Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.",
     "promotions_consent": "Sign me up for promotions about Doppler and its partners.",
+    "resend_email": "Resent it",
     "sign_up": "Sign Up",
     "sign_up_sub": "No contracts or credit cards required, up to 500 Subscribers.",
     "thanks_for_registering": "Thank you for registering"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -64,8 +64,11 @@
   },
   "reports_title": "Doppler | Reports",
   "signup": {
+    "activate_account_instructions": "* By clicking on the button from the Email, you will activate your account and you will be ready to enjoy all the benefits of Doppler.",
     "button_signup": "Sign Up",
-    "copyright": "© {year} Doppler LLC. Todos los derechos reservados.",
+    "check_inbox": "Check your inbox. You have an email!",
+    "check_inbox_icon_description": "Check your inbox",
+    "copyright": "© {year} Doppler LLC. All rights reserved.",
     "do_you_already_have_an_account": "Already have an account?",
     "label_email": "Email: ",
     "label_firstname": "Name: ",
@@ -84,7 +87,8 @@
     "promotion_code_reminder": "Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.",
     "promotions_consent": "Sign me up for promotions about Doppler and its partners.",
     "sign_up": "Sign Up",
-    "sign_up_sub": "No contracts or credit cards required, up to 500 Subscribers."
+    "sign_up_sub": "No contracts or credit cards required, up to 500 Subscribers.",
+    "thanks_for_registering": "Thank you for registering"
   },
   "upgradePlanForm": {
     "message_placeholder": "Your mensaje",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -70,6 +70,7 @@
     "check_inbox_icon_description": "Fíjate en tu correo electrónico",
     "copyright": "© {year} Doppler LLC. Todos los derechos reservados.",
     "do_you_already_have_an_account": "¿Ya tienes una cuenta?",
+    "email_not_received": "¿No has recibido el Email?",
     "label_email": "Email: ",
     "label_firstname": "Nombre: ",
     "label_lastname": "Apellido: ",
@@ -77,6 +78,7 @@
     "label_phone": "Teléfono: ",
     "legal_HTML": "\n<p>Doppler te informa que los datos de carácter personal que nos proporciones al rellenar el presente formulario serán tratados por Making Sense LLC (Doppler) como responsable de esta web.</p>\n<p><strong>Finalidad:</strong> Darte de alta en nuestra plataforma y brindarte los servicios que nos requieras.</p>\n<p><strong>Legitimación:</strong> Consentimiento del interesado.</p>\n<p><strong>Destinatarios:</strong> Tus datos serán guardados por Doppler, Zoho como CRM, Digital Ocean, Cogeco Peer1 y Rackspace como empresas de hosting.</p>\n<p><strong>Información adicional:</strong> En la <a class=\"link-green\" href=\"https://www.fromdoppler.com/legales/privacidad\">Política de Privacidad</a> de Doppler encontrarás información adicional sobre la recopilación y el uso de su información personal por parte de Doppler, incluida información sobre acceso, conservación, rectificación, eliminación, seguridad, transferencias transfronterizas y otros temas.</p>",
     "log_in": "Ingresa",
+    "no_more_resend": "¿Aún no has recibido el Email? Ya te lo hemos reenviado, si no llega en los próximos minutos, por favor contáctate con soporte",
     "placeholder_email": "Tu Email será tu nombre de usuario",
     "placeholder_firstname": "Nombre",
     "placeholder_lastname": "Apellido",
@@ -86,6 +88,7 @@
     "promotion_code_help_url": "https://help.fromdoppler.com/es/como-activo-mi-descuento-en-doppler/",
     "promotion_code_reminder": "Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.",
     "promotions_consent": "Acepto recibir las promociones de Doppler y sus aliados.",
+    "resend_email": "Reenvíalo",
     "sign_up": "Regístrate",
     "sign_up_sub": "Crea una cuenta GRATIS hasta 500 Suscriptores.",
     "thanks_for_registering": "Gracias por registrarte"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -64,7 +64,10 @@
   },
   "reports_title": "Doppler | Reportes",
   "signup": {
+    "activate_account_instructions": "* Al hacer click en el botón que aparece en el Email, activarás tu cuenta y estarás listo para disfrutar todos los beneficios de Doppler.",
     "button_signup": "Crear cuenta",
+    "check_inbox": "Revisa tu casilla. ¡Tienes un Email!",
+    "check_inbox_icon_description": "Fíjate en tu correo electrónico",
     "copyright": "© {year} Doppler LLC. Todos los derechos reservados.",
     "do_you_already_have_an_account": "¿Ya tienes una cuenta?",
     "label_email": "Email: ",
@@ -84,7 +87,8 @@
     "promotion_code_reminder": "Pst! si tienes un código promocional podrás ingresarlo al confirmar tu cuenta.",
     "promotions_consent": "Acepto recibir las promociones de Doppler y sus aliados.",
     "sign_up": "Regístrate",
-    "sign_up_sub": "Crea una cuenta GRATIS hasta 500 Suscriptores."
+    "sign_up_sub": "Crea una cuenta GRATIS hasta 500 Suscriptores.",
+    "thanks_for_registering": "Gracias por registrarte"
   },
   "upgradePlanForm": {
     "message_placeholder": "Tu mensaje",

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -2,12 +2,18 @@ import {
   DopplerLegacyClient,
   mapHeaderDataJson,
   DopplerLegacyUpgradePlanContactModel,
+  UserRegistrationModel,
 } from './doppler-legacy-client';
 import headerDataJson from '../headerData.json';
 import { timeout } from '../utils';
 
 export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
   public constructor(public readonly email = 'hardcoded@email.com') {}
+
+  public async registerUser(model: UserRegistrationModel) {
+    console.log(this.registerUser, model);
+    await timeout(1500);
+  }
 
   public async getUserData() {
     console.log('getUserData');

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -15,6 +15,11 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
     await timeout(1500);
   }
 
+  public async resendRegistrationEmail(email: string) {
+    console.log(this.resendRegistrationEmail, email);
+    await timeout(1500);
+  }
+
   public async getUserData() {
     console.log('getUserData');
     await timeout(1500);

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -5,7 +5,30 @@ export interface DopplerLegacyClient {
   getUserData(): Promise<DopplerLegacyUserData>;
   getUpgradePlanData(isSubscriberPlan: boolean): Promise<DopplerLegacyClientTypePlan[]>;
   sendEmailUpgradePlan(planModel: DopplerLegacyUpgradePlanContactModel): Promise<void>;
+  registerUser(userRegistrationModel: UserRegistrationModel): Promise<void>;
 }
+
+/* #region Registration data types */
+export interface UserRegistrationModel {
+  firstname: string;
+  lastname: string;
+  phone: string;
+  email: string;
+  password: string;
+  accept_privacy_policies: boolean;
+  accept_promotions: boolean;
+  /*
+  // TODO: take into account the following data
+    ClientTimeZoneOffset=-180
+    FingerPrint=317203850
+    origin=login
+    Language=en
+    showCaptcha=False
+    IdCountry=10
+*/
+}
+
+/* #endregion */
 
 /* #region DopplerLegacyUserData data types */
 interface NavEntry {
@@ -158,6 +181,18 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
     }
 
     return mapHeaderDataJson(response.data);
+  }
+
+  public async registerUser(model: UserRegistrationModel) {
+    const response = await this.axios.post(`WebAppPublic/CreateUser`, {
+      Name: model.firstname,
+      LastName: model.lastname,
+      Phone: model.phone,
+      Email: model.email,
+      NewPassword: model.password,
+      TermsAndConditionsActive: model.accept_privacy_policies,
+      PromotionsEnabled: model.accept_promotions,
+    });
   }
 
   public async getUpgradePlanData(isSubscriberPlan: boolean) {

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -6,6 +6,7 @@ export interface DopplerLegacyClient {
   getUpgradePlanData(isSubscriberPlan: boolean): Promise<DopplerLegacyClientTypePlan[]>;
   sendEmailUpgradePlan(planModel: DopplerLegacyUpgradePlanContactModel): Promise<void>;
   registerUser(userRegistrationModel: UserRegistrationModel): Promise<void>;
+  resendRegistrationEmail(email: string): Promise<void>;
 }
 
 /* #region Registration data types */
@@ -193,6 +194,11 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
       TermsAndConditionsActive: model.accept_privacy_policies,
       PromotionsEnabled: model.accept_promotions,
     });
+    // TODO: parse validation errors in response
+  }
+
+  public async resendRegistrationEmail(email: string) {
+    await this.axios.post(`WebAppPublic/ResendRegistrationEmail`, { Email: email });
   }
 
   public async getUpgradePlanData(isSubscriberPlan: boolean) {


### PR DESCRIPTION
Hi team,

I am adding the methods `registerUser` and `resendRegistrationEmail` to Doppler Legacy Client and also show the confirmation page after server response.

I decided to limit the resendings to only one time. If someone is clear about the desired behavior, please let me know and I can change it in this same PR; if not, we can improve it later.

Could you review it?