### PR TITLE
DBR-187 - Redirect 'ingresa' and 'registrate' URLs to canonical ones

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { InjectAppServices } from './services/pure-di';
 import queryString from 'query-string';
 import { OriginCatcher } from './services/origin-management';
 import RedirectToLegacyUrl from './components/RedirectToLegacyUrl';
+import RedirectWithQuery from './components/RedirectWithQuery';
 
 class App extends Component {
   /**
@@ -92,6 +93,8 @@ class App extends Component {
             <PublicRouteWithLegacyFallback exact path="/login" />
             <PublicRouteWithLegacyFallback exact path="/signup" />
             <PublicRouteWithLegacyFallback exact path="/forgot-password" />
+            <RedirectWithQuery exact from="/ingresa" to="/login?lang=es" />
+            <RedirectWithQuery exact from="/registrate" to="/signup?lang=es" />
             {/* TODO: Implement NotFound page in place of redirect all to reports */}
             {/* <Route component={NotFound} /> */}
             <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />

--- a/src/components/RedirectWithQuery.js
+++ b/src/components/RedirectWithQuery.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+
+function parse(path) {
+  const parsed = /^([^?]*)(\?(.+))?$/.exec(path);
+  const pathname = parsed[1];
+  const search = parsed[3];
+  return { pathname, search };
+}
+
+const RedirectWithQuery = ({ exact, from, to }) => (
+  <Route
+    exact={exact}
+    path={from}
+    component={({ location: { search } }) => {
+      const parsedTo = parse(to);
+      const parsedCurrent = parse(search);
+      const newSearch =
+        parsedTo.search && parsedCurrent.search
+          ? '?' + parsedTo.search + '&' + parsedCurrent.search
+          : parsedTo.search
+          ? '?' + parsedTo.search
+          : parsedCurrent.search
+          ? '?' + parsedCurrent.search
+          : '';
+      return (
+        <Redirect
+          to={{
+            pathname: parsedTo.pathname,
+            search: newSearch,
+          }}
+        />
+      );
+    }}
+  />
+);
+
+export default RedirectWithQuery;


### PR DESCRIPTION
Hi Team,

We need to redirect:

* `https://app.fromdoppler.com/#/registrate` to `https://app.fromdoppler.com/#/signup?lang=es`
* `https://app.fromdoppler.com/#/ingresa` to `https://app.fromdoppler.com/#/login?lang=es`

We are also including the rest of the parametes, and now we have a new component to RedirectWithQueryString.

Could you review?