### PR TITLE
feat: improvement of the zoho chat

### DIFF
--- a/public/zoho-chat.css
+++ b/public/zoho-chat.css
@@ -10,7 +10,8 @@
 }
 
 .zsiq_floatmain.siq_bR div.zsiq_cnt {
-  height: 70px;
+  max-height: 120px;
+  height: auto;
   background: #fff;
   padding: 14px 16px;
   border-radius: 5px;

--- a/public/zoho-chat.css
+++ b/public/zoho-chat.css
@@ -52,3 +52,19 @@
 .zsiq_floatmain.siq_bR .zsiq_cnt #zsiq_byline {
   display: none;
 }
+
+.zsiq_floatmain.siq_bR .zsiq_cnt:after{
+  display: none;
+}
+.zsiq_floatmain.siq_bR .zsiq_cnt:before{
+    content: '';
+    position: absolute;
+    transform: rotate(45deg);
+    width: 10px;
+    height: 14px;
+    right: 23px;
+    bottom: -6px;
+    background: #FFF;
+    z-index: 2;
+    box-shadow: none;
+}

--- a/public/zoho-chat.css
+++ b/public/zoho-chat.css
@@ -12,7 +12,7 @@
 .zsiq_floatmain.siq_bR div.zsiq_cnt {
   height: 70px;
   background: #fff;
-  padding: 14px 18px;
+  padding: 14px 16px;
   border-radius: 5px;
   bottom: 85px;
   left: auto;


### PR DESCRIPTION
We won by specificity and eliminated the ::after where the arrow shows, and placed the arrow in the ::before of the box, allowing it to grow and always show.

Look at @andresmoschini @cbernat @silsanchez8 :) what do you think?


![bug_chat_zoho2](https://user-images.githubusercontent.com/46735526/57404700-00527780-71b3-11e9-9ec7-5eee77b11013.gif)
