### PR TITLE
Shopify: manage connected/disconnected states

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import RedirectToLegacyUrl from './components/RedirectToLegacyUrl';
 import RedirectWithQuery from './components/RedirectWithQuery';
 import { Helmet } from 'react-helmet';
 import { availableLanguageOrNull } from './i18n/utils';
+import Shopify from './components/Integrations/Shopify/Shopify';
 
 class App extends Component {
   /**
@@ -90,6 +91,7 @@ class App extends Component {
               <RedirectToLegacyUrl to="/Campaigns/Draft" />
             </Route>
             <PrivateRoute path="/reports/" exact requireSiteTracking component={Reports} />
+            <PrivateRoute path="/integrations/shopify" exact component={Shopify} />
             <PublicRouteWithLegacyFallback exact path="/login" />
             <PublicRouteWithLegacyFallback exact path="/signup" />
             <PublicRouteWithLegacyFallback exact path="/login/reset-password" />

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -4,8 +4,8 @@ import HeaderMessages from './HeaderMessages/HeaderMessages';
 import HeaderUserMenu from './HeaderUserMenu/HeaderUserMenu';
 import { FormattedMessage } from 'react-intl';
 
-const Header = ({ userData: { user, nav, alert }, location: {pathname} }) => {
-  const inactiveSection = pathname.match(/^\/integrations\/*/) !== null; 
+const Header = ({ userData: { user, nav, alert }, location: { pathname } }) => {
+  const inactiveSection = pathname.match(/^\/integrations\/*/) !== null;
   return (
     <div>
       {alert ? <HeaderMessages alert={alert} user={user} /> : null}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -4,14 +4,20 @@ import HeaderMessages from './HeaderMessages/HeaderMessages';
 import HeaderUserMenu from './HeaderUserMenu/HeaderUserMenu';
 import { FormattedMessage } from 'react-intl';
 
-const Header = ({ userData: { user, nav, alert } }) => {
+const Header = ({ userData: { user, nav, alert }, location: {pathname} }) => {
+  const inactiveSection = pathname.match(/^\/integrations\/*/) !== null; 
   return (
     <div>
       {alert ? <HeaderMessages alert={alert} user={user} /> : null}
       {/* //TODO: Refactor backend to send proper active values. Class 'header-is-active' must be removed */}
       <header
         className={
-          user.clientManager ? 'header-main header-open dp-header--cm' : 'header-main header-open'
+          'header-main' +
+          (!inactiveSection
+            ? user.clientManager
+              ? ' header-open dp-header--cm'
+              : ' header-open'
+            : '')
         }
       >
         {user.clientManager ? (
@@ -28,7 +34,7 @@ const Header = ({ userData: { user, nav, alert } }) => {
           <div className="logo">
             <span className="ms-icon icon-doppler-logo" />
           </div>
-          <HeaderNav nav={nav} />
+          <HeaderNav nav={nav} inactiveSection={inactiveSection} />
           <nav className="nav-right-main">
             <ul className="nav-right-main--list">
               <li>

--- a/src/components/Header/HeaderNav/HeaderNav.js
+++ b/src/components/Header/HeaderNav/HeaderNav.js
@@ -11,10 +11,13 @@ const HeaderNav = ({ nav, inactiveSection }) => {
                 {item.title}
               </a>
               {item.subNav.length ? (
-                <ul className={'sub-menu' + (item.isSelected && !inactiveSection  ? ' open' : '')}>
+                <ul className={'sub-menu' + (item.isSelected && !inactiveSection ? ' open' : '')}>
                   {item.subNav.map((itemSubNav, index) => (
                     <li key={index}>
-                      <a className={itemSubNav.isSelected && !inactiveSection ? 'active' : ''} href={itemSubNav.url}>
+                      <a
+                        className={itemSubNav.isSelected && !inactiveSection ? 'active' : ''}
+                        href={itemSubNav.url}
+                      >
                         {itemSubNav.title}
                       </a>
                     </li>

--- a/src/components/Header/HeaderNav/HeaderNav.js
+++ b/src/components/Header/HeaderNav/HeaderNav.js
@@ -1,20 +1,20 @@
 import React from 'react';
 
-const HeaderNav = ({ nav }) => {
+const HeaderNav = ({ nav, inactiveSection }) => {
   return (
     <nav className="nav-left-main">
       <div className="menu-main--container">
         <ul className="menu-main">
           {nav.map((item, index) => (
             <li className={item.subNav.length ? 'submenu-item' : ''} key={index}>
-              <a className={item.isSelected ? 'active' : ''} href={item.url}>
+              <a className={item.isSelected && !inactiveSection ? 'active' : ''} href={item.url}>
                 {item.title}
               </a>
               {item.subNav.length ? (
-                <ul className={'sub-menu' + (item.isSelected ? ' open' : '')}>
+                <ul className={'sub-menu' + (item.isSelected && !inactiveSection  ? ' open' : '')}>
                   {item.subNav.map((itemSubNav, index) => (
                     <li key={index}>
-                      <a className={itemSubNav.isSelected ? 'active' : ''} href={itemSubNav.url}>
+                      <a className={itemSubNav.isSelected && !inactiveSection ? 'active' : ''} href={itemSubNav.url}>
                         {itemSubNav.title}
                       </a>
                     </li>

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -6,44 +6,45 @@ import Loading from '../../Loading/Loading';
 const shopifyClient = new HardcodedShopifyClient();
 
 const Shopify = () => {
-  const [shopName, setShopName] = useState(null);
+  const [shopName, setShopName] = useState('');
+  const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
   useEffect(() => {
     const getData = async () => {
       const result = await shopifyClient.getShopifyData();
       if (result.success && result.value.length) {
+        setIsConnected(true);
         setShopName(result.value[0].shopName);
-      } else if (result.success) {
-        setShopName('');
       } else if (
         !result.success &&
         result.expectedError &&
         result.expectedError.cannotConnectToAPI
       ) {
         setError('Error: No hemos podido conectar con la Api de Shopify, vuelve a intentar luego.');
-      } else {
+      } else if (!result.success) {
         setError('Error: Error inesperado.');
       }
+      setIsLoading(false);
     };
     getData();
   }, []);
 
   return (
     <>
-      <Helmet>
-        <title>Doppler | Shopify</title>
-      </Helmet>
+      <Helmet title={'Doppler | Shopify'} />
       <section style={{ width: '100%', padding: '60px 30px' }}>
         Panel de control | Integraciones y preferencias avanzadas
         <h1>Panel de Control - Shopify</h1>
-        {shopName === null && error === null ? (
+        {isLoading ? (
           <Loading />
-        ) : shopName !== null && shopName.length ? (
-          'Shopify conectado a tienda: ' + shopName
-        ) : error === null ? (
-          'Shopify desconectado'
-        ) : (
+        ) : error ? (
           error
+        ) : isConnected ? (
+          'Shopify conectado a tienda: ' + shopName
+        ) : (
+          'Shopify desconectado'
         )}
       </section>
     </>

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -12,17 +12,13 @@ const Shopify = ({ dependencies: { shopifyClient } }) => {
   useEffect(() => {
     const getData = async () => {
       const result = await shopifyClient.getShopifyData();
-      if (result.success && result.value.length) {
-        setIsConnected(true);
-        setShops(result.value);
-      } else if (
-        !result.success &&
-        result.expectedError &&
-        result.expectedError.cannotConnectToAPI
-      ) {
+      if (result.expectedError && result.expectedError.cannotConnectToAPI) {
         setError('Error: No hemos podido conectar con la Api de Shopify, vuelve a intentar luego.');
       } else if (!result.success) {
         setError('Error: Error inesperado.');
+      } else if (result.value.length) {
+        setIsConnected(true);
+        setShops(result.value);
       }
       setIsLoading(false);
     };
@@ -32,6 +28,7 @@ const Shopify = ({ dependencies: { shopifyClient } }) => {
   return (
     <>
       <Helmet title={'Doppler | Shopify'} />
+      {/* inline style will be removed in next PR */}
       <section style={{ width: '100%', padding: '60px 30px' }}>
         Panel de control | Integraciones y preferencias avanzadas
         <h1>Panel de Control - Shopify</h1>

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import Loading from '../../Loading/Loading';
-import {InjectAppServices} from '../../../services/pure-di'
+import { InjectAppServices } from '../../../services/pure-di';
 
-const Shopify = ({dependencies: {shopifyClient} }) => {
+const Shopify = ({ dependencies: { shopifyClient } }) => {
   const [shops, setShops] = useState([]);
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState(null);
@@ -38,7 +38,7 @@ const Shopify = ({dependencies: {shopifyClient} }) => {
         {isLoading ? (
           <Loading />
         ) : error ? (
-          error
+          <p>{error}</p>
         ) : isConnected ? (
           <>
             <p>Shopify conectado a: </p>
@@ -49,7 +49,7 @@ const Shopify = ({dependencies: {shopifyClient} }) => {
             </ul>
           </>
         ) : (
-          'Shopify desconectado'
+          <p>Shopify desconectado</p>
         )}
       </section>
     </>

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { HardcodedShopifyClient } from '../../../services/shopify-client.doubles';
 import Loading from '../../Loading/Loading';
+import {InjectAppServices} from '../../../services/pure-di'
 
-const shopifyClient = new HardcodedShopifyClient();
-
-const Shopify = () => {
+const Shopify = ({dependencies: {shopifyClient} }) => {
   const [shops, setShops] = useState([]);
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState(null);
@@ -58,4 +56,4 @@ const Shopify = () => {
   );
 };
 
-export default Shopify;
+export default InjectAppServices(Shopify);

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+import { HardcodedShopifyClient } from '../../../services/shopify-client.doubles';
+import Loading from '../../Loading/Loading';
+
+const shopifyClient = new HardcodedShopifyClient();
+
+const Shopify = () => {
+  const [shopName, setShopName] = useState(null);
+  useEffect(() => {
+    const getData = async () => {
+      const result = await shopifyClient.getShopifyData();
+      if (result.length) {
+        setShopName(result[0].shopName);
+      } else {
+        setShopName('');
+      }
+    };
+    getData();
+  }, []);
+
+  return (
+    <>
+      <Helmet>
+        <title>Doppler | Shopify</title>
+      </Helmet>
+      <section style={{ width: '100%', padding: '60px 30px' }}>
+        Panel de control | Integraciones y preferencias avanzadas
+        <h1>Panel de Control - Shopify</h1>
+        {shopName === null ? (
+          <Loading />
+        ) : shopName.length ? (
+          'Shopify conectado a tienda: ' + shopName
+        ) : (
+          'Shopify desconectado'
+        )}
+      </section>
+    </>
+  );
+};
+
+export default Shopify;

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -27,7 +27,7 @@ const Shopify = ({ dependencies: { shopifyClient } }) => {
       setIsLoading(false);
     };
     getData();
-  }, []);
+  }, [shopifyClient]);
 
   return (
     <>

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -7,13 +7,22 @@ const shopifyClient = new HardcodedShopifyClient();
 
 const Shopify = () => {
   const [shopName, setShopName] = useState(null);
+  const [error, setError] = useState(null);
   useEffect(() => {
     const getData = async () => {
       const result = await shopifyClient.getShopifyData();
-      if (result.length) {
-        setShopName(result[0].shopName);
-      } else {
+      if (result.success && result.value.length) {
+        setShopName(result.value[0].shopName);
+      } else if (result.success) {
         setShopName('');
+      } else if (
+        !result.success &&
+        result.expectedError &&
+        result.expectedError.cannotConnectToAPI
+      ) {
+        setError('Error: No hemos podido conectar con la Api de Shopify, vuelve a intentar luego.');
+      } else {
+        setError('Error: Error inesperado.');
       }
     };
     getData();
@@ -27,12 +36,14 @@ const Shopify = () => {
       <section style={{ width: '100%', padding: '60px 30px' }}>
         Panel de control | Integraciones y preferencias avanzadas
         <h1>Panel de Control - Shopify</h1>
-        {shopName === null ? (
+        {shopName === null && error === null ? (
           <Loading />
-        ) : shopName.length ? (
+        ) : shopName !== null && shopName.length ? (
           'Shopify conectado a tienda: ' + shopName
-        ) : (
+        ) : error === null ? (
           'Shopify desconectado'
+        ) : (
+          error
         )}
       </section>
     </>

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -46,7 +46,7 @@ const Shopify = () => {
             <p>Shopify conectado a: </p>
             <ul>
               {shops.map((shop) => (
-                <li> {shop.shopName} </li>
+                <li key={shop.shopName}> {shop.shopName} </li>
               ))}{' '}
             </ul>
           </>

--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -6,7 +6,7 @@ import Loading from '../../Loading/Loading';
 const shopifyClient = new HardcodedShopifyClient();
 
 const Shopify = () => {
-  const [shopName, setShopName] = useState('');
+  const [shops, setShops] = useState([]);
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -16,7 +16,7 @@ const Shopify = () => {
       const result = await shopifyClient.getShopifyData();
       if (result.success && result.value.length) {
         setIsConnected(true);
-        setShopName(result.value[0].shopName);
+        setShops(result.value);
       } else if (
         !result.success &&
         result.expectedError &&
@@ -42,7 +42,14 @@ const Shopify = () => {
         ) : error ? (
           error
         ) : isConnected ? (
-          'Shopify conectado a tienda: ' + shopName
+          <>
+            <p>Shopify conectado a: </p>
+            <ul>
+              {shops.map((shop) => (
+                <li> {shop.shopName} </li>
+              ))}{' '}
+            </ul>
+          </>
         ) : (
           'Shopify desconectado'
         )}

--- a/src/components/Integrations/Shopify/Shopify.test.js
+++ b/src/components/Integrations/Shopify/Shopify.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, cleanup, waitForDomChange, wait, act } from 'react-testing-library';
+import { render, cleanup, waitForDomChange } from '@testing-library/react';
 import 'jest-dom/extend-expect';
 import DopplerIntlProvider from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
 import { AppServicesProvider } from '../../../services/pure-di';

--- a/src/components/Integrations/Shopify/Shopify.test.js
+++ b/src/components/Integrations/Shopify/Shopify.test.js
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, cleanup, waitForDomChange, wait, act } from 'react-testing-library';
+import 'jest-dom/extend-expect';
+import DopplerIntlProvider from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+import { AppServicesProvider } from '../../../services/pure-di';
+import Shopify from './Shopify';
+
+const oneShop = [
+  {
+    shopName: 'myshop.com',
+    synchronization_date: new Date('2017-12-17'),
+    list: {
+      name: 'MyList',
+      id: 1251,
+      amountSubscribers: 2,
+      state: 'SubscriberListState.ready',
+    },
+  },
+];
+const twoShops = [
+  {
+    shopName: 'myshop.com',
+    synchronization_date: new Date('2017-12-17'),
+    list: {
+      name: 'MyList',
+      id: 1251,
+      amountSubscribers: 2,
+      state: 'SubscriberListState.ready',
+    },
+  },
+  {
+    shopName: 'myshop2.com',
+    synchronization_date: new Date('2017-12-17'),
+    list: {
+      name: 'MyList',
+      id: 1251,
+      amountSubscribers: 2,
+      state: 'SubscriberListState.ready',
+    },
+  },
+];
+
+const emptyResponse = { success: true, value: [] };
+const oneShopConnected = { success: true, value: oneShop };
+const moreThanOneShopConnected = { success: true, value: twoShops };
+const expectedErrorResponse = { success: false, expectedError: { cannotConnectToAPI: true } };
+const unexpectedErrorResponse = { success: false, message: 'Some random error' };
+
+describe('Shopify Component', () => {
+  afterEach(cleanup);
+
+  it('should show not connected user data', async () => {
+    const shopifyClientDouble = {
+      getShopifyData: async () => emptyResponse,
+    };
+    const { container, getByText } = render(
+      <AppServicesProvider
+        forcedServices={{
+          shopifyClient: shopifyClientDouble,
+        }}
+      >
+        <DopplerIntlProvider>
+          <Shopify />
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+    expect(container.querySelector('.loading-box')).toBeInTheDocument();
+    await waitForDomChange();
+    expect(getByText('Shopify desconectado'));
+  });
+
+  it('should manage expected error', async () => {
+    const shopifyClientDouble = {
+      getShopifyData: async () => expectedErrorResponse,
+    };
+    const { container, getByText } = render(
+      <AppServicesProvider
+        forcedServices={{
+          shopifyClient: shopifyClientDouble,
+        }}
+      >
+        <DopplerIntlProvider>
+          <Shopify />
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+    expect(container.querySelector('.loading-box')).toBeInTheDocument();
+    await waitForDomChange();
+    expect(
+      getByText('Error: No hemos podido conectar con la Api de Shopify, vuelve a intentar luego.'),
+    );
+  });
+
+  it('should get connected user with one shop', async () => {
+    const shopifyClientDouble = {
+      getShopifyData: async () => oneShopConnected,
+    };
+    const { container, getByText } = render(
+      <AppServicesProvider
+        forcedServices={{
+          shopifyClient: shopifyClientDouble,
+        }}
+      >
+        <DopplerIntlProvider>
+          <Shopify />
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+    expect(container.querySelector('.loading-box')).toBeInTheDocument();
+    await waitForDomChange();
+    expect(getByText(oneShopConnected.value[0].shopName));
+  });
+
+  it('should get connected user with more than one shop', async () => {
+    const shopifyClientDouble = {
+      getShopifyData: async () => moreThanOneShopConnected,
+    };
+    const { container, getByText } = render(
+      <AppServicesProvider
+        forcedServices={{
+          shopifyClient: shopifyClientDouble,
+        }}
+      >
+        <DopplerIntlProvider>
+          <Shopify />
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+    expect(container.querySelector('.loading-box')).toBeInTheDocument();
+    await waitForDomChange();
+    expect(getByText(moreThanOneShopConnected.value[0].shopName));
+    expect(getByText(moreThanOneShopConnected.value[1].shopName));
+  });
+
+  it('should manage unexpected errors', async () => {
+    const shopifyClientDouble = {
+      getShopifyData: async () => unexpectedErrorResponse,
+    };
+    const { container, getByText } = render(
+      <AppServicesProvider
+        forcedServices={{
+          shopifyClient: shopifyClientDouble,
+        }}
+      >
+        <DopplerIntlProvider>
+          <Shopify />
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+    expect(container.querySelector('.loading-box')).toBeInTheDocument();
+    await waitForDomChange();
+    expect(getByText('Error: Error inesperado.'));
+  });
+});

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -32,7 +32,7 @@ export default InjectAppServices(
           <Loading page />
         ) : dopplerSession.status === 'authenticated' ? (
           <>
-            <Header userData={dopplerSession.userData} />
+            <Header userData={dopplerSession.userData} location={props.location} />
             {requireSiteTracking &&
             !dopplerSession.userData.features.siteTrackingEnabled &&
             !dopplerSession.userData.user.plan.isFreeAccount ? (

--- a/src/doppler-types.ts
+++ b/src/doppler-types.ts
@@ -1,0 +1,9 @@
+export type UnexpectedError = { success?: false; message?: string | null; error?: any };
+export type ErrorResult<TError> = { success?: false; expectedError: TError } | UnexpectedError;
+export type Result<TResult, TError> = { success: true; value: TResult } | ErrorResult<TError>;
+export type EmptyResult<TError> = { success: true } | ErrorResult<TError>;
+// It does not work:
+// type EmptyResult = { success: true } | UnexpectedError;
+// Duplicate identifier 'EmptyResult'.ts(2300)
+// TODO: Research how to fix it and rename EmptyResultWithoutExpectedErrors as EmptyResult
+export type EmptyResultWithoutExpectedErrors = { success: true } | UnexpectedError;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import { polyfill } from 'es6-object-assign';
 import 'polyfill-array-includes';
 import 'promise-polyfill/src/polyfill';
 import { availableLanguageOrDefault } from './i18n/utils';
+import { HardcodedShopifyClient } from './services/shopify-client.doubles';
 
 polyfill();
 
@@ -29,6 +30,7 @@ const forcedServices =
     ? {
         dopplerLegacyClient: new HardcodedDopplerLegacyClient(),
         datahubClient: new HardcodedDatahubClient(),
+        shopifyClient: new HardcodedShopifyClient()
       }
     : {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ const forcedServices =
     ? {
         dopplerLegacyClient: new HardcodedDopplerLegacyClient(),
         datahubClient: new HardcodedDatahubClient(),
-        shopifyClient: new HardcodedShopifyClient()
+        shopifyClient: new HardcodedShopifyClient(),
       }
     : {};
 

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance, AxiosStatic } from 'axios';
 import { Color } from 'csstype';
+import { Result, EmptyResult, EmptyResultWithoutExpectedErrors } from '../doppler-types';
 
 export interface DopplerLegacyClient {
   getUserData(): Promise<DopplerLegacyUserData>;
@@ -11,17 +12,6 @@ export interface DopplerLegacyClient {
   activateSiteTrackingTrial(): Promise<void>;
   sendResetPasswordEmail(forgotPasswordModel: ForgotPasswordModel): Promise<ForgotPasswordResult>;
 }
-
-// TODO: move it a common place if it will be reused
-type UnexpectedError = { success?: false; message?: string | null; error?: any };
-type ErrorResult<TError> = { success?: false; expectedError: TError } | UnexpectedError;
-type Result<TResult, TError> = { success: true; value: TResult } | ErrorResult<TError>;
-type EmptyResult<TError> = { success: true } | ErrorResult<TError>;
-// It does not work:
-// type EmptyResult = { success: true } | UnexpectedError;
-// Duplicate identifier 'EmptyResult'.ts(2300)
-// TODO: Research how to fix it and rename EmptyResultWithoutExpectedErrors as EmptyResult
-type EmptyResultWithoutExpectedErrors = { success: true } | UnexpectedError;
 
 interface PayloadWithCaptchaToken {
   captchaResponseToken: string;

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -5,6 +5,8 @@ import React, { createContext, ReactNode, RefObject, MutableRefObject } from 're
 import { DatahubClient, HttpDatahubClient } from './datahub-client';
 import { AppSession, createAppSessionRef } from './app-session';
 import { OriginResolver, LocalStorageOriginResolver } from './origin-management';
+import { ShopifyClient } from './shopify-client';
+import { HardcodedShopifyClient } from './shopify-client.doubles';
 
 interface AppConfiguration {
   dopplerLegacyUrl: string;
@@ -31,6 +33,7 @@ export interface AppServices {
   sessionManager: SessionManager;
   localStorage: Storage;
   originResolver: OriginResolver;
+  shopifyClient: ShopifyClient;
 }
 
 /**
@@ -96,6 +99,14 @@ export class AppCompositionRoot implements AppServices {
           axiosStatic: this.axiosStatic,
           baseUrl: this.appConfiguration.dopplerLegacyUrl,
         }),
+    );
+  }
+
+  get shopifyClient() {
+    return this.singleton(
+      'shopifyClient',
+      () =>
+        new HardcodedShopifyClient(),
     );
   }
 

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -103,11 +103,7 @@ export class AppCompositionRoot implements AppServices {
   }
 
   get shopifyClient() {
-    return this.singleton(
-      'shopifyClient',
-      () =>
-        new HardcodedShopifyClient(),
-    );
+    return this.singleton('shopifyClient', () => new HardcodedShopifyClient());
   }
 
   get sessionManager() {

--- a/src/services/shopify-client.doubles.ts
+++ b/src/services/shopify-client.doubles.ts
@@ -20,7 +20,7 @@ const oneShop = [
   },
 ];
 
-const twoShops = [
+/*const twoShops = [
   {
     shopName: 'myshop.com',
     synchronization_date: new Date('2017-12-17'),
@@ -41,7 +41,7 @@ const twoShops = [
       state: SubscriberListState.ready,
     },
   },
-];
+];*/
 
 export class HardcodedShopifyClient implements ShopifyClient {
   public async getShopifyData(): Promise<Result<ConnectedShop[], ShopifyErrorResult>> {

--- a/src/services/shopify-client.doubles.ts
+++ b/src/services/shopify-client.doubles.ts
@@ -1,5 +1,11 @@
-import { ShopifyClient, SubscriberListState, ConnectedShops } from './shopify-client';
+import {
+  ShopifyClient,
+  SubscriberListState,
+  ConnectedShop,
+  ShopifyErrorResult,
+} from './shopify-client';
 import { timeout } from '../utils';
+import { Result } from '../doppler-types';
 
 const fakeData = [
   {
@@ -15,9 +21,11 @@ const fakeData = [
 ];
 
 export class HardcodedShopifyClient implements ShopifyClient {
-  public async getShopifyData(): Promise<ConnectedShops[]> {
+  public async getShopifyData(): Promise<Result<ConnectedShop[], ShopifyErrorResult>> {
     console.log('getShopifyData');
     await timeout(1500);
-    return fakeData;
+    //return {success: false, message: 'Some random error'};
+    //return {success: false, expectedError: {cannotConnectToAPI: true}};
+    return { success: true, value: fakeData };
   }
 }

--- a/src/services/shopify-client.doubles.ts
+++ b/src/services/shopify-client.doubles.ts
@@ -7,9 +7,32 @@ import {
 import { timeout } from '../utils';
 import { Result } from '../doppler-types';
 
-const fakeData = [
+const oneShop = [
   {
     shopName: 'myshop.com',
+    synchronization_date: new Date('2017-12-17'),
+    list: {
+      name: 'MyList',
+      id: 1251,
+      amountSubscribers: 2,
+      state: SubscriberListState.ready,
+    },
+  },
+];
+
+const twoShops = [
+  {
+    shopName: 'myshop.com',
+    synchronization_date: new Date('2017-12-17'),
+    list: {
+      name: 'MyList',
+      id: 1251,
+      amountSubscribers: 2,
+      state: SubscriberListState.ready,
+    },
+  },
+  {
+    shopName: 'myshop2.com',
     synchronization_date: new Date('2017-12-17'),
     list: {
       name: 'MyList',
@@ -26,7 +49,8 @@ export class HardcodedShopifyClient implements ShopifyClient {
     await timeout(1500);
     //return {success: false, message: 'Some random error'};
     //return {success: false, expectedError: {cannotConnectToAPI: true}};
-    return { success: true, value: fakeData };
+    //return { success: true, value: twoShops };
+    return { success: true, value: oneShop };
     //return { success: true, value:[]};
   }
 }

--- a/src/services/shopify-client.doubles.ts
+++ b/src/services/shopify-client.doubles.ts
@@ -27,5 +27,6 @@ export class HardcodedShopifyClient implements ShopifyClient {
     //return {success: false, message: 'Some random error'};
     //return {success: false, expectedError: {cannotConnectToAPI: true}};
     return { success: true, value: fakeData };
+    //return { success: true, value:[]};
   }
 }

--- a/src/services/shopify-client.doubles.ts
+++ b/src/services/shopify-client.doubles.ts
@@ -1,0 +1,23 @@
+import { ShopifyClient, SubscriberListState, ConnectedShops } from './shopify-client';
+import { timeout } from '../utils';
+
+const fakeData = [
+  {
+    shopName: 'myshop.com',
+    synchronization_date: new Date('2017-12-17'),
+    list: {
+      name: 'MyList',
+      id: 1251,
+      amountSubscribers: 2,
+      state: SubscriberListState.ready,
+    },
+  },
+];
+
+export class HardcodedShopifyClient implements ShopifyClient {
+  public async getShopifyData(): Promise<ConnectedShops[]> {
+    console.log('getShopifyData');
+    await timeout(1500);
+    return fakeData;
+  }
+}

--- a/src/services/shopify-client.ts
+++ b/src/services/shopify-client.ts
@@ -1,0 +1,21 @@
+export enum SubscriberListState {
+  ready,
+  synchronizingContacts,
+}
+
+export interface SubscriberList {
+  name: string;
+  id: number;
+  amountSubscribers: number;
+  state: SubscriberListState;
+}
+
+export interface ConnectedShops {
+  shopName: string;
+  synchronization_date: Date | null;
+  list: SubscriberList;
+}
+
+export interface ShopifyClient {
+  getShopifyData(): Promise<ConnectedShops[]>;
+}

--- a/src/services/shopify-client.ts
+++ b/src/services/shopify-client.ts
@@ -1,3 +1,4 @@
+import { Result } from '../doppler-types';
 export enum SubscriberListState {
   ready,
   synchronizingContacts,
@@ -10,12 +11,13 @@ export interface SubscriberList {
   state: SubscriberListState;
 }
 
-export interface ConnectedShops {
+export interface ConnectedShop {
   shopName: string;
   synchronization_date: Date | null;
   list: SubscriberList;
 }
 
+export type ShopifyErrorResult = { cannotConnectToAPI: true };
 export interface ShopifyClient {
-  getShopifyData(): Promise<ConnectedShops[]>;
+  getShopifyData(): Promise<Result<ConnectedShop[], ShopifyErrorResult>>;
 }


### PR DESCRIPTION
Shopify section:
- Add Shopify client and shopify hardcoded client
- Add tests
- Add view with title only, access via /#/integrations/shopify
- Add header without section

![image](https://user-images.githubusercontent.com/2439363/60031288-d5e14e80-967a-11e9-9928-8e1307782f77.png)


https://cdn.fromdoppler.com/doppler-webapp/build883/#/integrations/shopify