### PR TITLE
DBR-220 - Site tracking user data

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build236/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build241/css/styles.css">
     <link rel="stylesheet" type="text/css" href="zoho-chat.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -45,7 +45,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build236/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build241/js/app.js"></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -84,7 +84,7 @@ class App extends Component {
             <Route path="/" exact>
               <RedirectToLegacyUrl to="/Campaigns/Draft" />
             </Route>
-            <PrivateRoute path="/reports/" exact requireDatahub component={Reports} />
+            <PrivateRoute path="/reports/" exact requireSiteTracking component={Reports} />
             <PublicRouteWithLegacyFallback exact path="/login" />
             <PublicRouteWithLegacyFallback exact path="/signup" />
             <PublicRouteWithLegacyFallback exact path="/forgot-password" />

--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,7 @@ class App extends Component {
     this.sessionManager = sessionManager;
 
     this.state = {
+      // TODO: consider removing dopplerSession from the state
       dopplerSession: appSessionRef.current,
       i18nLocale: locale,
     };
@@ -73,7 +74,7 @@ class App extends Component {
   }
 
   render() {
-    const { dopplerSession, i18nLocale } = this.state;
+    const { i18nLocale } = this.state;
 
     return (
       <DopplerIntlProvider locale={i18nLocale}>
@@ -83,13 +84,7 @@ class App extends Component {
             <Route path="/" exact>
               <RedirectToLegacyUrl to="/Campaigns/Draft" />
             </Route>
-            <PrivateRoute
-              path="/reports/"
-              exact
-              requireDatahub
-              component={Reports}
-              dopplerSession={dopplerSession}
-            />
+            <PrivateRoute path="/reports/" exact requireDatahub component={Reports} />
             <PublicRouteWithLegacyFallback exact path="/login" />
             <PublicRouteWithLegacyFallback exact path="/signup" />
             <PublicRouteWithLegacyFallback exact path="/forgot-password" />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -5,10 +5,15 @@ import App from './App';
 import { AppServicesProvider } from './services/pure-di';
 import { MemoryRouter as Router, withRouter } from 'react-router-dom';
 
-function createDoubleSessionManager() {
+function createDoubleSessionManager(appSessionRef) {
   const double = {
     initialize: (handler) => {
-      double.updateAppSession = handler;
+      double.updateAppSession = (session) => {
+        if (appSessionRef) {
+          appSessionRef.current = session;
+        }
+        handler(session);
+      };
     },
     finalize: () => {},
     session: {
@@ -87,8 +92,10 @@ describe('App component', () => {
 
     it("should be updated based on user's data", () => {
       // Arrange
+      const appSessionRef = { current: { status: 'unknown' } };
       const dependencies = {
-        sessionManager: createDoubleSessionManager(),
+        appSessionRef: appSessionRef,
+        sessionManager: createDoubleSessionManager(appSessionRef),
       };
 
       const { getByText } = render(
@@ -112,6 +119,12 @@ describe('App component', () => {
             nav: [],
           },
           nav: [],
+          features: {
+            siteTrackingEnabled: false,
+            siteTrackingActive: false,
+            emailParameterEnabled: false,
+            emailParameterActive: false,
+          },
         },
       });
 
@@ -129,6 +142,12 @@ describe('App component', () => {
             nav: [],
           },
           nav: [],
+          features: {
+            siteTrackingEnabled: false,
+            siteTrackingActive: false,
+            emailParameterEnabled: false,
+            emailParameterActive: false,
+          },
         },
       });
 
@@ -153,6 +172,12 @@ describe('App component', () => {
             nav: [],
           },
           nav: [],
+          features: {
+            siteTrackingEnabled: false,
+            siteTrackingActive: false,
+            emailParameterEnabled: false,
+            emailParameterActive: false,
+          },
         },
       });
       dependencies.sessionManager.updateAppSession({ status: 'unknown' });
@@ -167,8 +192,10 @@ describe('App component', () => {
       // Arrange
       const expectedEmail = 'fcoronel@makingsense.com';
 
+      const appSessionRef = { current: { status: 'unknown' } };
       const dependencies = {
-        sessionManager: createDoubleSessionManager(),
+        appSessionRef: appSessionRef,
+        sessionManager: createDoubleSessionManager(appSessionRef),
       };
 
       const { getByText } = render(
@@ -193,6 +220,12 @@ describe('App component', () => {
             lang: 'en',
           },
           nav: [],
+          features: {
+            siteTrackingEnabled: false,
+            siteTrackingActive: false,
+            emailParameterEnabled: false,
+            emailParameterActive: false,
+          },
         },
       });
 
@@ -203,7 +236,9 @@ describe('App component', () => {
 
     describe('not authenticated user', () => {
       it('should be redirected to Legacy Doppler Login after open /reports when useLegacy.login is active', () => {
+        const appSessionRef = { current: { status: 'unknown' } };
         const dependencies = {
+          appSessionRef: appSessionRef,
           appConfiguration: {
             dopplerLegacyUrl: 'http://legacyUrl.localhost',
             useLegacy: { login: true },
@@ -216,7 +251,7 @@ describe('App component', () => {
               href: 'unset',
             },
           },
-          sessionManager: createDoubleSessionManager(),
+          sessionManager: createDoubleSessionManager(appSessionRef),
           localStorage: createLocalStorageDouble(),
         };
 
@@ -242,8 +277,10 @@ describe('App component', () => {
       });
 
       it('should be redirected to Internal Login after open /reports (when using RedirectToInternalLogin)', () => {
+        const appSessionRef = { current: { status: 'unknown' } };
         const dependencies = {
-          sessionManager: createDoubleSessionManager(),
+          appSessionRef: appSessionRef,
+          sessionManager: createDoubleSessionManager(appSessionRef),
         };
 
         const currentRouteState = {};
@@ -336,8 +373,10 @@ describe('App component', () => {
       });
 
       it('should be redirected to /login when route does not exists', () => {
+        const appSessionRef = { current: { status: 'unknown' } };
         const dependencies = {
-          sessionManager: createDoubleSessionManager(),
+          appSessionRef: appSessionRef,
+          sessionManager: createDoubleSessionManager(appSessionRef),
         };
 
         const currentRouteState = {};
@@ -378,8 +417,10 @@ describe('App component', () => {
 
     describe('authenticated user', () => {
       it('should be redirected to /reports when route does not exists', () => {
+        const appSessionRef = { current: { status: 'unknown' } };
         const dependencies = {
-          sessionManager: createDoubleSessionManager(),
+          appSessionRef: appSessionRef,
+          sessionManager: createDoubleSessionManager(appSessionRef),
         };
 
         const currentRouteState = {};
@@ -409,6 +450,12 @@ describe('App component', () => {
               nav: [],
             },
             nav: [],
+            features: {
+              siteTrackingEnabled: false,
+              siteTrackingActive: false,
+              emailParameterEnabled: false,
+              emailParameterActive: false,
+            },
           },
         });
 
@@ -425,8 +472,10 @@ describe('App component', () => {
       });
 
       it('should keep /reports path when the authenticated state is verified', () => {
+        const appSessionRef = { current: { status: 'unknown' } };
         const dependencies = {
-          sessionManager: createDoubleSessionManager(),
+          appSessionRef: appSessionRef,
+          sessionManager: createDoubleSessionManager(appSessionRef),
         };
 
         const currentRouteState = {};
@@ -456,6 +505,12 @@ describe('App component', () => {
               nav: [],
             },
             nav: [],
+            features: {
+              siteTrackingEnabled: false,
+              siteTrackingActive: false,
+              emailParameterEnabled: false,
+              emailParameterActive: false,
+            },
           },
         });
 

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import Header from './Header/Header';
 import Footer from './Footer/Footer';
-import DatahubRequired from './DatahubRequired/DatahubRequired';
+import SiteTrackingRequired from './SiteTrackingRequired/SiteTrackingRequired';
 import RedirectToLogin from './RedirectToLogin';
 import Loading from './Loading/Loading';
 import { InjectAppServices } from '../services/pure-di';
@@ -11,12 +11,12 @@ export default InjectAppServices(
   /**
    * @param { Object } props
    * @param { React.Component } props.component
-   * @param { Boolean } props.requireDatahub
+   * @param { Boolean } props.requireSiteTracking
    * @param { import('../services/pure-di').AppServices } props.dependencies
    */
   ({
     component: Component,
-    requireDatahub,
+    requireSiteTracking,
     dependencies: {
       appSessionRef: { current: dopplerSession },
     },
@@ -30,10 +30,10 @@ export default InjectAppServices(
         ) : dopplerSession.status === 'authenticated' ? (
           <>
             <Header userData={dopplerSession.userData} />
-            {!requireDatahub || dopplerSession.datahubCustomerId ? (
+            {!requireSiteTracking || dopplerSession.datahubCustomerId ? (
               <Component {...props} />
             ) : (
-              <DatahubRequired />
+              <SiteTrackingRequired />
             )}
             <Footer />
           </>

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -5,15 +5,23 @@ import Footer from './Footer/Footer';
 import DatahubRequired from './DatahubRequired/DatahubRequired';
 import RedirectToLogin from './RedirectToLogin';
 import Loading from './Loading/Loading';
+import { InjectAppServices } from '../services/pure-di';
 
-/**
- * @param { Object } props
- * @param { React.Component } props.component
- * @param { Boolean } props.requireDatahub
- * @param { import('../services/app-session').AppSession } props.dopplerSession
- */
-function PrivateRoute({ component: Component, requireDatahub, dopplerSession, ...rest }) {
-  return (
+export default InjectAppServices(
+  /**
+   * @param { Object } props
+   * @param { React.Component } props.component
+   * @param { Boolean } props.requireDatahub
+   * @param { import('../services/pure-di').AppServices } props.dependencies
+   */
+  ({
+    component: Component,
+    requireDatahub,
+    dependencies: {
+      appSessionRef: { current: dopplerSession },
+    },
+    ...rest
+  }) => (
     <Route
       {...rest}
       render={(props) =>
@@ -34,7 +42,5 @@ function PrivateRoute({ component: Component, requireDatahub, dopplerSession, ..
         )
       }
     />
-  );
-}
-
-export default PrivateRoute;
+  ),
+);

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import Header from './Header/Header';
 import Footer from './Footer/Footer';
-import SiteTrackingRequired from './SiteTrackingRequired/SiteTrackingRequired';
+import {
+  SiteTrackingRequired,
+  SiteTrackingNotAvailableReasons,
+} from './SiteTrackingRequired/SiteTrackingRequired';
 import RedirectToLogin from './RedirectToLogin';
 import Loading from './Loading/Loading';
 import { InjectAppServices } from '../services/pure-di';
@@ -30,10 +33,20 @@ export default InjectAppServices(
         ) : dopplerSession.status === 'authenticated' ? (
           <>
             <Header userData={dopplerSession.userData} />
-            {!requireSiteTracking || dopplerSession.datahubCustomerId ? (
-              <Component {...props} />
+            {requireSiteTracking &&
+            !dopplerSession.userData.features.siteTrackingEnabled &&
+            !dopplerSession.userData.user.plan.isFreeAccount ? (
+              <SiteTrackingRequired reason={SiteTrackingNotAvailableReasons.trialNotAccepted} />
+            ) : requireSiteTracking &&
+              !dopplerSession.userData.features.siteTrackingEnabled &&
+              dopplerSession.userData.user.plan.isFreeAccount ? (
+              <SiteTrackingRequired reason={SiteTrackingNotAvailableReasons.freeAccount} />
+            ) : requireSiteTracking && !dopplerSession.userData.datahubCustomerId ? (
+              <SiteTrackingRequired reason={SiteTrackingNotAvailableReasons.noDatahubId} />
+            ) : requireSiteTracking && !dopplerSession.userData.features.siteTrackingActive ? (
+              <SiteTrackingRequired reason={SiteTrackingNotAvailableReasons.featureDisabled} />
             ) : (
-              <SiteTrackingRequired />
+              <Component {...props} />
             )}
             <Footer />
           </>

--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -3,7 +3,11 @@ import ReportsFilters from './ReportsFilters/ReportsFilters';
 import ReportsBox from './ReportsBox/ReportsBox';
 import ReportsPageRanking from './ReportsPageRanking/ReportsPageRanking';
 import { InjectAppServices } from '../../services/pure-di';
-import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
+import {
+  SiteTrackingRequired,
+  SiteTrackingNotAvailableReasons,
+} from '../SiteTrackingRequired/SiteTrackingRequired';
 
 class Reports extends React.Component {
   /**
@@ -52,6 +56,9 @@ class Reports extends React.Component {
   };
 
   render() {
+    if (this.state.domains && !this.state.domainSelected) {
+      return <SiteTrackingRequired reason={SiteTrackingNotAvailableReasons.thereAreNotDomains} />;
+    }
     return (
       <>
         <FormattedMessage id="reports_title">
@@ -70,20 +77,8 @@ class Reports extends React.Component {
           periodSelectedDays={this.state.periodSelectedDays}
           changePeriod={this.changePeriod}
         />
-
         {!this.state.domains ? (
           <div className="loading-box" />
-        ) : !this.state.domainSelected ? (
-          <section className="container-reports">
-            <div className="wrapper-kpi">
-              {/* TODO: review this solution, probably styles, content and behavior are wrong */}
-              <FormattedHTMLMessage
-                className="patch-no-domains"
-                id="reports.no_domains_HTML"
-                values={{ dopplerBaseUrl: this.appConfiguration.dopplerLegacyUrl }}
-              />
-            </div>
-          </section>
         ) : (
           <section className="container-reports">
             <div className="wrapper-kpi">

--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.js
@@ -1,48 +1,59 @@
-@@ -0,0 +1,47 @@
 import React from 'react';
 import { InjectAppServices } from '../../services/pure-di';
 import { FormattedHTMLMessage, FormattedMessage } from 'react-intl';
 
-export default InjectAppServices(
+export const SiteTrackingNotAvailableReasons = {
+  freeAccount: 'freeAccount',
+  trialNotAccepted: 'trialNotAccepted',
+  featureDisabled: 'featureDisabled',
+  thereAreNotDomains: 'thereAreNotDomains',
+  noDatahubId: 'noDatahubId',
+};
+
+export const SiteTrackingRequired = InjectAppServices(
   /**
    * @param { Object } props
    * @param { import('../../services/pure-di').AppServices } props.dependencies
    */
   ({
+    reason,
     dependencies: {
-      appSessionRef,
       appConfiguration: { dopplerLegacyUrl },
     },
-  }) => {
-    const isFreeAccount =
-      appSessionRef.current.userData !== undefined
-        ? appSessionRef.current.userData.user.plan.isFreeAccount
-        : false;
-
-    return (
-      <section className="container-reports">
-        <div className="wrapper-kpi">
-          {isFreeAccount ? (
-            <div>
-              <FormattedMessage tagName="h3" id="reports.upgrade_account_free_title" />
-              <FormattedHTMLMessage
-                tagName="div"
-                id="reports.upgrade_account_free_HTML"
-                values={{ dopplerBaseUrl: dopplerLegacyUrl }}
-              />
-            </div>
-          ) : (
-            <div>
-              <FormattedMessage tagName="h3" id="reports.datahub_not_active_title" />
-              <FormattedHTMLMessage
-                tagName="div"
-                id="reports.datahub_not_active_HTML"
-                values={{ dopplerBaseUrl: dopplerLegacyUrl }}
-              />
-            </div>
-          )}
-        </div>
-      </section>
-    );
-  },
+  }) => (
+    <section className="container-reports">
+      <div className="wrapper-kpi">
+        {reason === SiteTrackingNotAvailableReasons.freeAccount ? (
+          // Free accounts cannot enable trial, they should buy
+          <div>
+            <FormattedMessage tagName="h3" id="reports.upgrade_account_free_title" />
+            <FormattedHTMLMessage
+              tagName="div"
+              id="reports.upgrade_account_free_HTML"
+              values={{ dopplerBaseUrl: dopplerLegacyUrl }}
+            />
+          </div>
+        ) : reason === SiteTrackingNotAvailableReasons.trialNotAccepted ? (
+          // Any paid account can enable the trial
+          <div>
+            <FormattedMessage tagName="h3" id="reports.datahub_not_active_title" />
+            <FormattedHTMLMessage
+              tagName="div"
+              id="reports.datahub_not_active_HTML"
+              values={{ dopplerBaseUrl: dopplerLegacyUrl }}
+            />
+          </div>
+        ) : (
+          // SiteTrackingNotAvailableReasons.featureDisabled
+          // SiteTrackingNotAvailableReasons.thereAreNotDomains
+          // SiteTrackingNotAvailableReasons.noDatahubId
+          <FormattedHTMLMessage
+            className="patch-no-domains"
+            id="reports.no_domains_HTML"
+            values={{ dopplerBaseUrl: dopplerLegacyUrl }}
+          />
+        )}
+      </div>
+    </section>
+  ),
 );

--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.js
@@ -1,47 +1,48 @@
+@@ -0,0 +1,47 @@
 import React from 'react';
 import { InjectAppServices } from '../../services/pure-di';
 import { FormattedHTMLMessage, FormattedMessage } from 'react-intl';
 
-/**
- * @param { Object } props
- * @param { import('../../services/pure-di').AppServices } props.dependencies
- */
-function SiteTrackingRequired({
-  dependencies: {
-    appSessionRef,
-    appConfiguration: { dopplerLegacyUrl },
+export default InjectAppServices(
+  /**
+   * @param { Object } props
+   * @param { import('../../services/pure-di').AppServices } props.dependencies
+   */
+  ({
+    dependencies: {
+      appSessionRef,
+      appConfiguration: { dopplerLegacyUrl },
+    },
+  }) => {
+    const isFreeAccount =
+      appSessionRef.current.userData !== undefined
+        ? appSessionRef.current.userData.user.plan.isFreeAccount
+        : false;
+
+    return (
+      <section className="container-reports">
+        <div className="wrapper-kpi">
+          {isFreeAccount ? (
+            <div>
+              <FormattedMessage tagName="h3" id="reports.upgrade_account_free_title" />
+              <FormattedHTMLMessage
+                tagName="div"
+                id="reports.upgrade_account_free_HTML"
+                values={{ dopplerBaseUrl: dopplerLegacyUrl }}
+              />
+            </div>
+          ) : (
+            <div>
+              <FormattedMessage tagName="h3" id="reports.datahub_not_active_title" />
+              <FormattedHTMLMessage
+                tagName="div"
+                id="reports.datahub_not_active_HTML"
+                values={{ dopplerBaseUrl: dopplerLegacyUrl }}
+              />
+            </div>
+          )}
+        </div>
+      </section>
+    );
   },
-}) {
-  const isFreeAccount =
-    appSessionRef.current.userData !== undefined
-      ? appSessionRef.current.userData.user.plan.isFreeAccount
-      : false;
-
-  return (
-    <section className="container-reports">
-      <div className="wrapper-kpi">
-        {isFreeAccount ? (
-          <div>
-            <FormattedMessage tagName="h3" id="reports.upgrade_account_free_title" />
-            <FormattedHTMLMessage
-              tagName="div"
-              id="reports.upgrade_account_free_HTML"
-              values={{ dopplerBaseUrl: dopplerLegacyUrl }}
-            />
-          </div>
-        ) : (
-          <div>
-            <FormattedMessage tagName="h3" id="reports.datahub_not_active_title" />
-            <FormattedHTMLMessage
-              tagName="div"
-              id="reports.datahub_not_active_HTML"
-              values={{ dopplerBaseUrl: dopplerLegacyUrl }}
-            />
-          </div>
-        )}
-      </div>
-    </section>
-  );
-}
-
-export default InjectAppServices(SiteTrackingRequired);
+);

--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.js
@@ -6,7 +6,7 @@ import { FormattedHTMLMessage, FormattedMessage } from 'react-intl';
  * @param { Object } props
  * @param { import('../../services/pure-di').AppServices } props.dependencies
  */
-function DatahubRequired({
+function SiteTrackingRequired({
   dependencies: {
     appSessionRef,
     appConfiguration: { dopplerLegacyUrl },
@@ -44,4 +44,4 @@ function DatahubRequired({
   );
 }
 
-export default InjectAppServices(DatahubRequired);
+export default InjectAppServices(SiteTrackingRequired);

--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.js
@@ -26,7 +26,7 @@ export const SiteTrackingRequired = InjectAppServices(
         {reason === SiteTrackingNotAvailableReasons.freeAccount ? (
           // Free accounts cannot enable trial, they should buy
           <>
-            <FormattedMessage tagName="h3" id="reports.upgrade_account_free_title" />
+            <FormattedMessage tagName="h2" id="reports.upgrade_account_free_title" />
             <FormattedHTMLMessage
               tagName="div"
               id="reports.upgrade_account_free_HTML"
@@ -36,7 +36,7 @@ export const SiteTrackingRequired = InjectAppServices(
         ) : reason === SiteTrackingNotAvailableReasons.trialNotAccepted ? (
           // Any paid account can enable the trial
           <>
-            <FormattedMessage tagName="h3" id="reports.allow_enable_trial_title" />
+            <FormattedMessage tagName="h2" id="reports.allow_enable_trial_title" />
             <FormattedHTMLMessage tagName="div" id="reports.allow_enable_trial_HTML" />
             <div className="dp-messages-actions">
               {/* TODO: implement this action DBR-227 */}

--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { InjectAppServices } from '../../services/pure-di';
 import { FormattedHTMLMessage, FormattedMessage } from 'react-intl';
 
@@ -19,43 +19,65 @@ export const SiteTrackingRequired = InjectAppServices(
     reason,
     dependencies: {
       appConfiguration: { dopplerLegacyUrl },
+      dopplerLegacyClient,
+      sessionManager,
     },
-  }) => (
-    <section className="container-reports">
-      <div className="dp-wrapper-messages">
-        {reason === SiteTrackingNotAvailableReasons.freeAccount ? (
-          // Free accounts cannot enable trial, they should buy
-          <>
-            <FormattedMessage tagName="h2" id="reports.upgrade_account_free_title" />
+  }) => {
+    const [isActivatingTrial, setIsActivatingTrial] = useState(false);
+
+    const activateTrial = async () => {
+      setIsActivatingTrial(true);
+      try {
+        await dopplerLegacyClient.activateSiteTrackingTrial();
+        sessionManager.restart();
+      } finally {
+        setIsActivatingTrial(false);
+      }
+    };
+
+    return (
+      <section className="container-reports">
+        <div className="dp-wrapper-messages">
+          {reason === SiteTrackingNotAvailableReasons.freeAccount ? (
+            // Free accounts cannot enable trial, they should buy
+            <>
+              <FormattedMessage tagName="h2" id="reports.upgrade_account_free_title" />
+              <FormattedHTMLMessage
+                tagName="div"
+                id="reports.upgrade_account_free_HTML"
+                values={{ dopplerBaseUrl: dopplerLegacyUrl }}
+              />
+            </>
+          ) : reason === SiteTrackingNotAvailableReasons.trialNotAccepted ? (
+            // Any paid account can enable the trial
+            <>
+              <FormattedMessage tagName="h2" id="reports.allow_enable_trial_title" />
+              <FormattedHTMLMessage tagName="div" id="reports.allow_enable_trial_HTML" />
+              <div className="dp-messages-actions">
+                <button
+                  onClick={activateTrial}
+                  className={
+                    'dp-button button-medium primary-green' +
+                    ((isActivatingTrial && ' button--loading') || '')
+                  }
+                  disabled={isActivatingTrial}
+                >
+                  <FormattedMessage id="reports.allow_enable_trial_button" />
+                </button>
+              </div>
+            </>
+          ) : (
+            // SiteTrackingNotAvailableReasons.featureDisabled
+            // SiteTrackingNotAvailableReasons.thereAreNotDomains
+            // SiteTrackingNotAvailableReasons.noDatahubId
             <FormattedHTMLMessage
-              tagName="div"
-              id="reports.upgrade_account_free_HTML"
+              className="patch-no-domains"
+              id="reports.no_domains_HTML"
               values={{ dopplerBaseUrl: dopplerLegacyUrl }}
             />
-          </>
-        ) : reason === SiteTrackingNotAvailableReasons.trialNotAccepted ? (
-          // Any paid account can enable the trial
-          <>
-            <FormattedMessage tagName="h2" id="reports.allow_enable_trial_title" />
-            <FormattedHTMLMessage tagName="div" id="reports.allow_enable_trial_HTML" />
-            <div className="dp-messages-actions">
-              {/* TODO: implement this action DBR-227 */}
-              <button className="dp-button button-medium primary-green">
-                <FormattedMessage id="reports.allow_enable_trial_button" />
-              </button>
-            </div>
-          </>
-        ) : (
-          // SiteTrackingNotAvailableReasons.featureDisabled
-          // SiteTrackingNotAvailableReasons.thereAreNotDomains
-          // SiteTrackingNotAvailableReasons.noDatahubId
-          <FormattedHTMLMessage
-            className="patch-no-domains"
-            id="reports.no_domains_HTML"
-            values={{ dopplerBaseUrl: dopplerLegacyUrl }}
-          />
-        )}
-      </div>
-    </section>
-  ),
+          )}
+        </div>
+      </section>
+    );
+  },
 );

--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.js
@@ -22,27 +22,29 @@ export const SiteTrackingRequired = InjectAppServices(
     },
   }) => (
     <section className="container-reports">
-      <div className="wrapper-kpi">
+      <div className="dp-wrapper-messages">
         {reason === SiteTrackingNotAvailableReasons.freeAccount ? (
           // Free accounts cannot enable trial, they should buy
-          <div>
+          <>
             <FormattedMessage tagName="h3" id="reports.upgrade_account_free_title" />
             <FormattedHTMLMessage
               tagName="div"
               id="reports.upgrade_account_free_HTML"
               values={{ dopplerBaseUrl: dopplerLegacyUrl }}
             />
-          </div>
+          </>
         ) : reason === SiteTrackingNotAvailableReasons.trialNotAccepted ? (
           // Any paid account can enable the trial
-          <div>
-            <FormattedMessage tagName="h3" id="reports.datahub_not_active_title" />
-            <FormattedHTMLMessage
-              tagName="div"
-              id="reports.datahub_not_active_HTML"
-              values={{ dopplerBaseUrl: dopplerLegacyUrl }}
-            />
-          </div>
+          <>
+            <FormattedMessage tagName="h3" id="reports.allow_enable_trial_title" />
+            <FormattedHTMLMessage tagName="div" id="reports.allow_enable_trial_HTML" />
+            <div className="dp-messages-actions">
+              {/* TODO: implement this action DBR-227 */}
+              <button className="dp-button button-medium primary-green">
+                <FormattedMessage id="reports.allow_enable_trial_button" />
+              </button>
+            </div>
+          </>
         ) : (
           // SiteTrackingNotAvailableReasons.featureDisabled
           // SiteTrackingNotAvailableReasons.thereAreNotDomains

--- a/src/headerData.json
+++ b/src/headerData.json
@@ -154,5 +154,11 @@
   "homeUrl": "https://appint.fromdoppler.net/Campaigns/Draft/",
   "urlBase": "https://appint.fromdoppler.net/",
   "datahubCustomerId": "1024",
+  "features": {
+    "siteTrackingEnabled": true,
+    "siteTrackingActive": true,
+    "emailParameterEnabled": true,
+    "emailParameterActive": true
+  },
   "jwtToken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1N1IjpmYWxzZSwic3ViIjoiY2Jlcm5hdEBnZXRjcy5jb20iLCJjdXN0b21lcklkIjoiMTAyNCIsImRhdGFodWJDdXN0b21lcklkIjoiMTAyNCIsImlhdCI6MTU1NjU0NTQ2MSwiZXhwIjoxNTU2NTQ3MjYxfQ.meC1sFsC7m8nGFfcK2oih1hqdKQ4Lj81O5rN_-awOcM_JEe9ddviocPbYAg64L6nC6b0a7J5xmTmiW_-MAIEIg"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -48,6 +48,9 @@
     "you_want_create_account": "Do not you have an account yet?"
   },
   "reports": {
+    "allow_enable_trial_HTML": "<p>Target users based on their behavior on your website or E-commerce. Thanks to this feature you can send automatic and 100% personalized Emails to the users who visit a specific page. For example, you can send a discount to users who view a particular product page.</p><h4>When does the free trial end?</h4><p>Our goal is that you can see how to use this feature in your business and check its benefits, so for the moment you can use it with no restrictions.</p><h4>What will happen to the Automations created when the free trial ends?</h4><p>They'll remain inactive, and you won't be able to edit them until you hire the special module which includes this service.</p>",
+    "allow_enable_trial_button": "Activate free trial",
+    "allow_enable_trial_title": "Try On-Site Tracking Automation for FREE",
     "datahub_not_active_HTML": "<p>How do users behave on your Website or E-commerce? Track their behavior for a period of time and find out which are the most visited pages, how many of those visits have an Email identified by Doppler and how many don’t. By tracking the user’s journey you'll be able to detect vanishing points and opportunities for improvement!</p><p>You haven’t enabled On-Site Tracking yet. You can trigger it from the <a href=\"{dopplerBaseUrl}/ControlPanel/CampaignsPreferences/SiteTrackingSettings\">On-Site Tracking</a> option in the Control Panel.</p>",
     "datahub_not_active_title":"Track user behavior and optimize your Marketing actions",
     "datahub_not_domains_title":"Track user behavior and optimize your Marketing actions",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -48,6 +48,9 @@
     "you_want_create_account": "¿Aún no tienes una cuenta?"
   },
   "reports": {
+    "allow_enable_trial_HTML": "<p>Envía Emails automáticos y 100% personalizados a quienes visiten una página específica de tu sitio web o tienda online. Por ejemplo, puedes enviar un descuento a los usuarios que visitaron la página de un producto en particular para hacer que regresen a comprarlo.</p><h4>¿Cuándo finaliza el periodo de prueba?</h4><p>Nuestro objetivo es que puedas ver de qué forma utilizar esta funcionalidad en tu negocio y comprobar sus beneficios, por lo que por el momento podrás utilizarla sin limitaciones.</p><h4>¿Qué sucederá con las Automations creadas cuando finalice el periodo de prueba?</h4><p>Permanecerán inactivas, y no podrás editarlas hasta que contrates el módulo especial que incluye este servicio.</p>",
+    "allow_enable_trial_button": "Activar período de prueba",
+    "allow_enable_trial_title": "Prueba Automation por Comportamiento GRATIS",
     "datahub_not_active_HTML": "<p>Accede a Reportes sobre el comportamiento de los usuarios en tu Sitio Web o E-commerce durante un periodo de tiempo. Descubre cuáles son las páginas más visitadas, cuántas de esas visitas poseen un Email que Doppler ha identificado y cuántas no. ¡Sigue el recorrido de los usuarios, detecta puntos de fuga y oportunidades de mejora!</p><p>Aún no has habilitado la funcionalidad de Comportamiento en Sitio. Puedes hacerlo desde la opción de <a href=\"{dopplerBaseUrl}/ControlPanel/CampaignsPreferences/SiteTrackingSettings\">Seguimiento en Sitio</a> en el Panel de Control.</p>",
     "datahub_not_active_title": "Trackea el comportamiento de los usuarios y optimiza tus acciones",
     "datahub_not_domains_title":"Trackea el comportamiento de los usuarios y optimiza tus acciones",

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -48,6 +48,7 @@ export class HardcodedDatahubClient implements DatahubClient {
     console.log('getAccountDomains');
     await timeout(1500);
     return fakeData.map((x) => ({ name: x.name, verified_date: x.verified_date }));
+    // return [];
   }
 
   public async getVisitsByPeriod({

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -36,7 +36,9 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
   public async getUserData() {
     console.log('getUserData');
     await timeout(1500);
-    const { user, nav, alert, datahubCustomerId, jwtToken } = mapHeaderDataJson(headerDataJson);
+    const { user, nav, alert, datahubCustomerId, features, jwtToken } = mapHeaderDataJson(
+      headerDataJson,
+    );
 
     return {
       user: {
@@ -46,6 +48,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
       nav: nav,
       alert,
       datahubCustomerId,
+      features,
       jwtToken,
     };
   }

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -115,12 +115,22 @@ interface AlertEntry {
   type: string;
 }
 
+interface DopplerFeatures {
+  /** Site tracking trial accepted or not */
+  siteTrackingEnabled: boolean;
+  /** Site tracking feature active or disabled */
+  siteTrackingActive: boolean;
+  emailParameterEnabled: boolean;
+  emailParameterActive: boolean;
+}
+
 export interface DopplerLegacyUserData {
   alert: AlertEntry | undefined;
   nav: MainNavEntry[];
   user: UserEntry;
   jwtToken: string;
   datahubCustomerId: string | null;
+  features: DopplerFeatures;
 }
 /* #endregion */
 
@@ -179,6 +189,12 @@ export function mapHeaderDataJson(json: any) {
     },
     jwtToken: json.jwtToken,
     datahubCustomerId: json.datahubCustomerId || null,
+    features: {
+      siteTrackingEnabled: !!(json.features && json.features.siteTrackingEnabled),
+      siteTrackingActive: !!(json.features && json.features.siteTrackingActive),
+      emailParameterEnabled: !!(json.features && json.features.emailParameterEnabled),
+      emailParameterActive: !!(json.features && json.features.emailParameterActive),
+    },
   };
 }
 /* #endregion */


### PR DESCRIPTION
Hi team, 

I am reading the backend features exposed by https://github.com/MakingSense/Doppler/pull/5936 and also unified the management of all these states in a single component.

```
                                                                      
  Trial no activo y C.Free |----> Mensaje con link a comprar          
                                                                      
                                                                      
  Trial no activo y C.Paga |----> Mensaje con opción de activar Trial 
                                                                      
                                                                      
        No tiene datahubId |                                          
                           |      Mensaje con ayuda para activar la   
      Desactivó la feature |----> feature, agregar dominios, etc y    
                           |      link a sección del panel de control 
         No tiene dominios |                                          
                                                                      
```

Tomorrow I will add screenshot with the instructions to reproduce the scenarios with local configuration.

Could you review?