### PR TITLE
Accept register user results

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build204/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build208/css/styles.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -44,6 +44,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build204/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build208/js/app.js"></script>
   </body>
 </html>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -170,8 +170,8 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
                   label={_('signup.promotions_consent')}
                 />
               </FieldGroup>
-              <SubmitButton>{_('signup.button_signup')}</SubmitButton>
             </fieldset>
+            <SubmitButton>{_('signup.button_signup')}</SubmitButton>
           </Form>
         </Formik>
         <div className="content-legal">

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -44,17 +44,36 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
   const [registeredUser, setRegisteredUser] = useState(null);
+  const [alreadyExistentAddresses, setAlreadyExistentAddresses] = useState([]);
+
+  const addExistentEmailAddress = (email) => {
+    setAlreadyExistentAddresses((x) => [...x, email]);
+  };
 
   if (registeredUser) {
     const resend = () => dopplerLegacyClient.resendRegistrationEmail(registeredUser);
     return <SignupConfirmation resend={resend} />;
   }
 
+  const validate = (values) => {
+    const errors = {};
+
+    const email = values[fieldNames.email];
+    if (email && alreadyExistentAddresses.includes(email)) {
+      errors[fieldNames.email] = 'validation_messages.error_email_already_exists';
+    }
+
+    return errors;
+  };
+
   const onSubmit = async (values, { setSubmitting, setErrors, validateForm }) => {
     try {
       const result = await dopplerLegacyClient.registerUser(values);
       if (result.success) {
         setRegisteredUser(values[fieldNames.email]);
+      } else if (!result.unexpectedError && result.emailAlreadyExists) {
+        addExistentEmailAddress(values[fieldNames.email]);
+        validateForm();
       } else {
         console.log('Unexpected error', result);
         setErrors({ _general: 'validation_messages.error_unexpected' });
@@ -79,7 +98,7 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
             {_('signup.log_in')}
           </Link>
         </p>
-        <Formik initialValues={getFormInitialValues()} onSubmit={onSubmit}>
+        <Formik initialValues={getFormInitialValues()} onSubmit={onSubmit} validate={validate}>
           <Form className="signup-form">
             <fieldset>
               <FieldGroup>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -50,13 +50,14 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
     return <SignupConfirmation resend={resend} />;
   }
 
-  const onSubmit = async (values, { setSubmitting }) => {
+  const onSubmit = async (values, { setSubmitting, setErrors, validateForm }) => {
     try {
       const result = await dopplerLegacyClient.registerUser(values);
       if (result.success) {
         setRegisteredUser(values[fieldNames.email]);
       } else {
         console.log('Unexpected error', result);
+        setErrors({ _general: 'validation_messages.error_unexpected' });
       }
     } finally {
       setSubmitting(false);

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -52,13 +52,12 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient } }) {
 
   const onSubmit = async (values, { setSubmitting }) => {
     try {
-      await dopplerLegacyClient.registerUser(values);
-      // TODO: deal with returned errors, we can get, for example:
-      // setErrors({email: "Already exists an account with that name."});
-      // If there are no errors:
-      setRegisteredUser(values[fieldNames.email]);
-    } catch (e) {
-      console.error(e);
+      const result = await dopplerLegacyClient.registerUser(values);
+      if (result.success) {
+        setRegisteredUser(values[fieldNames.email]);
+      } else {
+        console.log('Unexpected error', result);
+      }
     } finally {
       setSubmitting(false);
     }

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -353,19 +353,31 @@ export const CheckboxFieldItem = ({ className, fieldName, label, checkRequired, 
 /**
  * Submit Button Component
  * @param { Object } props
+ * @param { import('react-intl').InjectedIntl } props.intl
  * @param { import('formik').FormikProps<Values> } props.formik
  * @param { string } props.className
  */
-const _SubmitButton = ({ children, formik: { isSubmitting } }) => (
-  <button
-    type="submit"
-    disabled={isSubmitting}
-    className={
-      'dp-button button-medium primary-green' + ((isSubmitting && ' button--loading') || '')
-    }
-  >
-    {children}
-  </button>
-);
+const _SubmitButton = ({ children, intl, formik: { isSubmitting, errors } }) => {
+  return (
+    <>
+      {errors && errors['_general'] ? (
+        <div className="error">
+          <div className="wrapper-errors">
+            <p className="error-message">{intl.formatMessage({ id: errors['_general'] })}</p>
+          </div>
+        </div>
+      ) : null}
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className={
+          'dp-button button-medium primary-green' + ((isSubmitting && ' button--loading') || '')
+        }
+      >
+        {children}
+      </button>
+    </>
+  );
+};
 
-export const SubmitButton = connect(_SubmitButton);
+export const SubmitButton = injectIntl(connect(_SubmitButton));

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -361,10 +361,8 @@ const _SubmitButton = ({ children, intl, formik: { isSubmitting, errors } }) => 
   return (
     <>
       {errors && errors['_general'] ? (
-        <div className="error">
-          <div className="wrapper-errors">
-            <p className="error-message">{intl.formatMessage({ id: errors['_general'] })}</p>
-          </div>
+        <div className="unexpected-message">
+          <span>{intl.formatMessage({ id: errors['_general'] })}</span>
         </div>
       ) : null}
       <button

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -101,6 +101,7 @@
     "title": "Solicita una actualización de tu plan"
   },
   "validation_messages": {
+    "error_email_already_exists": "Ouch! You already have a Doppler account.",
     "error_invalid_email_address": "Ouch! Invalid email address",
     "error_password_character_length": "At least 8 characters",
     "error_password_digit": "One number",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -110,6 +110,7 @@
     "error_phone_invalid_country": "Ouch! The country code is not valid",
     "error_phone_too_long": "Ouch! The phone number is too long",
     "error_phone_too_short": "Ouch! The phone number is too short",
-    "error_required_field": "Ouch! The field is empty."
+    "error_required_field": "Ouch! The field is empty.",
+    "error_unexpected": "Unexpected error. Please try again or contact support."
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -102,6 +102,7 @@
   },
   "validation_messages": {
     "error_email_already_exists": "Ouch! You already have a Doppler account.",
+    "error_invalid_domain_to_register_account": "Ouch! Invalid Email to create an account.",
     "error_invalid_email_address": "Ouch! Invalid email address",
     "error_password_character_length": "At least 8 characters",
     "error_password_digit": "One number",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -102,6 +102,7 @@
   },
   "validation_messages": {
     "error_email_already_exists": "¡Ouch! Ya posees una cuenta en Doppler.",
+    "error_invalid_domain_to_register_account": "¡Ouch! Email inválido para crear una cuenta.",
     "error_invalid_email_address": "¡Ouch! El formato del email es incorrecto",
     "error_password_character_length": "8 caracteres como mínimo",
     "error_password_digit": "Un número",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -101,6 +101,7 @@
     "title": "Solicita una actualización de tu plan"
   },
   "validation_messages": {
+    "error_email_already_exists": "¡Ouch! Ya posees una cuenta en Doppler.",
     "error_invalid_email_address": "¡Ouch! El formato del email es incorrecto",
     "error_password_character_length": "8 caracteres como mínimo",
     "error_password_digit": "Un número",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -110,6 +110,7 @@
     "error_phone_invalid_country": "¡Ouch! El código de país no es válido",
     "error_phone_too_long": "¡Ouch! El número de teléfono es demasiado largo",
     "error_phone_too_short": "¡Ouch! El número de teléfono es demasiado corto",
-    "error_required_field": "¡Ouch! El campo está vacío."
+    "error_required_field": "¡Ouch! El campo está vacío.",
+    "error_unexpected": "Error inesperado. Por favor, intenta nuevamente o contacta a soporte."
   }
 }

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -3,6 +3,7 @@ import {
   mapHeaderDataJson,
   DopplerLegacyUpgradePlanContactModel,
   UserRegistrationModel,
+  UserRegistrationResult,
 } from './doppler-legacy-client';
 import headerDataJson from '../headerData.json';
 import { timeout } from '../utils';
@@ -10,9 +11,10 @@ import { timeout } from '../utils';
 export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
   public constructor(public readonly email = 'hardcoded@email.com') {}
 
-  public async registerUser(model: UserRegistrationModel) {
+  public async registerUser(model: UserRegistrationModel): Promise<UserRegistrationResult> {
     console.log(this.registerUser, model);
     await timeout(1500);
+    return { success: true };
   }
 
   public async resendRegistrationEmail(email: string) {

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -201,7 +201,7 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
         PromotionsEnabled: model.accept_promotions,
       });
 
-      if (!response.data.success && response.data.emailAlreadyExists) {
+      if (!response.data.success && response.data.error == 'EmailAlreadyExists') {
         return { success: false, unexpectedError: false, emailAlreadyExists: true };
       }
 

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -11,7 +11,8 @@ export interface DopplerLegacyClient {
 
 export type UserRegistrationResult =
   | { success: true }
-  | { success: false; unexpectedError?: false; emailAlreadyExists: true }
+  | { success: false; unexpectedError?: false; emailAlreadyExists: true; blockedDomain?: false }
+  | { success: false; unexpectedError?: false; emailAlreadyExists?: false; blockedDomain: true }
   | { success: false; unexpectedError: true; message: string | null; error?: any };
 
 /* #region Registration data types */
@@ -203,6 +204,10 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
 
       if (!response.data.success && response.data.error == 'EmailAlreadyExists') {
         return { success: false, unexpectedError: false, emailAlreadyExists: true };
+      }
+
+      if (!response.data.success && response.data.error == 'BlockedDomain') {
+        return { success: false, unexpectedError: false, blockedDomain: true };
       }
 
       if (!response.data.success) {

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -5,9 +5,14 @@ export interface DopplerLegacyClient {
   getUserData(): Promise<DopplerLegacyUserData>;
   getUpgradePlanData(isSubscriberPlan: boolean): Promise<DopplerLegacyClientTypePlan[]>;
   sendEmailUpgradePlan(planModel: DopplerLegacyUpgradePlanContactModel): Promise<void>;
-  registerUser(userRegistrationModel: UserRegistrationModel): Promise<void>;
+  registerUser(userRegistrationModel: UserRegistrationModel): Promise<UserRegistrationResult>;
   resendRegistrationEmail(email: string): Promise<void>;
 }
+
+export type UserRegistrationResult =
+  | { success: true }
+  | { success: false; unexpectedError?: false; emailAlreadyExists: true }
+  | { success: false; unexpectedError: true; message: string | null; error?: any };
 
 /* #region Registration data types */
 export interface UserRegistrationModel {
@@ -184,17 +189,39 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
     return mapHeaderDataJson(response.data);
   }
 
-  public async registerUser(model: UserRegistrationModel) {
-    const response = await this.axios.post(`WebAppPublic/CreateUser`, {
-      Name: model.firstname,
-      LastName: model.lastname,
-      Phone: model.phone,
-      Email: model.email,
-      NewPassword: model.password,
-      TermsAndConditionsActive: model.accept_privacy_policies,
-      PromotionsEnabled: model.accept_promotions,
-    });
-    // TODO: parse validation errors in response
+  public async registerUser(model: UserRegistrationModel): Promise<UserRegistrationResult> {
+    try {
+      const response = await this.axios.post(`WebAppPublic/CreateUser`, {
+        Name: model.firstname,
+        LastName: model.lastname,
+        Phone: model.phone,
+        Email: model.email,
+        NewPassword: model.password,
+        TermsAndConditionsActive: model.accept_privacy_policies,
+        PromotionsEnabled: model.accept_promotions,
+      });
+
+      if (!response.data.success && response.data.emailAlreadyExists) {
+        return { success: false, unexpectedError: false, emailAlreadyExists: true };
+      }
+
+      if (!response.data.success) {
+        return {
+          success: false,
+          unexpectedError: true,
+          message: response.data.error || null,
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        unexpectedError: true,
+        message: error.message || null,
+        error: error,
+      };
+    }
   }
 
   public async resendRegistrationEmail(email: string) {


### PR DESCRIPTION
Hi team, 

I applied these changes to deal with register user errors, by the moment we accept two kinds of errors:

* Email already exists
* Unexpected errors

Could you review it?

Here you have some examples of how it works:

Duplicated email address (cached):

![2019-04-16_19-01-15 (1)](https://user-images.githubusercontent.com/1157864/56247603-b8d93f80-607b-11e9-9c33-96413cc18fc8.gif)

Unexpected error:

![2019-04-16_18-58-04](https://user-images.githubusercontent.com/1157864/56247610-becf2080-607b-11e9-918f-419555e3ca43.png)

Fixes: DBR-174, DBR-186