### PR TITLE
fix: normalize recaptcha legals in all public pages

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -3,7 +3,13 @@ import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { timeout } from '../../utils';
 import { Formik, Form } from 'formik';
-import { EmailFieldItem, FieldGroup, SubmitButton, FormErrors } from '../form-helpers/form-helpers';
+import {
+  EmailFieldItem,
+  FieldGroup,
+  SubmitButton,
+  FormErrors,
+  CaptchaLegalMessage,
+} from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 
 const fieldNames = {
@@ -76,9 +82,7 @@ const ForgotPassword = ({ intl }) => {
           </Form>
         </Formik>
         <footer>
-          <p>
-            <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
-          </p>
+          <CaptchaLegalMessage />
           <p>
             <FormattedHTMLMessage
               tagName="small"

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -76,11 +76,16 @@ const ForgotPassword = ({ intl }) => {
           </Form>
         </Formik>
         <footer>
-          <FormattedHTMLMessage
-            tagName="small"
-            id="signup.copyright_HTML"
-            values={{ year: new Date().getFullYear() }}
-          />
+          <p>
+            <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
+          </p>
+          <p>
+            <FormattedHTMLMessage
+              tagName="small"
+              id="common.copyright_HTML"
+              values={{ year: new Date().getFullYear() }}
+            />
+          </p>
         </footer>
       </article>
       <section className="feature-panel bg--forgot">

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -9,6 +9,7 @@ import {
   SubmitButton,
   FormWithCaptcha,
   FormErrors,
+  CaptchaLegalMessage,
 } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import RedirectToLegacyUrl from '../RedirectToLegacyUrl';
@@ -129,9 +130,7 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
           </fieldset>
         </FormWithCaptcha>
         <footer>
-          <p>
-            <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
-          </p>
+          <CaptchaLegalMessage />
           <p>
             <FormattedHTMLMessage
               tagName="small"

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -129,11 +129,16 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
           </fieldset>
         </FormWithCaptcha>
         <footer>
-          <FormattedHTMLMessage
-            tagName="small"
-            id="signup.copyright_HTML"
-            values={{ year: new Date().getFullYear() }}
-          />
+          <p>
+            <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
+          </p>
+          <p>
+            <FormattedHTMLMessage
+              tagName="small"
+              id="common.copyright_HTML"
+              values={{ year: new Date().getFullYear() }}
+            />
+          </p>
         </footer>
       </article>
       <section className="feature-panel bg--login">

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -195,14 +195,18 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
         </FormWithCaptcha>
         <div className="content-legal">
           <FormattedHTMLMessage id="signup.legal_HTML" />
-          <FormattedHTMLMessage id="signup.recaptcha_legal_HTML" />
         </div>
         <footer>
-          <FormattedHTMLMessage
-            tagName="small"
-            id="signup.copyright_HTML"
-            values={{ year: new Date().getFullYear() }}
-          />
+          <p>
+            <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
+          </p>
+          <p>
+            <FormattedHTMLMessage
+              tagName="small"
+              id="common.copyright_HTML"
+              values={{ year: new Date().getFullYear() }}
+            />
+          </p>
         </footer>
       </article>
       <section className="feature-panel bg--signup">

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -13,6 +13,7 @@ import {
   PhoneFieldItem,
   SubmitButton,
   FormErrors,
+  CaptchaLegalMessage,
 } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import SignupConfirmation from './SignupConfirmation';
@@ -197,9 +198,7 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
           <FormattedHTMLMessage id="signup.legal_HTML" />
         </div>
         <footer>
-          <p>
-            <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
-          </p>
+          <CaptchaLegalMessage />
           <p>
             <FormattedHTMLMessage
               tagName="small"

--- a/src/components/Signup/SignupConfirmation.js
+++ b/src/components/Signup/SignupConfirmation.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { useCaptcha } from '../form-helpers/captcha-utils';
+import { CaptchaLegalMessage } from '../form-helpers/form-helpers';
 
 /**
  * Signup Confirmation Page
@@ -53,9 +54,7 @@ const SignupConfirmation = function({ resend, intl }) {
         )}
       </main>
       <footer className="confirmation-footer">
-        <p>
-          <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
-        </p>
+        <CaptchaLegalMessage />
         <p>
           <FormattedHTMLMessage
             tagName="small"

--- a/src/components/Signup/SignupConfirmation.js
+++ b/src/components/Signup/SignupConfirmation.js
@@ -53,11 +53,16 @@ const SignupConfirmation = function({ resend, intl }) {
         )}
       </main>
       <footer className="confirmation-footer">
-        <FormattedHTMLMessage
-          tagName="small"
-          id="signup.copyright_HTML"
-          values={{ year: new Date().getFullYear() }}
-        />
+        <p>
+          <FormattedHTMLMessage tagName="small" id="common.recaptcha_legal_HTML" />
+        </p>
+        <p>
+          <FormattedHTMLMessage
+            tagName="small"
+            id="common.copyright_HTML"
+            values={{ year: new Date().getFullYear() }}
+          />
+        </p>
       </footer>
       <div className="background bg-b" />
     </main>

--- a/src/components/form-helpers/form-helpers.css
+++ b/src/components/form-helpers/form-helpers.css
@@ -9,3 +9,9 @@
   font-size: 14px;
   width: 414px;
 }
+
+.captcha-legal-message {
+  font-size: 12px;
+  line-height: 16px;
+  font-family: proxima-nova, Helvetica;
+}

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -95,7 +95,7 @@ export const FormWithCaptcha = ({
         formikProps,
       );
     } else {
-      console.log('Capcha error', result);
+      console.log('Captcha error', result);
       formikProps.setErrors({ _general: 'validation_messages.error_unexpected' });
       formikProps.setSubmitting(false);
     }

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { connect, Field, Formik, Form } from 'formik';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage, injectIntl, FormattedHTMLMessage } from 'react-intl';
 import {
   validateEmail,
   validateCheckRequired,
@@ -56,6 +56,12 @@ function createRequiredValidation(requiredProp) {
 
   return (value) => validateRequiredField(value, requiredProp);
 }
+
+export const CaptchaLegalMessage = () => (
+  <p className="captcha-legal-message">
+    <FormattedHTMLMessage id="common.recaptcha_legal_HTML" />
+  </p>
+);
 
 /**
  * Form With Captcha Component

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,9 +1,11 @@
 {
   "common": {
     "cancel": "Cancel",
+    "copyright_HTML": "© {year} Doppler LLC. All rights reserved. <a target=\"_blank\" href=\"https://www.fromdoppler.com/en/legal/privacy-policy\">Privacy and Legal Policy.</a>",
     "help": "Help",
     "hide": "Hide",
     "message": "Message",
+    "recaptcha_legal_HTML": "This site is protected by reCAPTCHA and the Google <a href=\"https://policies.google.com/privacy?hl=en\">Privacy Policy</a> and <a href=\"https://policies.google.com/terms?hl=en\">Terms of Service</a> apply.",
     "send": "Send",
     "show": "Show"
   },
@@ -82,7 +84,6 @@
     "button_signup": "create your free account",
     "check_inbox": "Check your inbox. You have an email!",
     "check_inbox_icon_description": "Check your inbox",
-    "copyright_HTML": "© {year} Doppler LLC. All rights reserved. <a target=\"_blank\" href=\"https://www.fromdoppler.com/en/legal/privacy-policy\">Privacy and Legal Policy.</a>",
     "do_you_already_have_an_account": "Already have an account?",
     "email_not_received": "Haven't you received the Email?",
     "head_description": "Attract, engage and convert clients using the Email Marketing Automation power. Try out Doppler!",
@@ -102,7 +103,6 @@
     "placeholder_phone": "9 11 2345-6789",
     "privacy_policy_consent_HTML": "I accept Doppler's <a target=\"_blank\" href=\"https://www.fromdoppler.com/en/legal/privacy-policy\">Privacy Policy</a>.",
     "promotions_consent": "Sign me up for promotions about Doppler and its partners.",
-    "recaptcha_legal_HTML": "<p>This site is protected by reCAPTCHA and the Google <a href=\"https://policies.google.com/privacy?hl=en\">Privacy Policy</a> and <a href=\"https://policies.google.com/terms?hl=en\">Terms of Service</a> apply.</p>",
     "resend_email": "Resent it",
     "sign_up": "Sign Up",
     "sign_up_sub": "No contracts or credit cards required, up to 500 Subscribers.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,9 +1,11 @@
 ﻿{
   "common": {
     "cancel": "Cancelar",
+    "copyright_HTML": "© {year} Doppler LLC. Todos los derechos reservados. <a target=\"_blank\" href=\"https://www.fromdoppler.com/legales/privacidad\">Política de Privacidad y Legales.</a>",
     "help": "Ayuda",
     "hide": "Ocultar",
     "message": "Mensaje",
+    "recaptcha_legal_HTML": "Este sitio es protegido por reCAPTCHA y aplican la <a href=\"https://policies.google.com/privacy?hl=es\">Política de Privacidad</a> y <a href=\"https://policies.google.com/terms?hl=es\">Condiciones del Servicio</a> de Google.",
     "send": "Enviar",
     "show": "Mostrar"
   },
@@ -82,7 +84,6 @@
     "button_signup": "Crea tu cuenta gratis",
     "check_inbox": "Revisa tu casilla. ¡Tienes un Email!",
     "check_inbox_icon_description": "Fíjate en tu correo electrónico",
-    "copyright_HTML": "© {year} Doppler LLC. Todos los derechos reservados. <a target=\"_blank\" href=\"https://www.fromdoppler.com/legales/privacidad\">Política de Privacidad y Legales.</a>",
     "do_you_already_have_an_account": "¿Ya tienes una cuenta?",
     "email_not_received": "¿No has recibido el Email?",
     "head_description": "Atrae, convierte y fideliza clientes con el poder del Email Marketing Automation. ¡Ingresa a Doppler!",
@@ -102,7 +103,6 @@
     "placeholder_phone": "9 11 2345-6789",
     "privacy_policy_consent_HTML": "Acepto la <a target=\"_blank\" href=\"https://www.fromdoppler.com/legales/privacidad\">Política de Privacidad</a> de Doppler.",
     "promotions_consent": "Acepto recibir las promociones de Doppler y sus aliados.",
-    "recaptcha_legal_HTML": "<p>Este sitio es protegido por reCAPTCHA y aplican la <a href=\"https://policies.google.com/privacy?hl=es\">Política de Privacidad</a> y <a href=\"https://policies.google.com/terms?hl=es\">Condiciones del Servicio</a> de Google.</p>",
     "resend_email": "Reenvíalo",
     "sign_up": "Regístrate",
     "sign_up_sub": "Crea una cuenta GRATIS hasta 500 Suscriptores.",


### PR DESCRIPTION
Hi team, and mainly @carodipietro, @santiagopaolucci and @GusBaamonde,

I added _reCaptcha_ legal messages in all public pages using a consistent style (based on copyright message in the same pages).

Maybe it is not the best option, but it is the best that I could do without changing the current layout and styles.

Please, let me know if there is a relatively simple improvement. If improve it will take time, I am going to merge (because I need adding the legal messages), but feel free to work on that, and let me know later.

I did not touch contents, only moving them from _signup_ section to _common_ section.

Could you kindly review?

![image](https://user-images.githubusercontent.com/1157864/56840899-a079d980-6860-11e9-98d5-280f2d1bacfb.png)

![image](https://user-images.githubusercontent.com/1157864/56840901-a66fba80-6860-11e9-9f24-04175885b17d.png)

![image](https://user-images.githubusercontent.com/1157864/56840904-af608c00-6860-11e9-86c0-233061ad93ac.png)

![image](https://user-images.githubusercontent.com/1157864/56840905-b38ca980-6860-11e9-97a8-375ededd9b90.png)
