### PR TITLE
Error messages refactor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build219/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build224/css/styles.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -44,6 +44,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build219/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build224/js/app.js"></script>
   </body>
 </html>

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -55,7 +55,6 @@ const ForgotPassword = ({ intl }) => {
         </p>
         <Formik initialValues={getFormInitialValues()} onSubmit={onSubmit}>
           <Form className="login-form">
-            <FormErrors />
             <fieldset>
               <FieldGroup>
                 <EmailFieldItem
@@ -67,6 +66,7 @@ const ForgotPassword = ({ intl }) => {
               </FieldGroup>
             </fieldset>
             <fieldset>
+              <FormErrors />
               <SubmitButton>{_('login.button_login')}</SubmitButton>
               <Link to="/login" className="forgot-link">
                 <span className="triangle-right" />

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { timeout } from '../../utils';
 import { Formik, Form } from 'formik';
-import { EmailFieldItem, FieldGroup, SubmitButton } from '../form-helpers/form-helpers';
+import { EmailFieldItem, FieldGroup, SubmitButton, FormErrors } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 
 const fieldNames = {
@@ -55,6 +55,7 @@ const ForgotPassword = ({ intl }) => {
         </p>
         <Formik initialValues={getFormInitialValues()} onSubmit={onSubmit}>
           <Form className="login-form">
+            <FormErrors />
             <fieldset>
               <FieldGroup>
                 <EmailFieldItem

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -104,7 +104,6 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
           initialValues={getFormInitialValues()}
           onSubmit={onSubmit}
         >
-          <FormErrors />
           <fieldset>
             <FieldGroup>
               <EmailFieldItem
@@ -122,6 +121,7 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
             </FieldGroup>
           </fieldset>
           <fieldset>
+            <FormErrors />
             <SubmitButton>{_('login.button_login')}</SubmitButton>
             <Link to="/forgot-password" className="forgot-link">
               {_('login.forgot_password')}

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -8,6 +8,7 @@ import {
   PasswordFieldItem,
   SubmitButton,
   FormWithCaptcha,
+  FormErrors,
 } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import RedirectToLegacyUrl from '../RedirectToLegacyUrl';
@@ -103,6 +104,7 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
           initialValues={getFormInitialValues()}
           onSubmit={onSubmit}
         >
+          <FormErrors />
           <fieldset>
             <FieldGroup>
               <EmailFieldItem

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -12,6 +12,7 @@ import {
   ValidatedPasswordFieldItem,
   PhoneFieldItem,
   SubmitButton,
+  FormErrors,
 } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import SignupConfirmation from './SignupConfirmation';
@@ -136,6 +137,7 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
           onSubmit={onSubmit}
           validate={validate}
         >
+          <FormErrors />
           <fieldset>
             <FieldGroup>
               <InputFieldItem

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -137,7 +137,6 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
           onSubmit={onSubmit}
           validate={validate}
         >
-          <FormErrors />
           <fieldset>
             <FieldGroup>
               <InputFieldItem
@@ -191,6 +190,7 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
               />
             </FieldGroup>
           </fieldset>
+          <FormErrors />
           <SubmitButton>{_('signup.button_signup')}</SubmitButton>
         </FormWithCaptcha>
         <div className="content-legal">

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -128,8 +128,10 @@ export const FormErrors = connect(
    */
   ({ formik: { errors } }) =>
     errors && errors['_general'] ? (
-      <div className="unexpected-message">
-        <ErrorMessage error={errors['_general']} />
+      <div className="form-message error">
+        <div className="wrapper-errors">
+          <ErrorMessage error={errors['_general']} />
+        </div>
       </div>
     ) : null,
 );

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -121,6 +121,19 @@ export const FieldGroup = ({ className, children }) => (
   <ul className={concatClasses('field-group', className)}>{children}</ul>
 );
 
+export const FormErrors = connect(
+  /**
+   * @param { Object } props
+   * @param { import('formik').FormikProps<Values> } props.formik
+   */
+  ({ formik: { errors } }) =>
+    errors && errors['_general'] ? (
+      <div className="unexpected-message">
+        <ErrorMessage error={errors['_general']} />
+      </div>
+    ) : null,
+);
+
 const ErrorMessage = injectIntl(({ intl, error }) =>
   React.isValidElement(error) ? (
     error
@@ -433,14 +446,9 @@ export const CheckboxFieldItem = ({ className, fieldName, label, checkRequired, 
  * @param { import('formik').FormikProps<Values> } props.formik
  * @param { string } props.className
  */
-const _SubmitButton = ({ children, formik: { isSubmitting, errors } }) => {
+const _SubmitButton = ({ children, formik: { isSubmitting } }) => {
   return (
     <>
-      {errors && errors['_general'] ? (
-        <div className="unexpected-message">
-          <ErrorMessage error={errors['_general']} />
-        </div>
-      ) : null}
       <button
         type="submit"
         disabled={isSubmitting}

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -121,19 +121,30 @@ export const FieldGroup = ({ className, children }) => (
   <ul className={concatClasses('field-group', className)}>{children}</ul>
 );
 
-export const FieldItem = injectIntl(
-  connect(({ intl, className, fieldName, children, formik: { errors, touched } }) => (
+const ErrorMessage = injectIntl(({ intl, error }) =>
+  React.isValidElement(error) ? (
+    error
+  ) : (
+    // assuming string
+    // TODO: also consider array of errors, and parameters for localization message placeholders
+    <p className="error-message">{intl.formatMessage({ id: error })}</p>
+  ),
+);
+
+export const FieldItem = connect(
+  ({ className, fieldName, children, formik: { errors, touched } }) => (
     <li
       className={concatClasses(className, touched[fieldName] && errors[fieldName] ? 'error' : '')}
     >
       {children}
-      {touched[fieldName] && errors[fieldName] && typeof errors[fieldName] === 'string' ? (
+      {/* Boolean errors will not have message */}
+      {touched[fieldName] && errors[fieldName] && errors[fieldName] !== true ? (
         <div className="wrapper-errors">
-          <p className="error-message">{intl.formatMessage({ id: errors[fieldName] })}</p>
+          <ErrorMessage error={errors[fieldName]} />
         </div>
       ) : null}
     </li>
-  )),
+  ),
 );
 
 const PasswordWrapper = connect(
@@ -422,12 +433,12 @@ export const CheckboxFieldItem = ({ className, fieldName, label, checkRequired, 
  * @param { import('formik').FormikProps<Values> } props.formik
  * @param { string } props.className
  */
-const _SubmitButton = ({ children, intl, formik: { isSubmitting, errors } }) => {
+const _SubmitButton = ({ children, formik: { isSubmitting, errors } }) => {
   return (
     <>
       {errors && errors['_general'] ? (
         <div className="unexpected-message">
-          <span>{intl.formatMessage({ id: errors['_general'] })}</span>
+          <ErrorMessage error={errors['_general']} />
         </div>
       ) : null}
       <button
@@ -444,4 +455,4 @@ const _SubmitButton = ({ children, intl, formik: { isSubmitting, errors } }) => 
   );
 };
 
-export const SubmitButton = injectIntl(connect(_SubmitButton));
+export const SubmitButton = connect(_SubmitButton);


### PR DESCRIPTION
Hi team (including @santiagopaolucci!)

With the help of @GusBaamonde, I have refactored error messages in order to make them more flexible, see this example:

![image](https://user-images.githubusercontent.com/1157864/56933092-bc79b700-6abc-11e9-92cb-a42542a87216.png)

Now (based on https://github.com/FromDoppler/Doppler-UI-System/pull/94), both _field error messages_ and _general form error messages_ follow the same rules and both accept a resource key or a React component.

Could you take a look?