### PR TITLE
fix: issues with line-height and font declaration specificity

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build257/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build259/css/styles.css">
     <link rel="stylesheet" type="text/css" href="zoho-chat.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -45,7 +45,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build257/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build259/js/app.js"></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Bumped library version based on a fix there. 
Currently `<p>` tags have a default line-height value of 22px. Based on my fix, the idea would be to have a dynamic unitless line height value that is proportional to the default line height for 15px of font-size.

NOTE: I've tested this change, and despite of visually changing line heights, I guess it's much better to have a proportional ratio for font-sizes to improve legibility. 

![image](https://user-images.githubusercontent.com/1157864/57734560-83267700-7678-11e9-808d-955513a40e28.png)

![image](https://user-images.githubusercontent.com/1157864/57734857-50c94980-7679-11e9-9c16-94b8e505381c.png)

