### PR TITLE
feat: adjust zoho chat for mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,6 @@
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/v1.1.1/css/styles.css">
-    <link rel="stylesheet" type="text/css" href="zoho-chat.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -49,5 +48,6 @@
     -->
     <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/v1.1.1/js/app.js"></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
+    <link rel="stylesheet" type="text/css" href="zoho-chat.css">
   </body>
 </html>

--- a/public/zoho-chat.css
+++ b/public/zoho-chat.css
@@ -1,3 +1,28 @@
+@media (max-width: 480px) {
+  .zsiq_theme1.zsiq_floatmain.siq_bR .zsiq_flt_rel {
+    width: 50px;
+    height: 50px;
+  }
+
+  .zsiq_theme1.zsiq_floatmain.siq_bR {
+    bottom: 15px;
+    right: 5px;
+  }
+
+  .zsiq_floatmain.siq_bR .zsiq_cnt {
+    visibility: hidden !important;
+  }
+
+  .zsiq_theme1.zsiq_floatmain.siq_bR .zsiq_flt_rel .siqico-chat:before {
+    font-size: 23px;
+    line-height: 50px;
+  }
+  
+  body .zsiq-mobhgt[embedtheme].siqembed {
+    height: 60% !important;
+  }
+}
+
 .zsiq_floatmain.siq_bR {
   bottom: 56px;
   right: 40px;


### PR DESCRIPTION
- Add mediaqueries to adjust zoho chat in mobile
- Move zoho-chat stylesheet to avoid problems with own zoho's styles

![image](https://user-images.githubusercontent.com/10213170/59212154-03f96580-8b88-11e9-8e22-f45a0cc70fc3.png)
