### PR TITLE
Support markdown content

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-google-recaptcha": "^1.0.5",
     "react-helmet": "^5.2.0",
     "react-intl": "^2.8.0",
+    "react-remarkable": "^1.1.3",
     "react-router-dom": "^5.0.0",
     "react-scripts": "^2.1.8",
     "react-testing-library": "^6.1.2",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -129,7 +129,7 @@ describe('App component', () => {
       });
 
       // Assert
-      getByText('Políticas de privacidad y legales.');
+      getByText('Política de Privacidad y Legales');
 
       // Act
       dependencies.sessionManager.updateAppSession({
@@ -152,7 +152,7 @@ describe('App component', () => {
       });
 
       // Assert
-      getByText('Privacy Policy & Legals.');
+      getByText('Privacy and Legal Policy');
 
       // Act
       dependencies.sessionManager.updateAppSession({ status: 'unknown' });

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 
 const Footer = () => (
   <footer className="footer-main">
@@ -7,17 +8,11 @@ const Footer = () => (
       <span>
         <FormattedMessage id="footer.iso" />
       </span>
-      <span>
-        &copy; {new Date().getFullYear()} Doppler LLC.{' '}
-        <FormattedMessage id="footer.allRightReserved" />.{' '}
-        <FormattedMessage id="footer.privacy_url">
-          {(url) => (
-            <a href={url}>
-              <FormattedMessage id="footer.privacy" />
-            </a>
-          )}
-        </FormattedMessage>
-      </span>
+      <FormattedMessageMarkdown
+        id="common.copyright_MD"
+        values={{ year: new Date().getFullYear() }}
+        options={{ linkTarget: '_blank' }}
+      />
     </div>
   </footer>
 );

--- a/src/components/Footer/Footer.test.js
+++ b/src/components/Footer/Footer.test.js
@@ -14,6 +14,6 @@ describe('Footer component', () => {
         <Footer />
       </IntlProvider>,
     );
-    expect(getByText('footer.allRightReserved')).toBeInTheDocument();
+    expect(getByText('common.copyright_MD')).toBeInTheDocument();
   });
 });

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -12,6 +12,7 @@ import {
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import { InjectAppServices } from '../../services/pure-di';
 import './ForgotPassword.css';
+import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 
 const fieldNames = {
   email: 'email',
@@ -103,10 +104,11 @@ const ForgotPassword = ({ intl, dependencies: { dopplerLegacyClient } }) => {
         <footer>
           <CaptchaLegalMessage />
           <p>
-            <FormattedHTMLMessage
-              tagName="small"
-              id="common.copyright_HTML"
+            <FormattedMessageMarkdown
+              container="small"
+              id="common.copyright_MD"
               values={{ year: new Date().getFullYear() }}
+              options={{ linkTarget: '_blank' }}
             />
           </p>
         </footer>

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -16,6 +16,7 @@ import RedirectToLegacyUrl from '../RedirectToLegacyUrl';
 import { InjectAppServices } from '../../services/pure-di';
 import { LoginErrorAccountNotValidated } from './LoginErrorAccountNotValidated';
 import LoginErrorCancelatedAccount from './LoginErrorCancelatedAccount';
+import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 
 const fieldNames = {
   user: 'user',
@@ -143,10 +144,11 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
         <footer>
           <CaptchaLegalMessage />
           <p>
-            <FormattedHTMLMessage
-              tagName="small"
-              id="common.copyright_HTML"
+            <FormattedMessageMarkdown
+              container="small"
+              id="common.copyright_MD"
               values={{ year: new Date().getFullYear() }}
+              options={{ linkTarget: '_blank' }}
             />
           </p>
         </footer>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -17,6 +17,7 @@ import {
 } from '../form-helpers/form-helpers';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import SignupConfirmation from './SignupConfirmation';
+import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 
 const fieldNames = {
   firstname: 'firstname',
@@ -204,10 +205,11 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
         <footer>
           <CaptchaLegalMessage />
           <p>
-            <FormattedHTMLMessage
-              tagName="small"
-              id="common.copyright_HTML"
+            <FormattedMessageMarkdown
+              container="small"
+              id="common.copyright_MD"
               values={{ year: new Date().getFullYear() }}
+              options={{ linkTarget: '_blank' }}
             />
           </p>
         </footer>

--- a/src/components/Signup/SignupConfirmation.js
+++ b/src/components/Signup/SignupConfirmation.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { FormattedHTMLMessage, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { useCaptcha } from '../form-helpers/captcha-utils';
 import { CaptchaLegalMessage } from '../form-helpers/form-helpers';
+import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 
 /**
  * Signup Confirmation Page
@@ -56,10 +57,11 @@ const SignupConfirmation = function({ resend, intl }) {
       <footer className="confirmation-footer">
         <CaptchaLegalMessage />
         <p>
-          <FormattedHTMLMessage
-            tagName="small"
-            id="common.copyright_HTML"
+          <FormattedMessageMarkdown
+            container="small"
+            id="common.copyright_MD"
             values={{ year: new Date().getFullYear() }}
+            options={{ linkTarget: '_blank' }}
           />
         </p>
       </footer>

--- a/src/i18n/FormattedMessageMarkdown.css
+++ b/src/i18n/FormattedMessageMarkdown.css
@@ -2,3 +2,7 @@
 small p {
   font: inherit;
 }
+
+.footer-wrapper p {
+  font: inherit;
+}

--- a/src/i18n/FormattedMessageMarkdown.css
+++ b/src/i18n/FormattedMessageMarkdown.css
@@ -1,0 +1,4 @@
+/* This is <p> are not making honor to parent styles */
+small p {
+  font: inherit;
+}

--- a/src/i18n/FormattedMessageMarkdown.js
+++ b/src/i18n/FormattedMessageMarkdown.js
@@ -7,11 +7,12 @@ import './FormattedMessageMarkdown.css';
 // TODO: do something to build markdown files inside es.json and en.json
 // to edit it in a more friendly way, or at least use a different format
 // than JSON to allow line breaks.
-// TODO: also consider memoize it, for example https://medium.com/@planttheidea/memoize-react-components-33377d7ebb6c
+// TODO: also consider memoize it, for example:
+// https://medium.com/@planttheidea/memoize-react-components-33377d7ebb6c
 // in order to avoid multiple processing of the same markdown source (Take
 // into account the message in the memoization.
-// TODO: also consider using always a linkTarget option as function detecting not webapp nor
-// doppler legacy links and apply _blank target to them.
+// TODO: also consider using always a linkTarget option as function detecting
+// not webapp nor doppler legacy links and apply _blank target to them.
 export const FormattedMessageMarkdown = injectIntl(
   ({ id, defaultMessage, values, description, intl: { formatMessage }, ...rest }) => (
     <Markdown source={formatMessage({ id, defaultMessage, description }, values)} {...rest} />

--- a/src/i18n/FormattedMessageMarkdown.js
+++ b/src/i18n/FormattedMessageMarkdown.js
@@ -10,6 +10,8 @@ import './FormattedMessageMarkdown.css';
 // TODO: also consider memoize it, for example https://medium.com/@planttheidea/memoize-react-components-33377d7ebb6c
 // in order to avoid multiple processing of the same markdown source (Take
 // into account the message in the memoization.
+// TODO: also consider using always a linkTarget option as function detecting not webapp nor
+// doppler legacy links and apply _blank target to them.
 export const FormattedMessageMarkdown = injectIntl(
   ({ id, defaultMessage, values, description, intl: { formatMessage }, ...rest }) => (
     <Markdown source={formatMessage({ id, defaultMessage, description }, values)} {...rest} />

--- a/src/i18n/FormattedMessageMarkdown.js
+++ b/src/i18n/FormattedMessageMarkdown.js
@@ -1,0 +1,16 @@
+// Based on https://github.com/yahoo/react-intl/issues/513#issuecomment-252083860-permalink
+import React from 'react';
+import Markdown from 'react-remarkable';
+import { injectIntl } from 'react-intl';
+
+// TODO: do something to build markdown files inside es.json and en.json
+// to edit it in a more friendly way, or at least use a different format
+// than JSON to allow line breaks.
+// TODO: also consider memoize it, for example https://medium.com/@planttheidea/memoize-react-components-33377d7ebb6c
+// in order to avoid multiple processing of the same markdown source (Take
+// into account the message in the memoization.
+export const FormattedMessageMarkdown = injectIntl(
+  ({ id, defaultMessage, values, description, intl: { formatMessage }, ...rest }) => (
+    <Markdown source={formatMessage({ id, defaultMessage, description }, values)} {...rest} />
+  ),
+);

--- a/src/i18n/FormattedMessageMarkdown.js
+++ b/src/i18n/FormattedMessageMarkdown.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import Markdown from 'react-remarkable';
 import { injectIntl } from 'react-intl';
+import './FormattedMessageMarkdown.css';
 
 // TODO: do something to build markdown files inside es.json and en.json
 // to edit it in a more friendly way, or at least use a different format

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -21,10 +21,7 @@
     "forms_remarks": "Classics and pop-ups with Single or Double Opt-In subscription. You decide how you want them to look, what data to request and where to place them!"
   },
   "footer": {
-    "allRightReserved": "All rights reserved",
-    "iso": "ISO Quality Certification 9001:2008",
-    "privacy": "Privacy Policy & Legals.",
-    "privacy_url": "https://fromdoppler.com/en/privacy-policy"
+    "iso": "ISO Quality Certification 9001:2008"
   },
   "forgot_password": {
     "back_login": "Did you remember your password and want to return?",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "cancel": "Cancel",
-    "copyright_HTML": "© {year} Doppler LLC. All rights reserved. <a target=\"_blank\" href=\"https://www.fromdoppler.com/en/legal/privacy-policy\">Privacy and Legal Policy.</a>",
+    "copyright_MD": "© {year} Doppler LLC. All rights reserved. [Privacy and Legal Policy](https://www.fromdoppler.com/en/legal/privacy-policy).",
     "help": "Help",
     "hide": "Hide",
     "message": "Message",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,7 +1,7 @@
 ﻿{
   "common": {
     "cancel": "Cancelar",
-    "copyright_HTML": "© {year} Doppler LLC. Todos los derechos reservados. <a target=\"_blank\" href=\"https://www.fromdoppler.com/legales/privacidad\">Política de Privacidad y Legales.</a>",
+    "copyright_MD": "© {year} Doppler LLC. Todos los derechos reservados. [Política de Privacidad y Legales](https://www.fromdoppler.com/legales/privacidad).",
     "help": "Ayuda",
     "hide": "Ocultar",
     "message": "Mensaje",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -21,10 +21,7 @@
     "forms_remarks": "Clásicos y pop-ups con suscripción Simple o Doble Opt-In. ¡Tú eliges cómo quieres que luzcan, qué datos solicitar y dónde ubicarlos!"
   },
   "footer": {
-    "allRightReserved": "Todos los derechos reservados",
-    "iso": "Certificación de Calidad ISO 9001:2008",
-    "privacy": "Políticas de privacidad y legales.",
-    "privacy_url": "https://fromdoppler.com/privacidad"
+    "iso": "Certificación de Calidad ISO 9001:2008"
   },
   "forgot_password": {
     "back_login": "¿Recordaste tu contraseña y quieres regresar?",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -25,7 +25,7 @@
   },
   "forgot_password": {
     "back_login": "¿Recordaste tu contraseña y quieres regresar?",
-    "confirmation_message_HTML": "<p>¡Revisa tu casilla!</p><p>Encontrarás un Email con los pasos a Seguir.</p>",
+    "confirmation_message_HTML": "<p>¡Revisa tu casilla!</p><p>Encontrarás un Email con los pasos a seguir.</p>",
     "description": "¡No te preocupes! Nos sucede a todos.",
     "description2": "Ingresa tu Email y te ayudaremos."
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,6 +1491,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@~0.1.15:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
+  integrity sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=
+  dependencies:
+    underscore "~1.7.0"
+    underscore.string "~2.4.0"
+
 aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
@@ -1688,6 +1696,11 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+autolinker@~0.15.0:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.15.3.tgz#342417d8f2f3461b14cf09088d5edf8791dc9832"
+  integrity sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=
 
 autoprefixer@^9.4.2:
   version "9.4.9"
@@ -8900,6 +8913,13 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+react-remarkable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-remarkable/-/react-remarkable-1.1.3.tgz#6ef3861812d806fbf747cc1d1e151ee3172130a6"
+  integrity sha512-H4kfiT0Q84OzNAcNfWKDMe1Xhm/7jJAIHV5n4mAff2N0nGpPtRN2M7zhLXaTalD5DNGCGKEq1b4XApZ/1QpKbg==
+  dependencies:
+    remarkable "^1.x"
+
 react-router-dom@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.0.tgz#542a9b86af269a37f0b87218c4c25ea8dcf0c073"
@@ -9213,6 +9233,14 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
+
+remarkable@^1.x:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.1.tgz#aaca4972100b66a642a63a1021ca4bac1be3bff6"
+  integrity sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=
+  dependencies:
+    argparse "~0.1.15"
+    autolinker "~0.15.0"
 
 remove-bom-buffer@^3.0.0:
   version "3.0.0"
@@ -10518,6 +10546,16 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
+
+underscore.string@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
+  integrity sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=
+
+underscore@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Hi Team,

Sorry, I could not contain myself and I have added this PR, only for love.

The idea is accepting nice and safe markdown content in place of ugly and insecure HTML content.

The next step is finding a way to define the content (or part of it) without using this ugly JSON, maybe using independent files for entries or using yml.

Could you review it? 

@GusBaamonde, in the future we should do something with `<p>` styles, they do not make honor to parent element styles!