### PR TITLE
Shopify fixes

### DIFF
--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -157,6 +157,8 @@ const Shopify = ({ intl, dependencies: { shopifyClient } }) => {
                     <a
                       href={_('shopify.admin_apps_url', { shopName: shop.shopName })}
                       className="dp-button button-big primary-green"
+                      rel="noopener noreferrer"
+                      target="_blank"
                     >
                       {_('shopify.admin_apps')}
                     </a>
@@ -197,7 +199,12 @@ const Shopify = ({ intl, dependencies: { shopifyClient } }) => {
                 >
                   {_('common.back')}
                 </a>
-                <a href={_('shopify.connect_url')} className="dp-button button-big primary-green">
+                <a
+                  href={_('shopify.connect_url')}
+                  className="dp-button button-big primary-green"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   {_('common.connect')}
                 </a>
               </footer>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -177,7 +177,7 @@ export default {
     admin_apps_url: `https://{shopName}/admin/apps`,
     connect_url: `${urlShopify}/install`,
     error_cannot_access_api: `Oops! We could not connect to Shopify API, please try again later.`,
-    header_disconnected_warning: `Seems you are not connected yet. Click on connect button to start.`,
+    header_disconnected_warning: `By pressing "Connect" you will be redirected to Shopify, where you can carry out the necessary steps to integrate.`,
     header_store: `Account name:`,
     header_subtitle: `Automatically send all your E-commerce Contacts and their purchase data to a Doppler List. Also you can import your store products in Email Templates
     and create Abandoned Cart and Retargeting Product Automations. Any questions? Press <a target="_blank" href="${urlHelp}/how-to-integrate-doppler-with-shopify/" ${patchForBlank}>HELP</a>.`,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -177,7 +177,7 @@ export default {
     admin_apps_url: `https://{shopName}/admin/apps`,
     connect_url: `${urlShopify}/install`,
     error_cannot_access_api: `Ouch! No pudimos conectar con la API de Shopify, por favor vuelve a intentarlo luego.`,
-    header_disconnected_warning: `Parece que aun no has conectado con tu tienda. Haz click en Conectar para comenzar.`,
+    header_disconnected_warning: `Al presionar "Conectar" serás redirigido a Shopify, donde podrás realizar todos los pasos necesarios para integrar.`,
     header_store: `Nombre de la cuenta:`,
     header_subtitle: `Envía automáticamente los Contactos de tu tienda y toda su información a una Lista de Doppler. Además, podrás importar los productos de tu tienda en
     Plantillas de Email y crear Automations de Carrito Abandonado y Producto Visitado. ¿Tienes dudas? Presiona <a target="_blank" href="${urlHelp}/como-integrar-doppler-y-shopify/" ${patchForBlank}>HELP</a>.`,


### PR DESCRIPTION
- Fix disconnected warning as in confluence text
- Fix open external urls in a new tab

http://cdn.fromdoppler.com/doppler-webapp/build1122/#/integrations/shopify