### PR TITLE
feat: allow custom tracking for datahub

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-scripts": "^3.0.1",
     "semantic-release": "^15.13.18",
     "styled-components": "^4.3.2",
-    "typescript": "^3.5.3"
+    "typescript": "^3.5.3",
+    "url-parse": "^1.4.7"
   },
   "homepage": ".",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Doppler</title>
-    <script type="text/javascript" async="async" src="https://hub.fromdoppler.com/public/dhtrack.js"></script>
+    <script src='https://hub.fromdoppler.com/public/dhapi.js' type='text/javascript' enableCustomTracking='true'></script>
   </head>
   <body>
     <noscript>

--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,33 @@ ReactGA.initialize('UA-532159-1');
 
 const history = createBrowserHistory();
 
+const parseUrl = (partialUrl) => {
+  const hash =
+    partialUrl.indexOf('#') !== -1
+      ? partialUrl.substring(partialUrl.indexOf('#') + 1, partialUrl.length)
+      : '';
+  const search =
+    partialUrl.indexOf('?') !== -1
+      ? hash.length
+        ? partialUrl.substring(partialUrl.indexOf('?') + 1, partialUrl.indexOf('#'))
+        : partialUrl.substring(partialUrl.indexOf('?') + 1, partialUrl.length)
+      : '';
+  const page =
+    partialUrl.split('?').length >= 2
+      ? partialUrl.split('?')[0]
+      : partialUrl.split('#').length >= 2
+      ? partialUrl.split('#')[0]
+      : partialUrl;
+  return { hash, search, page };
+};
+
 const trackNavigation = (location) => {
   const locationPage = location.hash && location.hash[0] === '#' && location.hash.slice(1);
   ReactGA.set({ page: locationPage });
   ReactGA.pageview(locationPage);
-  window._dha && window._dha.track({ navigatedPage: locationPage });
+  const result = parseUrl(locationPage);
+  window._dha &&
+    window._dha.track({ navigatedPage: result.page, hash: result.hash, search: result.search });
 };
 
 trackNavigation(window.location);

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import 'polyfill-array-includes';
 import 'promise-polyfill/src/polyfill';
 import { availableLanguageOrDefault } from './i18n/utils';
 import { HardcodedShopifyClient } from './services/shopify-client.doubles';
+import urlParse from 'url-parse';
 
 polyfill();
 
@@ -41,33 +42,17 @@ ReactGA.initialize('UA-532159-1');
 
 const history = createBrowserHistory();
 
-const parseUrl = (partialUrl) => {
-  const hash =
-    partialUrl.indexOf('#') !== -1
-      ? partialUrl.substring(partialUrl.indexOf('#') + 1, partialUrl.length)
-      : '';
-  const search =
-    partialUrl.indexOf('?') !== -1
-      ? hash.length
-        ? partialUrl.substring(partialUrl.indexOf('?') + 1, partialUrl.indexOf('#'))
-        : partialUrl.substring(partialUrl.indexOf('?') + 1, partialUrl.length)
-      : '';
-  const page =
-    partialUrl.split('?').length >= 2
-      ? partialUrl.split('?')[0]
-      : partialUrl.split('#').length >= 2
-      ? partialUrl.split('#')[0]
-      : partialUrl;
-  return { hash, search, page };
-};
-
 const trackNavigation = (location) => {
   const locationPage = location.hash && location.hash[0] === '#' && location.hash.slice(1);
   ReactGA.set({ page: locationPage });
   ReactGA.pageview(locationPage);
-  const result = parseUrl(locationPage);
+  const parsedUrl = urlParse(locationPage, false);
   window._dha &&
-    window._dha.track({ navigatedPage: result.page, hash: result.hash, search: result.search });
+    window._dha.track({
+      navigatedPage: parsedUrl.pathname,
+      hash: parsedUrl.hash,
+      search: parsedUrl.query,
+    });
 };
 
 trackNavigation(window.location);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import 'polyfill-array-includes';
 import 'promise-polyfill/src/polyfill';
 import { availableLanguageOrDefault } from './i18n/utils';
 import { HardcodedShopifyClient } from './services/shopify-client.doubles';
-import urlParse from 'url-parse';
+import { getDataHubParams } from './utils';
 
 polyfill();
 
