### PR TITLE
fix: add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+build
+.vscode
+*.log
+.git


### PR DESCRIPTION
It seems that we were copying all the files (including `node_modules`) to the container that generates the build, so, we were including unnecessary and probably wrong files.

Could you verify and let me know if do you think that other files could be ignored?

(I will merge it soon, but we can improve it later anyway)
