### PR TITLE
fix: typo in Attract

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -218,7 +218,7 @@ export default {
     promotions_consent: `Sign me up for promotions about Doppler and allies.`,
     resend_email: `Resent it`,
     sign_up: `Email, Automation & Data Marketing`,
-    sign_up_sub: `Attrack, Engage and Convert. Send unlimited Emails up to 500 Subscribers for free.`,
+    sign_up_sub: `Attract, Engage and Convert. Send unlimited Emails up to 500 Subscribers for free.`,
     thanks_for_registering: `Thank you for registering`,
     url_site: `${urlSiteFromSignup}`,
   },


### PR DESCRIPTION
@carodipietro noticed that we had a typo in Attract word.

It should fix the issue.