### PR TITLE
chore: add redirect for forgot password in spanish 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -91,9 +91,11 @@ class App extends Component {
             <PrivateRoute path="/reports/" exact requireSiteTracking component={Reports} />
             <PublicRouteWithLegacyFallback exact path="/login" />
             <PublicRouteWithLegacyFallback exact path="/signup" />
-            <PublicRouteWithLegacyFallback exact path="/forgot-password" />
+            <PublicRouteWithLegacyFallback exact path="/login/reset-password" />
             <RedirectWithQuery exact from="/ingresa" to="/login?lang=es" />
             <RedirectWithQuery exact from="/registrate" to="/signup?lang=es" />
+            <RedirectWithQuery exact from="/ingresa/cambiar-clave" to="/forgot-password?lang=es" />
+            <RedirectWithQuery exact from="/forgot-password" to="/login/reset-password" />
             {/* TODO: Implement NotFound page in place of redirect all to reports */}
             {/* <Route component={NotFound} /> */}
             <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />

--- a/src/components/PublicRouteWithLegacyFallback.js
+++ b/src/components/PublicRouteWithLegacyFallback.js
@@ -18,7 +18,7 @@ const pagesByPath = {
     webAppComponent: Signup,
     legacyRedirectDataResolver: signupRedirectionDataResolver,
   },
-  '/forgot-password': {
+  '/login/reset-password': {
     name: 'forgotPassword',
     webAppComponent: ForgotPassword,
     legacyRedirectDataResolver: forgotPasswordRedirectionDataResolver,


### PR DESCRIPTION
Add redirects for forgot password as follow:

- English: https://app.fromdoppler.com/#/login/reset-password
- Spanish: https://app.fromdoppler.com/#/ingresa/cambiar-clave

Reviewed this with @carodipietro 

Issue: DBR-266

https://cdn.fromdoppler.com/doppler-webapp/int-build622/#/login/reset-password
https://cdn.fromdoppler.com/doppler-webapp/int-build622/#/ingresa/cambiar-clave