### PR TITLE
fix: link to (almost) right URL in Page Ranking

### DIFF
--- a/src/components/Reports/ReportsPageRanking/ReportsPageRanking.js
+++ b/src/components/Reports/ReportsPageRanking/ReportsPageRanking.js
@@ -87,7 +87,7 @@ class ReportsPageRanking extends React.Component {
                   </p>
                   <a
                     className="link-ranking"
-                    href={item.name}
+                    href={item.url}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -22,23 +22,23 @@ const fakeData = [
 
 const fakePagesData = [
   {
-    name: 'https://www.fromdoppler.com/email-marketing',
+    name: '/email-marketing',
     totalVisits: 10122,
   },
   {
-    name: 'https://www.fromdoppler.com/precios',
+    name: '/precios',
     totalVisits: 9000,
   },
   {
-    name: 'https://www.fromdoppler.com/login',
+    name: '/login',
     totalVisits: 5001,
   },
   {
-    name: 'https://www.fromdoppler.com/productos',
+    name: '/productos',
     totalVisits: 3800,
   },
   {
-    name: 'https://www.fromdoppler.com/servicios',
+    name: '/servicios',
     totalVisits: 1023,
   },
 ];
@@ -72,9 +72,13 @@ export class HardcodedDatahubClient implements DatahubClient {
   }: {
     domainName: number;
     dateFrom: Date;
-  }): Promise<{ name: string; totalVisits: number }[]> {
+  }): Promise<{ name: string; totalVisits: number; url: string }[]> {
     console.log('getPagesRankingByPeriod', { domainName, dateFrom });
     await timeout(1500);
-    return fakePagesData.map((x) => ({ name: x.name, totalVisits: x.totalVisits }));
+    return fakePagesData.map((x) => ({
+      name: x.name,
+      totalVisits: x.totalVisits,
+      url: `http://${domainName}${x.name}`,
+    }));
   }
 }

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -19,7 +19,7 @@ export interface DatahubClient {
   getPagesRankingByPeriod(query: {
     domainName: number;
     dateFrom: Date;
-  }): Promise<{ name: string; totalVisits: number }[]>;
+  }): Promise<{ name: string; totalVisits: number; url: string }[]>;
 }
 
 export class HttpDatahubClient implements DatahubClient {
@@ -101,13 +101,22 @@ export class HttpDatahubClient implements DatahubClient {
   }: {
     domainName: number;
     dateFrom: Date;
-  }): Promise<{ name: string; totalVisits: number }[]> {
+  }): Promise<{ name: string; totalVisits: number; url: string }[]> {
     const response = await this.customerGet<{ items: { page: string; count: number }[] }>(
       `domains/${domainName}/events/summarized-by-page`,
       {
         startDate: dateFrom.toISOString(),
       },
     );
-    return response.data.items.map((x) => ({ name: x.page, totalVisits: x.count }));
+
+    // By the moment we are hard-coding it because DataHub does not have this
+    // information. I am looking you Leo :P
+    const urlSchema = 'http://';
+
+    return response.data.items.map((x) => ({
+      name: x.page,
+      totalVisits: x.count,
+      url: `${urlSchema}${domainName}${x.page}`,
+    }));
   }
 }


### PR DESCRIPTION
Hi team, 

I am fixing the link in Page Ranking box:

![image](https://user-images.githubusercontent.com/1157864/57246274-3f49c700-7013-11e9-9a69-320dba86598f.png)

Could you review?

CC: @leoslopez