### PR TITLE
feat: add autoFocus property to first field on each form

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -92,6 +92,7 @@ const ForgotPassword = ({ intl, dependencies: { dopplerLegacyClient } }) => {
             <fieldset>
               <FieldGroup>
                 <EmailFieldItem
+                  autoFocus
                   fieldName={fieldNames.email}
                   label={_('signup.label_email')}
                   required

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -148,6 +148,7 @@ const Login = ({ intl, location, dependencies: { dopplerLegacyClient, sessionMan
           <fieldset>
             <FieldGroup>
               <EmailFieldItem
+                autoFocus
                 fieldName={fieldNames.user}
                 label={_('login.label_user')}
                 required

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -151,6 +151,7 @@ const Signup = function({ intl, dependencies: { dopplerLegacyClient, originResol
           <fieldset>
             <FieldGroup>
               <InputFieldItem
+                autoFocus
                 className="field-item--50"
                 fieldName={fieldNames.firstname}
                 label={_('signup.label_firstname')}

--- a/src/components/UpgradePlanForm/UpgradePlanForm.js
+++ b/src/components/UpgradePlanForm/UpgradePlanForm.js
@@ -83,6 +83,7 @@ class UpgradePlanForm extends React.Component {
                       </label>
                       <span className="dropdown-arrow" />
                       <Field
+                        autoFocus
                         component="select"
                         name={fieldNames.selectedPlanId}
                         id={fieldNames.selectedPlanId}


### PR DESCRIPTION
In some places, for example https://davidwalsh.name/react-autofocus, they say that _autoFocus_ is not enough.

However, in some places, for example https://stackoverflow.com/questions/42324423/autofocus-an-input-element-in-react-js#42324485
other said that _autoFocus_ should work.

By the moment, it is working, we can improve it in the future, for example scanning autoFocus fields in FormWithCaptcha or other places.

Could you review?

You could test the build in:

* https://cdn.fromdoppler.com/doppler-webapp/int-build675/#/login
* https://cdn.fromdoppler.com/doppler-webapp/qa-build675/#/login
* https://cdn.fromdoppler.com/doppler-webapp/build675/#/login
