### PR TITLE
Change the default name in manifest for Doppler

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Doppler",
+  "name": "Doppler",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
Remplace name in manifest.json for Doppler.
![ezgif-5-3625b76b7e71](https://user-images.githubusercontent.com/22848246/60299675-ac872380-9903-11e9-907e-dcb21dc6b795.gif)

