### PR TITLE
Avoid loading on unknown session status in public pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,6 @@ import PrivateRoute from './components/PrivateRoute';
 import PublicRouteWithLegacyFallback from './components/PublicRouteWithLegacyFallback';
 import Reports from './components/Reports/Reports';
 import { InjectAppServices } from './services/pure-di';
-import Loading from './components/Loading/Loading';
 import queryString from 'query-string';
 import { OriginCatcher } from './services/origin-management';
 import RedirectToLegacyUrl from './components/RedirectToLegacyUrl';
@@ -79,28 +78,24 @@ class App extends Component {
       <DopplerIntlProvider locale={i18nLocale}>
         <>
           <OriginCatcher />
-          {dopplerSession.status === 'unknown' ? (
-            <Loading page />
-          ) : (
-            <Switch>
-              <Route path="/" exact>
-                <RedirectToLegacyUrl to="/Campaigns/Draft" />
-              </Route>
-              <PrivateRoute
-                path="/reports/"
-                exact
-                requireDatahub
-                component={Reports}
-                dopplerSession={dopplerSession}
-              />
-              <PublicRouteWithLegacyFallback exact path="/login" />
-              <PublicRouteWithLegacyFallback exact path="/signup" />
-              <PublicRouteWithLegacyFallback exact path="/forgot-password" />
-              {/* TODO: Implement NotFound page in place of redirect all to reports */}
-              {/* <Route component={NotFound} /> */}
-              <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />
-            </Switch>
-          )}
+          <Switch>
+            <Route path="/" exact>
+              <RedirectToLegacyUrl to="/Campaigns/Draft" />
+            </Route>
+            <PrivateRoute
+              path="/reports/"
+              exact
+              requireDatahub
+              component={Reports}
+              dopplerSession={dopplerSession}
+            />
+            <PublicRouteWithLegacyFallback exact path="/login" />
+            <PublicRouteWithLegacyFallback exact path="/signup" />
+            <PublicRouteWithLegacyFallback exact path="/forgot-password" />
+            {/* TODO: Implement NotFound page in place of redirect all to reports */}
+            {/* <Route component={NotFound} /> */}
+            <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />
+          </Switch>
         </>
       </DopplerIntlProvider>
     );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -56,7 +56,7 @@ describe('App component', () => {
       // Act
       const { getByText } = render(
         <AppServicesProvider forcedServices={dependencies}>
-          <Router>
+          <Router initialEntries={['/reports']}>
             <App locale="en" />
           </Router>
         </AppServicesProvider>,
@@ -75,7 +75,7 @@ describe('App component', () => {
       // Act
       const { getByText } = render(
         <AppServicesProvider forcedServices={dependencies}>
-          <Router>
+          <Router initialEntries={['/reports']}>
             <App locale="es" />
           </Router>
         </AppServicesProvider>,
@@ -300,8 +300,20 @@ describe('App component', () => {
           </AppServicesProvider>,
         );
 
-        expect(currentRouteState.location.pathname).toEqual('/login');
-        getByText('Loading...');
+        {
+          expect(currentRouteState.location.pathname).toEqual('/login');
+          expect(currentRouteState.location.state).toBeUndefined();
+          expect(currentRouteState.history.length).toEqual(1);
+          expect(currentRouteState.history.action).not.toEqual('REPLACE');
+          const headerEl = container.querySelector('.header-main');
+          expect(headerEl).toBeNull();
+          const menuEl = container.querySelector('.menu-main');
+          expect(menuEl).toBeNull();
+          const footerEl = container.querySelector('.footer-main');
+          expect(footerEl).toBeNull();
+          const passwordEl = container.querySelector('#password');
+          expect(passwordEl).toBeInstanceOf(HTMLInputElement);
+        }
 
         // Act
         dependencies.sessionManager.updateAppSession({
@@ -319,6 +331,8 @@ describe('App component', () => {
         expect(menuEl).toBeNull();
         const footerEl = container.querySelector('.footer-main');
         expect(footerEl).toBeNull();
+        const passwordEl = container.querySelector('#password');
+        expect(passwordEl).toBeInstanceOf(HTMLInputElement);
       });
 
       it('should be redirected to /login when route does not exists', () => {
@@ -337,7 +351,8 @@ describe('App component', () => {
           </AppServicesProvider>,
         );
 
-        expect(currentRouteState.location.pathname).toEqual('/this/route/does/not/exist');
+        expect(currentRouteState.location.pathname).toEqual('/reports');
+        expect(currentRouteState.location.state).toBeUndefined();
         getByText('Loading...');
 
         // Act
@@ -362,7 +377,7 @@ describe('App component', () => {
     });
 
     describe('authenticated user', () => {
-      it('should not be redirected after open /reports', () => {
+      it('should be redirected to /reports when route does not exists', () => {
         const dependencies = {
           sessionManager: createDoubleSessionManager(),
         };
@@ -378,9 +393,9 @@ describe('App component', () => {
           </AppServicesProvider>,
         );
 
-        expect(currentRouteState.location.pathname).toEqual('/this/route/does/not/exist');
-        expect(currentRouteState.location.search).toEqual('?param1=value1');
-        expect(currentRouteState.location.hash).toEqual('#hash');
+        expect(currentRouteState.location.pathname).toEqual('/reports');
+        expect(currentRouteState.location.search).toEqual('');
+        expect(currentRouteState.location.hash).toEqual('');
         getByText('Loading...');
 
         // Act
@@ -398,9 +413,6 @@ describe('App component', () => {
         });
 
         // Assert
-        expect(currentRouteState.location.pathname).toEqual('/reports');
-        expect(currentRouteState.location.search).toEqual('');
-        expect(currentRouteState.location.hash).toEqual('');
         expect(currentRouteState.location.state).toBeUndefined();
         expect(currentRouteState.history.length).toEqual(1);
         expect(currentRouteState.history.action).toEqual('REPLACE');
@@ -412,7 +424,7 @@ describe('App component', () => {
         expect(footerEl).not.toBeNull();
       });
 
-      it('should be redirected to /reports when route does not exists', () => {
+      it('should keep /reports path when the authenticated state is verified', () => {
         const dependencies = {
           sessionManager: createDoubleSessionManager(),
         };

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -4,6 +4,7 @@ import Header from './Header/Header';
 import Footer from './Footer/Footer';
 import DatahubRequired from './DatahubRequired/DatahubRequired';
 import RedirectToLogin from './RedirectToLogin';
+import Loading from './Loading/Loading';
 
 /**
  * @param { Object } props
@@ -16,7 +17,9 @@ function PrivateRoute({ component: Component, requireDatahub, dopplerSession, ..
     <Route
       {...rest}
       render={(props) =>
-        dopplerSession.status === 'authenticated' ? (
+        dopplerSession.status === 'unknown' ? (
+          <Loading page />
+        ) : dopplerSession.status === 'authenticated' ? (
           <>
             <Header userData={dopplerSession.userData} />
             {!requireDatahub || dopplerSession.datahubCustomerId ? (


### PR DESCRIPTION
As you know, we are polling Legacy Doppler backend to refresh session status.

We are also doing it in public pages, maybe we could avoid it, but it is not so expensive. By the moment, I decided to continue polling in public pages, but, in order to show it quickly, do not show the loading element when session status is unknown.

Caveat: suppose that your browser is configured in English, you have an open session in Spanish and you open Login page. The first rendering will be in English, and after server response with logged-in user data, it will be translated to Spanish. In my opinion, it is not so bad.

Could you review?