### PR TITLE
fix: Promotions default color

### DIFF
--- a/src/components/shared/Promotions/Promotions.js
+++ b/src/components/shared/Promotions/Promotions.js
@@ -12,7 +12,7 @@ const getDefaultBannerData = (intl) => {
     backgroundUrl: _('default_banner_data.background_url'),
     imageUrl: _('default_banner_data.image_url'),
     functionality: _('default_banner_data.functionality'),
-    fontColor: '#000',
+    fontColor: '#FFF',
   };
 };
 


### PR DESCRIPTION
https://makingsense.slack.com/archives/CGJ72QFQX/p1561667402133100?thread_ts=1561662983.122200&cid=CGJ72QFQX

> irodrigues  [9 minutes ago]
> @fcoronel esta bien que la fuente sea negra https://app.fromdoppler.com/#/signup ?

before: https://cdn.fromdoppler.com/doppler-webapp/build936/#/login
after: https://cdn.fromdoppler.com/doppler-webapp/build937/#/login