@@ -46,13 +46,8 @@ const trackNavigation = (location) => {
   const locationPage = location.hash && location.hash[0] === '#' && location.hash.slice(1);
   ReactGA.set({ page: locationPage });
   ReactGA.pageview(locationPage);
-  const parsedUrl = urlParse(locationPage, false);
-  window._dha &&
-    window._dha.track({
-      navigatedPage: parsedUrl.pathname,
-      hash: parsedUrl.hash,
-      search: parsedUrl.query,
-    });
+  const dataHubParams = getDataHubParams(locationPage);
+  window._dha && window._dha.track(dataHubParams);
 };
 
 trackNavigation(window.location);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,14 @@
+import urlParse from 'url-parse';
+
 export function timeout(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function getDataHubParams(partialUrl) {
+  const parsedUrl = urlParse(partialUrl, false);
+  return {
+    navigatedPage: parsedUrl.pathname,
+    hash: parsedUrl.hash,
+    search: parsedUrl.query,
+  };
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,63 @@
+import 'jest';
+import { getDataHubParams } from './utils';
+
+describe('utils', () => {
+  describe('getDataHubParams', () => {
+    it('should parse url with no params and no hash correctly', () => {
+      //Arrange
+      //Act
+      const dataHubParams = getDataHubParams('/login');
+      //Assert
+      expect(dataHubParams.navigatedPage).toBe('/login');
+      expect(dataHubParams.search).toBe('');
+      expect(dataHubParams.hash).toBe('');
+    });
+    it('should parse url with no params and hash correctly', () => {
+      //Arrange
+      //Act
+      const dataHubParams = getDataHubParams('/login#hash');
+      //Assert
+      expect(dataHubParams.navigatedPage).toBe('/login');
+      expect(dataHubParams.search).toBe('');
+      expect(dataHubParams.hash).toBe('#hash');
+    });
+    it('should parse url with params and no hash correctly', () => {
+      //Arrange
+      //Act
+      const dataHubParams = getDataHubParams('/login?param1=value');
+      //Assert
+      expect(dataHubParams.navigatedPage).toBe('/login');
+      expect(dataHubParams.search).toBe('?param1=value');
+      expect(dataHubParams.hash).toBe('');
+    });
+    it('should parse url with params and hash correctly', () => {
+      //Arrange
+      //Act
+      const dataHubParams = getDataHubParams('/login?param1=value#hash');
+      //Assert
+      expect(dataHubParams.navigatedPage).toBe('/login');
+      expect(dataHubParams.search).toBe('?param1=value');
+      expect(dataHubParams.hash).toBe('#hash');
+    });
+    it('should parse url with several params and several hash correctly', () => {
+      //Arrange
+      //Act
+      const dataHubParams = getDataHubParams('/login?param1=value&param2=value2#hash1#hash2');
+      //Assert
+      expect(dataHubParams.navigatedPage).toBe('/login');
+      expect(dataHubParams.search).toBe('?param1=value&param2=value2');
+      expect(dataHubParams.hash).toBe('#hash1#hash2');
+    });
+    it('should parse url with several params even badly formatted and several hash correctly', () => {
+      //Arrange
+      //Act
+      const dataHubParams = getDataHubParams(
+        '/login?param1=value?param2=value2?param3=value3#hash1#hash2',
+      );
+      //Assert
+      expect(dataHubParams.navigatedPage).toBe('/login');
+      expect(dataHubParams.search).toBe('?param1=value?param2=value2?param3=value3');
+      expect(dataHubParams.hash).toBe('#hash1#hash2');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12857,7 +12857,7 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-parse@^1.4.3:
+url-parse@^1.4.3, url-parse@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==


### PR DESCRIPTION
- Add datahub script as suggested in https://github.com/MakingSense/Customer-Data-Hub/pull/368
- Added `url-parse` library
- Refactor parse into utils
- Add tests

Pending to do in another PR by @andresmoschini and @fcoronelmakingsense : 
- [ ] Add `url-parse` library in the rest of the app
- [ ] Add promotions testing for url change and parse

To replace queryString library in the future take in account this example:
`queryString.parse(props.location.search)` --> `urlParse(props.location.search, true)`

http://cdn.fromdoppler.com/doppler-webapp/build1053/#/integrations/shopify