### PR TITLE
chore: start using official UI Library versions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/build269/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/v1.0.0/css/styles.css">
     <link rel="stylesheet" type="text/css" href="zoho-chat.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -47,7 +47,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/build269/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/v1.0.0/js/app.js"></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Hi Team, 

This is the counterpart of https://github.com/FromDoppler/Doppler-UI-System/pull/110

From now on, we should start using this kind of version numbers in place of build number. It will improve the traceability, library self-description, and less error-prone code reviews.