### PR TITLE
fix: fix email validation

### DIFF
--- a/src/validations.test.js
+++ b/src/validations.test.js
@@ -63,6 +63,17 @@ describe('validations', () => {
       expect(result).toEqual('validation_messages.error_invalid_email_address');
     });
 
+    it('should accept an email address with multiple levels of subdomains', () => {
+      // Arrange
+      const emailAddress = 'test@test.test.com.ar';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
     it('should not accept an email address starting with dot (.)', () => {
       // Arrange
       const emailAddress = '.test@test.com';

--- a/src/validations.test.js
+++ b/src/validations.test.js
@@ -41,9 +41,42 @@ describe('validations', () => {
       expect(result).toBeNull();
     });
 
+    it('should accept an email address with /', () => {
+      // Arrange
+      const emailAddress = 'te/st@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should accept an email address with &', () => {
+      // Arrange
+      const emailAddress = 'a&test&@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should accept an email address with ~', () => {
+      // Arrange
+      const emailAddress = 'a~test~@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
     it('should accept an email address with ñ', () => {
       // Arrange
-      const emailAddress = 'test@testñ.com';
+      const emailAddress = 'testñ@testñ.com';
 
       // Act
       const result = validateEmail(emailAddress);

--- a/src/validations.test.js
+++ b/src/validations.test.js
@@ -52,6 +52,61 @@ describe('validations', () => {
       expect(result).toBeNull();
     });
 
+    it('should not accept an email address with dot (.) before @', () => {
+      // Arrange
+      const emailAddress = 'test.@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toEqual('validation_messages.error_invalid_email_address');
+    });
+
+    it('should not accept an email address starting with dot (.)', () => {
+      // Arrange
+      const emailAddress = '.test@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toEqual('validation_messages.error_invalid_email_address');
+    });
+
+    it('should not accept an email address with two dots (.) together', () => {
+      // Arrange
+      const emailAddress = 'te..st@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toEqual('validation_messages.error_invalid_email_address');
+    });
+
+    it('should accept an email only a character before @', () => {
+      // Arrange
+      const emailAddress = 'a@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should accept an email with dot separated sections before @', () => {
+      // Arrange
+      const emailAddress = 'test.test.test@test.com';
+
+      // Act
+      const result = validateEmail(emailAddress);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
     it('should not accept an email address from a top-level domain', () => {
       // Arrange
       const emailAddress = 'test@test';

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -7,7 +7,9 @@ export function validateEmail(
   }
 
   if (
-    !/^([a-z\d[\]])([\w\-.+\][]*)([a-z\d[\]])@([ñ\w.\-\][]+)\.[\w\-\][.]{2,}(\?)?.*$/i.test(value)
+    !/^([a-z\d[\]])(\.?([\w\-+\][]*)([a-z\d[\]]))*@([ñ\w.\-\][]+)\.[\w\-\][.]{2,}(\?)?.*$/i.test(
+      value,
+    )
   ) {
     return commonErrorKey;
   }

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -1,3 +1,5 @@
+const emailRegex = /^([a-z\d[\]])(\.?([\w\-+\][]*)([a-z\d[\]]))*@([ñ\w.\-\][]+)\.[\w\-\][.]{2,}(\?)?.*$/i;
+
 export function validateEmail(
   value: string,
   commonErrorKey: true | string = 'validation_messages.error_invalid_email_address',
@@ -6,11 +8,7 @@ export function validateEmail(
     return null;
   }
 
-  if (
-    !/^([a-z\d[\]])(\.?([\w\-+\][]*)([a-z\d[\]]))*@([ñ\w.\-\][]+)\.[\w\-\][.]{2,}(\?)?.*$/i.test(
-      value,
-    )
-  ) {
+  if (!emailRegex.test(value)) {
     return commonErrorKey;
   }
 

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -1,4 +1,4 @@
-const emailRegex = /^([a-z\d[\]])(\.?([\w\-+\][]*)([a-z\d[\]]))*@([ñ\w.\-\][]+)\.[\w\-\][.]{2,}(\?)?.*$/i;
+const emailRegex = /^([a-zñ\d[\]])(\.?([\wñ&/~\-+\][]+))*@([ñ\w.\-\][]+)\.[\w\-\][.]{2,}(\?)?.*$/i;
 
 export function validateEmail(
   value: string,


### PR DESCRIPTION
Hi team, 

I found that the last changes in email validation do not allow emails with only a letter before @, I fixed that and added some tests.

Could you review?

CC: @CarlosSampedro, maybe you could think in other scenarios.
CC: @lucianaDilizio, if I am not wrong, you have applied the previous change in another place, you should consider also apply this one.