### PR TITLE
feat: deal with blocked account and invalid login

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -15,7 +15,6 @@ import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import RedirectToLegacyUrl from '../RedirectToLegacyUrl';
 import { InjectAppServices } from '../../services/pure-di';
 import { LoginErrorAccountNotValidated } from './LoginErrorAccountNotValidated';
-import LoginErrorCancelatedAccount from './LoginErrorCancelatedAccount';
 import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 
 const fieldNames = {
@@ -74,7 +73,19 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
       } else if (result.expectedError && result.expectedError.accountNotValidated) {
         setErrors({ _general: <LoginErrorAccountNotValidated email={values[fieldNames.user]} /> });
       } else if (result.expectedError && result.expectedError.cancelatedAccount) {
-        setErrors({ _general: <LoginErrorCancelatedAccount /> });
+        setErrors({
+          _general: (
+            <FormattedHTMLMessage id="validation_messages.error_account_is_canceled_HTML" />
+          ),
+        });
+      } else if (result.expectedError && result.expectedError.blockedAccountInvalidPassword) {
+        setErrors({
+          _general: (
+            <FormattedHTMLMessage id="validation_messages.error_account_is_blocked_invalid_pass_HTML" />
+          ),
+        });
+      } else if (result.expectedError && result.expectedError.invalidLogin) {
+        setErrors({ _general: 'validation_messages.error_invalid_login' });
       } else {
         console.log('Unexpected error', result);
         setErrors({ _general: 'validation_messages.error_unexpected' });

--- a/src/components/Login/LoginErrorCancelatedAccount.js
+++ b/src/components/Login/LoginErrorCancelatedAccount.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import { FormattedHTMLMessage } from 'react-intl';
-
-const LoginErrorCancelatedAccount = () => (
-  <FormattedHTMLMessage id="validation_messages.error_account_is_canceled_HTML" />
-);
-
-export default LoginErrorCancelatedAccount;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -116,11 +116,13 @@
     "title": "Request an update of your plan"
   },
   "validation_messages": {
+    "error_account_is_blocked_invalid_pass_HTML" : "For security reasons we've temporarily disabled your account. <a href=\"http://www.fromdoppler.com/en/contact\" target=\"_blank\">Contact Us.<a>",
     "error_account_is_canceled_HTML" : "Your account has been cancelled. To know more please <a target=\"_blank\" href=\"http://www.fromdoppler.com/en/contact.html\">contact us</a>.",
     "error_checkbox_policy": "Ouch! You haven't accepted the Doppler's Privacy Policy.",
     "error_email_already_exists": "Ouch! You already have a Doppler account.",
     "error_invalid_domain_to_register_account": "Ouch! Invalid Email to create an account.",
     "error_invalid_email_address": "Ouch! Invalid email address",
+    "error_invalid_login" : "Ouch! There is an error in your Username or Password. Please, try again.",
     "error_password_character_length": "At least 8 characters",
     "error_password_digit": "One number",
     "error_password_letter": "One letter",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -115,11 +115,13 @@
     "title": "Solicita una actualización de tu plan"
   },
   "validation_messages": {
-    "error_account_is_canceled_HTML" : "Tu cuenta se encuentra cancelada. Para más información <a target=\"_blank\" href=\"http://www.fromdoppler.com/en/contact.html\">contáctanos</a>.",
+    "error_account_is_blocked_invalid_pass_HTML" : "Por seguridad hemos bloqueado tu cuenta momentáneamente. <a href=\"http://www.fromdoppler.com/contacto\" target=\"_blank\">Contáctanos.<a>",
+    "error_account_is_canceled_HTML" : "Tu cuenta se encuentra cancelada. Para más información <a target=\"_blank\" href=\"http://www.fromdoppler.com/contacto\">contáctanos</a>.",
     "error_checkbox_policy": "¡Ouch! No has aceptado la Política de Privacidad de Doppler.",
     "error_email_already_exists": "¡Ouch! Ya posees una cuenta en Doppler.",
     "error_invalid_domain_to_register_account": "¡Ouch! Email inválido para crear una cuenta.",
     "error_invalid_email_address": "¡Ouch! El formato del email es incorrecto",
+    "error_invalid_login" : "¡Ouch! Hay un error en tu Usuario o Contraseña. Vuelve a intentarlo.",
     "error_password_character_length": "8 caracteres como mínimo",
     "error_password_digit": "Un número",
     "error_password_letter": "Una letra",

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -23,6 +23,8 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
     // return { expectedError: { blockedAccountNotPayed: true } };
     // return { expectedError: { accountNotValidated: true } };
     // return { expectedError: { cancelatedAccount: true } };
+    // return { expectedError: { invalidLogin: true } };
+    // return { expectedError: { blockedAccountInvalidPassword: true } };
   }
 
   public async registerUser(model: UserRegistrationModel): Promise<UserRegistrationResult> {

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -40,9 +40,41 @@ export type ForgotPasswordResult = EmptyResultWithoutExpectedErrors;
 /* #region Login data types */
 
 export type LoginErrorResult =
-  | { blockedAccountNotPayed: true; accountNotValidated?: false; cancelatedAccount?: false }
-  | { accountNotValidated: true; cancelatedAccount?: false; blockedAccountNotPayed?: false }
-  | { cancelatedAccount: true; blockedAccountNotPayed?: false; accountNotValidated?: false };
+  | {
+      blockedAccountNotPayed: true;
+      accountNotValidated?: false;
+      cancelatedAccount?: false;
+      blockedAccountInvalidPassword?: false;
+      invalidLogin?: false;
+    }
+  | {
+      accountNotValidated: true;
+      cancelatedAccount?: false;
+      blockedAccountNotPayed?: false;
+      blockedAccountInvalidPassword?: false;
+      invalidLogin?: false;
+    }
+  | {
+      cancelatedAccount: true;
+      blockedAccountNotPayed?: false;
+      accountNotValidated?: false;
+      blockedAccountInvalidPassword?: false;
+      invalidLogin?: false;
+    }
+  | {
+      blockedAccountInvalidPassword: true;
+      blockedAccountNotPayed?: false;
+      accountNotValidated?: false;
+      cancelatedAccount?: false;
+      invalidLogin?: false;
+    }
+  | {
+      invalidLogin: true;
+      blockedAccountInvalidPassword?: false;
+      blockedAccountNotPayed?: false;
+      accountNotValidated?: false;
+      cancelatedAccount?: false;
+    };
 
 export type LoginResult = EmptyResult<LoginErrorResult>;
 
@@ -269,6 +301,14 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
 
       if (!response.data.success && response.data.error == 'CancelatedAccount') {
         return { expectedError: { cancelatedAccount: true } };
+      }
+
+      if (!response.data.success && response.data.error == 'BlockedAccountInvalidPassword') {
+        return { expectedError: { blockedAccountInvalidPassword: true } };
+      }
+
+      if (!response.data.success && response.data.error == 'InvalidLogin') {
+        return { expectedError: { invalidLogin: true } };
       }
 
       if (!response.data.success) {


### PR DESCRIPTION
- Catch blocked account for invalid pass error
- Catch invalid login (common error)
- Delete unnecessary module for HTML formated text.
- Fix _**contact us**_ link in spanish

For test: https://cdn.fromdoppler.com/doppler-webapp/int-build597/#/login