### PR TITLE
Dbr 341 header fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     -->
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/v3.1.1/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.fromdoppler.com/doppler-ui-library/v3.2.1/css/styles.css">
     <link rel="stylesheet" type="text/css" href="zoho-chat.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -47,7 +47,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/v3.1.1/js/app.js"></script>
+    <script type="text/javascript" src="https://cdn.fromdoppler.com/doppler-ui-library/v3.2.1/js/app.js"></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
     <link rel="stylesheet" type="text/css" href="zoho-chat.css">
   </body>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -17,11 +17,8 @@ const Header = ({
       <header
         className={
           'header-main' +
-          (!inactiveSection
-            ? user.clientManager
-              ? ' header-open dp-header--cm'
-              : ' header-open'
-            : '')
+          (inactiveSection ? ' ' : ' header-open') +
+          (user.clientManager ? ' dp-header--cm' : ' ')
         }
       >
         {user.clientManager ? (

--- a/src/headerData-for-client-manager-user.json
+++ b/src/headerData-for-client-manager-user.json
@@ -1,0 +1,194 @@
+{
+  "nav": [
+    {
+      "title": "Campañas",
+      "url": "https://app2.fromdoppler.com/Campaigns/Draft/",
+      "isEnabled": false,
+      "isSelected": false,
+      "subNav": [
+        {
+          "title": "Borradores",
+          "url": "https://app2.fromdoppler.com/Campaigns/Draft/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "campaignDraftMenu"
+        },
+        {
+          "title": "Programadas",
+          "url": "https://app2.fromdoppler.com/Campaigns/Scheduled/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "campaignScheduledMenu"
+        },
+        {
+          "title": "Enviadas",
+          "url": "https://app2.fromdoppler.com/Campaigns/Sent/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "campaignSentMenu"
+        },
+        {
+          "title": "Test A/B",
+          "url": "https://app2.fromdoppler.com/Campaigns/TestAB/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "campaignTestABMenu"
+        }
+      ],
+      "idHTML": "campaignMenu"
+    },
+    {
+      "title": "Listas",
+      "url": "https://app2.fromdoppler.com/Lists/SubscribersList",
+      "isEnabled": false,
+      "isSelected": false,
+      "subNav": [
+        {
+          "title": "Listas Principales",
+          "url": "https://app2.fromdoppler.com/Lists/SubscribersList/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "listMainMenu"
+        },
+        {
+          "title": "Segmentos",
+          "url": "https://app2.fromdoppler.com/Lists/Segment/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "listSegmentMenu"
+        },
+        {
+          "title": "Suscriptores",
+          "url": "https://app2.fromdoppler.com/Lists/MasterSubscriber/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "listMasterSubscriberMenu"
+        },
+        {
+          "title": "Campos Personalizados",
+          "url": "https://app2.fromdoppler.com/Lists/MasterCustomFields/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "listCustomFieldMenu"
+        },
+        {
+          "title": "Formularios",
+          "url": "https://app2.fromdoppler.com/Lists/Form/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "listFormMenu"
+        }
+      ],
+      "idHTML": "listMenu"
+    },
+    {
+      "title": "Reportes",
+      "url": "https://app2.fromdoppler.com/Campaigns/Reports/",
+      "isEnabled": false,
+      "isSelected": false,
+      "subNav": [
+        {
+          "title": "Campañas Enviadas",
+          "url": "https://app2.fromdoppler.com/Campaigns/Reports/",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "reportsSentCampaign"
+        },
+        {
+          "title": "Historial del Suscriptor",
+          "url": "https://app2.fromdoppler.com/Campaigns/Reports/?redirect=subHistory",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "reportsSubsHistory"
+        },
+        {
+          "title": "Avanzados",
+          "url": "https://app.fromdoppler.com/#/reports",
+          "isEnabled": false,
+          "isSelected": false,
+          "idHTML": "webapp"
+        }
+      ],
+      "idHTML": "reportMenu"
+    },
+    {
+      "title": "Automation",
+      "url": "https://app2.fromdoppler.com/Automation/Automation/AutomationApp/",
+      "isEnabled": false,
+      "isSelected": false,
+      "subNav": [],
+      "idHTML": "automationMenu"
+    },
+    {
+      "title": "Plantillas",
+      "url": "https://app2.fromdoppler.com/Templates/Main/",
+      "isEnabled": false,
+      "isSelected": false,
+      "idHTML": "templateMenu"
+    }
+  ],
+  "user": {
+    "email": "cbernat@getcs.com",
+    "fullname": "Cecilia Bernat",
+    "plan": {
+      "planType": "5",
+      "description": "Emails disponibles",
+      "itemDescription": "Emails",
+      "planName": "Plan Mensual ",
+      "isSubscribers": "false",
+      "isMonthlyByEmail": "true",
+      "maxSubscribers": "0",
+      "remainingCredits": "0",
+      "buttonText": "COMPRAR"
+    },
+    "lang": "es",
+    "clientManager": {
+      "logo": "https://app2.dopplerfiles.com/ClientManagers/6/ClientLogo/logo_6.png",
+      "companyName": "Making Sense Tandil",
+      "isCmReseller": false
+    },
+    "avatar": {
+      "text": "CB",
+      "color": "#B58FC1"
+    },
+    "nav": [
+      {
+        "title": "Panel de Control",
+        "url": "https://app2.fromdoppler.com/ControlPanel/ControlPanel/",
+        "isEnabled": false,
+        "isSelected": false,
+        "idHTML": "controlPanel"
+      },
+      {
+        "title": "Centro de descargas",
+        "url": "https://app2.fromdoppler.com/DownloadCenter/DownloadCenter",
+        "isEnabled": false,
+        "isSelected": false,
+        "idHTML": "downloadCenter"
+      },
+      {
+        "title": "Primeros pasos en Doppler",
+        "url": "https://app2.fromdoppler.com/Steps/FirstSteps",
+        "isEnabled": false,
+        "isSelected": false,
+        "idHTML": "firstSteps"
+      },
+      {
+        "title": "Salir",
+        "url": "https://app2.fromdoppler.com/SignIn/SignOut",
+        "isEnabled": false,
+        "isSelected": false,
+        "idHTML": "signOut"
+      }
+    ]
+  },
+  "homeUrl": "https://app2.fromdoppler.com/Campaigns/Draft/",
+  "urlBase": "https://app2.fromdoppler.com/",
+  "features": {
+    "siteTrackingEnabled": false,
+    "siteTrackingActive": false,
+    "emailParameterEnabled": false,
+    "emailParameterActive": false
+  },
+  "jwtToken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1N1IjpmYWxzZSwic3ViIjoiY2Jlcm5hdEBnZXRjcy5jb20iLCJjdXN0b21lcklkIjpudWxsLCJkYXRhaHViQ3VzdG9tZXJJZCI6bnVsbCwiaWF0IjoxNTYxOTgyMjA1LCJleHAiOjE1NjE5ODQwMDV9.RFZSbqCQ0AlG1vcOAvq_24LH8vcp7yd3K6j9kOxMQz67WoeVVcx5fXus_iTDi8rOoJYrLPOEMXI419bU5eQ0sw"
+}


### PR DESCRIPTION
- Add fixes for client manager when inactive section, so logo can be seen in shopify

![image](https://user-images.githubusercontent.com/2439363/60445518-be174680-9bf5-11e9-9d7c-9d983f48c551.png)

- Also add client manager user json, for quick testing

Related to https://github.com/FromDoppler/Doppler-UI-System/pull/129

https://cdn.fromdoppler.com/doppler-webapp/build942/#/integrations/shopify