### PR TITLE
feat: add link to the logo with url by language

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build245/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build246/css/styles.css">
     <link rel="stylesheet" type="text/css" href="zoho-chat.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -45,7 +45,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build245/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build246/js/app.js"></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
   </body>
 </html>

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -64,7 +64,9 @@ const ForgotPassword = ({ intl, dependencies: { dopplerLegacyClient } }) => {
       </Helmet>
       <article className="main-panel">
         <header>
-          <h1 className="logo-doppler-new">Doppler</h1>
+          <h1 className="logo-doppler-new">
+            <a href={_('forgot_password.url_site')}>Doppler</a>
+          </h1>
           <LanguageSelector />
         </header>
         <h5>{_('login.forgot_password')}</h5>

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -65,7 +65,9 @@ const ForgotPassword = ({ intl, dependencies: { dopplerLegacyClient } }) => {
       <article className="main-panel">
         <header>
           <h1 className="logo-doppler-new">
-            <a target="_blank" href={_('forgot_password.url_site')}>Doppler</a>
+            <a target="_blank" href={_('forgot_password.url_site')}>
+              Doppler
+            </a>
           </h1>
           <LanguageSelector />
         </header>

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -65,7 +65,7 @@ const ForgotPassword = ({ intl, dependencies: { dopplerLegacyClient } }) => {
       <article className="main-panel">
         <header>
           <h1 className="logo-doppler-new">
-            <a href={_('forgot_password.url_site')}>Doppler</a>
+            <a target="_blank" href={_('forgot_password.url_site')}>Doppler</a>
           </h1>
           <LanguageSelector />
         </header>

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -122,7 +122,9 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
       <article className="main-panel">
         <header>
           <h1 className="logo-doppler-new">
-            <a target="_blank" href={_('login.url_site')}>Doppler</a>
+            <a target="_blank" href={_('login.url_site')}>
+              Doppler
+            </a>
           </h1>
           <LanguageSelector />
         </header>

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -122,7 +122,7 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
       <article className="main-panel">
         <header>
           <h1 className="logo-doppler-new">
-            <a href={_('login.url_site')}>Doppler</a>
+            <a target="_blank" href={_('login.url_site')}>Doppler</a>
           </h1>
           <LanguageSelector />
         </header>

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -121,7 +121,9 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
       </Helmet>
       <article className="main-panel">
         <header>
-          <h1 className="logo-doppler-new">Doppler</h1>
+          <h1 className="logo-doppler-new">
+            <a href={_('login.url_site')}>Doppler</a>
+          </h1>
           <LanguageSelector />
         </header>
         <h5>{_('login.enter_doppler')}</h5>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -128,7 +128,9 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
       <article className="main-panel">
         <header>
           <h1 className="logo-doppler-new">
-            <a target="_blank" href={_('signup.url_site')}>Doppler</a>
+            <a target="_blank" href={_('signup.url_site')}>
+              Doppler
+            </a>
           </h1>
           <LanguageSelector />
         </header>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -127,7 +127,9 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
       </Helmet>
       <article className="main-panel">
         <header>
-          <h1 className="logo-doppler-new">Doppler</h1>
+          <h1 className="logo-doppler-new">
+            <a href={_('signup.url_site')}>Doppler</a>
+          </h1>
           <LanguageSelector />
         </header>
         <h5>{_('signup.sign_up')}</h5>

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -128,7 +128,7 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
       <article className="main-panel">
         <header>
           <h1 className="logo-doppler-new">
-            <a href={_('signup.url_site')}>Doppler</a>
+            <a target="_blank" href={_('signup.url_site')}>Doppler</a>
           </h1>
           <LanguageSelector />
         </header>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -11,6 +11,9 @@ const urlContact = `${urlSite}/en/contact`;
 const urlControlPanel = `${urlDopplerLegacy}/ControlPanel`;
 const urlBuyMonthly = `${urlControlPanel}/AccountPreferences/UpgradeAccount?Plan=monthly`;
 const urlSiteTracking = `${urlControlPanel}/CampaignsPreferences/SiteTrackingSettings`;
+const urlSiteFromSignup = `${urlSite}/en/?utm_source=app&utm_medium=landing&utm_campaign=signup`;
+const urlSiteFromLogin = `${urlSite}/en/?utm_source=app&utm_medium=landing&utm_campaign=login`;
+const urlSiteFromForgot = `${urlSite}/en/?utm_source=app&utm_medium=landing&utm_campaign=reset-password`;
 
 export default {
   common: {
@@ -56,6 +59,7 @@ export default {
       `,
     description: `Don't worry! It happens.`,
     description2: `Enter your Email and well be glad to help you.`,
+    url_site: `${urlSiteFromForgot}`,
   },
   header: {
     help_url: `${urlHelp}`,
@@ -71,6 +75,7 @@ export default {
     head_title: `Free Email Marketing Automation with no sending limits | Doppler`,
     label_user: `Username: `,
     signup: `Sign up for free`,
+    url_site: `${urlSiteFromLogin}`,
     you_want_create_account: `Don't have an account yet?`,
   },
   reports: {
@@ -204,6 +209,7 @@ export default {
     sign_up: `Email, Automation & Data Marketing`,
     sign_up_sub: `Attrack, Engage and Convert. Send unlimited Emails up to 500 Subscribers for free.`,
     thanks_for_registering: `Thank you for registering`,
+    url_site: `${urlSiteFromSignup}`,
   },
   upgradePlanForm: {
     message_placeholder: `Your message`,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -11,6 +11,9 @@ const urlContact = `${urlSite}/contacto`;
 const urlControlPanel = `${urlDopplerLegacy}/ControlPanel`;
 const urlBuyMonthly = `${urlControlPanel}/AccountPreferences/UpgradeAccount?Plan=monthly`;
 const urlSiteTracking = `${urlControlPanel}/CampaignsPreferences/SiteTrackingSettings`;
+const urlSiteFromSignup = `${urlSite}/?utm_source=app&utm_medium=landing&utm_campaign=signup`;
+const urlSiteFromLogin = `${urlSite}/?utm_source=app&utm_medium=landing&utm_campaign=login`;
+const urlSiteFromForgot = `${urlSite}/?utm_source=app&utm_medium=landing&utm_campaign=restablecimiento-contrasenia`;
 
 export default {
   common: {
@@ -57,6 +60,7 @@ export default {
       `,
     description: `¡No te preocupes! Nos sucede a todos.`,
     description2: `Ingresa tu Email y te ayudaremos.`,
+    url_site: `${urlSiteFromForgot}`,
   },
   header: {
     help_url: `${urlHelp}`,
@@ -72,6 +76,7 @@ export default {
     head_title: `Email Marketing Automation gratis y con envíos ilimitados | Doppler`,
     label_user: `Nombre de Usuario: `,
     signup: `Régistrate gratis`,
+    url_site: `${urlSiteFromLogin}`,
     you_want_create_account: `¿Aún no tienes una cuenta?`,
   },
   reports: {
@@ -205,6 +210,7 @@ export default {
     sign_up: `Email, Automation & Data Marketing`,
     sign_up_sub: `Atrae, Convierte y Fideliza. Envíos ilimitados y gratis hasta 500 Suscriptores.`,
     thanks_for_registering: `Gracias por registrarte`,
+    url_site: `${urlSiteFromSignup}`,
   },
   upgradePlanForm: {
     message_placeholder: `Tu mensaje`,


### PR DESCRIPTION
**Add link to the logo with url by language
It was added in:** 

- Signup (ES/EN)
- Login (ES/EN)
- Forgot Password (ES/EN)

![url](https://user-images.githubusercontent.com/46735526/57530450-a4503600-730d-11e9-982d-17d046d04412.jpg)
