### PR TITLE
fix: remove description in reports pages ranking

### DIFF
--- a/src/components/Reports/ReportsPageRanking/ReportsPageRanking.js
+++ b/src/components/Reports/ReportsPageRanking/ReportsPageRanking.js
@@ -76,9 +76,6 @@ class ReportsPageRanking extends React.Component {
             <div className="reports-box">
               <h4 className="title-ranking">
                 <FormattedMessage id="reports_pageranking.top_pages" />
-                <small>
-                  <FormattedMessage id="reports_pageranking.top_pages_sub_head" />
-                </small>
               </h4>
 
               {pages.map((item, index) => (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8861133/60976386-35825f80-a2f3-11e9-9613-11e23759fb10.png)
