### PR TITLE
chore: add zoho chat in spanish only

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build236/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="zoho-chat.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -45,5 +46,6 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
     <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build236/js/app.js"></script>
+    <script type="text/javascript" src="zoho-chat.js"></script>
   </body>
 </html>

--- a/public/zoho-chat.css
+++ b/public/zoho-chat.css
@@ -1,0 +1,53 @@
+.zsiq_floatmain.siq_bR {
+  bottom: 56px;
+  right: 40px;
+}
+
+.zsiq_floatmain.siq_bR.up
+{
+  bottom: 116px;
+  transition: all 1s ease-in 0s;
+}
+
+.zsiq_floatmain.siq_bR div.zsiq_cnt {
+  height: 70px;
+  background: #fff;
+  padding: 14px 18px;
+  border-radius: 5px;
+  bottom: 85px;
+  left: auto;
+  top: auto;
+  right: 0;
+  box-shadow: -1px 8px 25px -1px rgba(0,0,0,.25);
+  font-family: hand-of-sean;
+  font-size: 18px;
+  white-space: pre-wrap;
+  letter-spacing: 1px;
+  font-weight: normal;
+  z-index: 1;
+  display: block;
+}
+.zsiq_floatmain.siq_bR div.zsiq_cnt:hover {
+  box-shadow: -1px 8px 25px -1px rgba(0,0,0,.35);
+}
+.zsiq_floatmain.siq_bR .zsiq_cnt:after
+{
+  content: '';
+  position: absolute;
+  transform: rotate(45deg);
+  width: 10px;
+  height: 14px;
+  right: 23px;
+  bottom: -68px;
+  z-index: -1;
+  box-shadow: none;
+}
+
+.zsiq_floatmain.siq_bR .zsiq_cnt .zsiq_ellips {
+  white-space: pre-wrap;
+  color: #525845;
+}
+
+.zsiq_floatmain.siq_bR .zsiq_cnt #zsiq_byline {
+  display: none;
+}

--- a/public/zoho-chat.js
+++ b/public/zoho-chat.js
@@ -1,0 +1,72 @@
+var langRes = {
+  "es": {
+      "online": {
+          "legend": "¡Hola! Estamos aquí para ayudarte"
+      },
+      "offline": {
+          "legend": "¡Hola! Estamos offline. Déjanos un mensaje:)"
+      }
+  },
+  "en": {
+      "online": {
+          "legend": "Hi! We’re here if you need some help :)"
+      },
+      "offline": {
+          "legend": "Hi! We’re offline now. We’ll be back ASAP :)"
+      }
+  }
+}
+
+var $zoho = $zoho || {};
+$zoho.salesiq = $zoho.salesiq ||
+  {
+    widgetcode: "44b76224430b91326cb02039d609a5e008e7fe0266102a0ce5060b5c1ff1e0ee",
+    values: {},
+    ready: function() {
+      var lang = 'en'; /*change this in the future*/ 
+      var chatResources = lang === 'en' ? langRes.en : langRes.es;
+      $zoho.salesiq.language('es'); //we need this hardcoded, only the bubble changes languages
+      $zoho.salesiq.chatbutton.texts([
+          [chatResources.online.legend, "Online"],
+          [chatResources.offline.legend, "Offline"]
+        ]);
+        $zoho.salesiq.customfield.add(
+            {
+                "name": "_default.name",
+                "hint": "¿Cómo te llamas?",
+                "type": "text",
+                "required": "true",
+                "visibility": "both"
+            }
+        );
+        $zoho.salesiq.customfield.add(
+            {
+                "name":"_default.email",
+                "hint": "¿Cuál es tu Email?",
+                "type": "email",
+                "required": "true",
+                "visibility": "both"
+            }
+        );
+        $zoho.salesiq.floatwindow.onlinetitle("¿En qué podemos ayudarte?");
+        $zoho.salesiq.floatwindow.offlinetitle("¿En qué podemos ayudarte?");
+        $zoho.salesiq.chatbutton.width("205");
+    }
+  };
+
+var zohoScript = document.createElement("script");
+zohoScript.type = "text/javascript";
+zohoScript.id = "zsiqscript";
+zohoScript.defer = true;
+zohoScript.src = "https://salesiq.zoho.com/widget";
+
+var firstScript = document.getElementsByTagName("script")[0];
+firstScript.parentNode.insertBefore(zohoScript,firstScript);
+document.write("<div id='zsiqwidget'></div>");
+
+// hide bubble after certain time
+window.onload = function () {
+  setTimeout(function () {
+      document.getElementById('titlediv').style.visibility = "hidden";
+  }, 12000);
+};


### PR DESCRIPTION
Add zoho chat, as it is in doppler and sites. 
Changed font handling, and renamed some variables. 
![image](https://user-images.githubusercontent.com/2439363/57102328-a573d880-6cf9-11e9-85e4-3ecb60ac6bf9.png)

https://cdn.fromdoppler.com/doppler-webapp/int-build521/#/signup
