### PR TITLE
DBR-169 - Redirect to default Doppler page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { InjectAppServices } from './services/pure-di';
 import Loading from './components/Loading/Loading';
 import queryString from 'query-string';
 import { OriginCatcher } from './services/origin-management';
+import RedirectToLegacyUrl from './components/RedirectToLegacyUrl';
 
 class App extends Component {
   /**
@@ -82,7 +83,9 @@ class App extends Component {
             <Loading page />
           ) : (
             <Switch>
-              <Route path="/" exact component={() => <Redirect to={{ pathname: '/reports' }} />} />
+              <Route path="/" exact>
+                <RedirectToLegacyUrl to="/Campaigns/Draft" />
+              </Route>
               <PrivateRoute
                 path="/reports/"
                 exact

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -93,7 +93,7 @@ describe('App component', () => {
 
       const { getByText } = render(
         <AppServicesProvider forcedServices={dependencies}>
-          <Router>
+          <Router initialEntries={['/reports']}>
             <App locale="en" />
           </Router>
         </AppServicesProvider>,
@@ -173,7 +173,7 @@ describe('App component', () => {
 
       const { getByText } = render(
         <AppServicesProvider forcedServices={dependencies}>
-          <Router>
+          <Router initialEntries={['/reports']}>
             <App locale="en" />
           </Router>
         </AppServicesProvider>,
@@ -222,7 +222,7 @@ describe('App component', () => {
 
         const { getByText } = render(
           <AppServicesProvider forcedServices={dependencies}>
-            <Router>
+            <Router initialEntries={['/reports']}>
               <App locale="en" />
             </Router>
           </AppServicesProvider>,

--- a/src/components/PublicRouteWithLegacyFallback.js
+++ b/src/components/PublicRouteWithLegacyFallback.js
@@ -5,6 +5,7 @@ import { injectIntl } from 'react-intl';
 import Login from './Login/Login';
 import Signup from './Signup/Signup';
 import ForgotPassword from './ForgotPassword/ForgotPassword';
+import RedirectToExternalUrl from './RedirectToExternalUrl';
 
 const pagesByPath = {
   '/login': {
@@ -107,9 +108,7 @@ function PublicRouteWithLegacyFallback({
           `${dopplerLegacyUrl}${redirectionData.page}` +
           (parametersString && '?' + parametersString);
 
-        location.href = destinationUrl;
-
-        return <></>;
+        return <RedirectToExternalUrl to={destinationUrl} />;
       }}
     />
   );

--- a/src/components/RedirectToExternalUrl.js
+++ b/src/components/RedirectToExternalUrl.js
@@ -1,0 +1,21 @@
+import React, { useLayoutEffect } from 'react';
+import { InjectAppServices } from '../services/pure-di';
+
+/**
+ * @param { Object } props
+ * @param { string } props.to
+ * @param { import('../services/pure-di').AppServices } props.dependencies
+ */
+function RedirectToExternalUrl({
+  to,
+  dependencies: {
+    window: { location },
+  },
+}) {
+  useLayoutEffect(() => {
+    location.href = to;
+  }, [to]);
+  return <></>;
+}
+
+export default InjectAppServices(RedirectToExternalUrl);

--- a/src/components/RedirectToLegacyUrl.js
+++ b/src/components/RedirectToLegacyUrl.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { InjectAppServices } from '../services/pure-di';
+import RedirectToExternalUrl from './RedirectToExternalUrl';
+
+/**
+ * @param { Object } props
+ * @param { string } props.to
+ * @param { import('../services/pure-di').AppServices } props.dependencies
+ */
+function RedirectToLegacyUrl({ to, dependencies }) {
+  return <RedirectToExternalUrl to={dependencies.appConfiguration.dopplerLegacyUrl + to} />;
+}
+
+export default InjectAppServices(RedirectToLegacyUrl);


### PR DESCRIPTION
When root page is open, or after login without redirect indication, the webapp will redirect to default Legacy Doppler page.

To achieve it, I created a couple of components that will be useful also in future features.

Could you review?