### PR TITLE
feat: do not stop in toggle password visibility icon

### DIFF
--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -384,6 +384,10 @@ const BasePasswordFieldItem = ({ fieldName, label, placeholder, required, ...res
           onClick={() => {
             setPassVisible((current) => !current);
           }}
+          // By the moment we will make it not accessible using keyboard
+          // In the future, we could move after the password input as,
+          // for example, Google does
+          tabIndex="-1"
         >
           <span className="content-eye">
             {' '}


### PR DESCRIPTION
Hi team, 

By the moment, I simply disabled tab stop for password visibility toggle button. 

![2019-05-14_13-42-28 (1)](https://user-images.githubusercontent.com/1157864/57716103-9ae90580-764e-11e9-992c-d2885868c13a.gif)

In the future we could move the tab stop after the input, as Google does:

![2019-05-14_13-44-27 (1)](https://user-images.githubusercontent.com/1157864/57716127-ab00e500-764e-11e9-9f90-321567dab6fe.gif)

Thoughts?