### PR TITLE
feat: deal with unexpected errors in Forgot Password

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -22,10 +22,19 @@ const getFormInitialValues = () =>
 const ForgotPassword = ({ intl }) => {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
-  const onSubmit = async (values, { setSubmitting }) => {
-    // TODO: implement login submit
-    await timeout(1500);
-    setSubmitting(false);
+  const onSubmit = async (values, { setSubmitting, setErrors }) => {
+    try {
+      // TODO: implement forgot password submit
+      const result = await timeout(1500);
+      if (result && result.success) {
+        // TODO: show OK message
+      } else {
+        console.log('Unexpected error', result);
+        setErrors({ _general: 'validation_messages.error_unexpected' });
+      }
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (


### PR DESCRIPTION
It simply shows an unexpected error message in Forgot Password when the result (of nothing by the moment) is not successful.

![2019-04-18_11-00-24 (1)](https://user-images.githubusercontent.com/1157864/56366372-5d1ccc80-61c9-11e9-894e-3fccfbee72c7.gif)
