### PR TITLE
Shopify: remove experimental feature set up

### DIFF
--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -80,8 +80,8 @@ const Shopify = ({ dependencies: { shopifyClient, dopplerApiClient, experimental
     </>
   );
 
-  const getSubscribersAmountFromAPI = async (listId, apikey) => {
-    const resultAPI = await dopplerApiClient.getListData(listId, apikey);
+  const getSubscribersAmountFromAPI = async (listId) => {
+    const resultAPI = await dopplerApiClient.getListData(listId);
     if (resultAPI.success) {
       return resultAPI.value.amountSubscribers;
     } else {
@@ -90,8 +90,7 @@ const Shopify = ({ dependencies: { shopifyClient, dopplerApiClient, experimental
   };
 
   const updateSubscriberCount = async (list) => {
-    const dopplerAPIFeature = experimentalFeatures && experimentalFeatures.getFeature('DopplerAPI');
-    if (list && dopplerAPIFeature) {
+    if (list) {
       const subscribersCount = await getSubscribersAmountFromAPI(list.id);
       list.amountSubscribers = subscribersCount != null ? subscribersCount : list.amountSubscribers;
     }

--- a/src/components/Integrations/Shopify/Shopify.test.js
+++ b/src/components/Integrations/Shopify/Shopify.test.js
@@ -170,14 +170,8 @@ describe('Shopify Component', () => {
     expect(getByText('validation_messages.error_unexpected_HTML'));
   });
 
-  it('should use DopplerAPI client when feature is enabled with apikey', async () => {
+  it('should use DopplerAPI client when there is a list associated', async () => {
     // Arrange
-    const experimentalFeaturesData = {
-      DopplerAPI: { apikey: 'myapikey', listId: 455222 },
-    };
-    const storage = new FakeLocalStorage();
-    storage.setItem('dopplerExperimental', JSON.stringify(experimentalFeaturesData));
-    const experimentalFeatures = new ExperimentalFeatures(storage);
     const listExist = {
       success: true,
       value: {
@@ -201,54 +195,6 @@ describe('Shopify Component', () => {
         forcedServices={{
           shopifyClient: shopifyClientDouble,
           dopplerApiClient: dopplerAPIClientDouble,
-          experimentalFeatures: experimentalFeatures,
-        }}
-      >
-        <DopplerIntlProvider>
-          <Shopify />
-        </DopplerIntlProvider>
-      </AppServicesProvider>,
-    );
-
-    // Assert
-    expect(container.querySelector('.loading-box')).toBeInTheDocument();
-    await waitForDomChange();
-    expect(container.querySelector('.dp-integration__status')).toBeInTheDocument();
-    expect(getByText(listExist.value.amountSubscribers.toString()));
-  });
-
-  it('should work ok whith api client with token when feature is enabled without apikey', async () => {
-    // Arrange
-    const experimentalFeaturesData = {
-      DopplerAPI: { listId: 455222 },
-    };
-    const storage = new FakeLocalStorage();
-    storage.setItem('dopplerExperimental', JSON.stringify(experimentalFeaturesData));
-    const experimentalFeatures = new ExperimentalFeatures(storage);
-    const listExist = {
-      success: true,
-      value: {
-        name: 'Shopify Contacto',
-        id: 27311899,
-        amountSubscribers: 200,
-        state: SubscriberListState.ready,
-      },
-    };
-
-    const shopifyClientDouble = {
-      getShopifyData: async () => oneShopConnected,
-    };
-    const dopplerAPIClientDouble = {
-      getListData: async () => listExist,
-    };
-
-    // Act
-    const { container, getByText } = render(
-      <AppServicesProvider
-        forcedServices={{
-          shopifyClient: shopifyClientDouble,
-          dopplerApiClient: dopplerAPIClientDouble,
-          experimentalFeatures: experimentalFeatures,
         }}
       >
         <DopplerIntlProvider>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -196,7 +196,7 @@ export default {
     list_title: `Synchronized List`,
     no_list_available: `Waiting for List...`,
     table_list: `List Name`,
-    table_shopify_customers_count: `Shopify customers`,
+    table_shopify_customers_count: `Subscribers`,
     title: `Doppler | Shopify`,
   },
   signup: {

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -196,7 +196,7 @@ export default {
     list_title: `Lista sincronizada`,
     no_list_available: `Esperando Lista...`,
     table_list: `Nombre de la Lista`,
-    table_shopify_customers_count: `Clientes de Shopify`,
+    table_shopify_customers_count: `Suscriptores`,
     title: `Doppler | Shopify`,
   },
   signup: {

--- a/src/services/doppler-api-client.test.ts
+++ b/src/services/doppler-api-client.test.ts
@@ -3,12 +3,11 @@ import { HttpDopplerApiClient } from './doppler-api-client';
 import { RefObject } from 'react';
 import { AppSession } from './app-session';
 import { DopplerLegacyUserData } from './doppler-legacy-client';
-import { ExperimentalFeatures } from './experimental-features';
 import { FakeLocalStorage } from './test-utils/local-storage-double';
 
 const consoleError = console.error;
 
-function createHttpDopplerApiClient(axios: any, experimentalFeatures?: any) {
+function createHttpDopplerApiClient(axios: any) {
   const axiosStatic = {
     create: () => axios,
   } as AxiosStatic;
@@ -17,7 +16,6 @@ function createHttpDopplerApiClient(axios: any, experimentalFeatures?: any) {
       status: 'authenticated',
       jwtToken: 'jwtToken',
       userData: { user: { email: 'email@mail.com' } } as DopplerLegacyUserData,
-      experimentalFeatures: experimentalFeatures,
     },
   } as RefObject<AppSession>;
   const apiClient = new HttpDopplerApiClient({
@@ -75,36 +73,5 @@ describe('HttpDopplerApiClient', () => {
     expect(request).toBeCalledTimes(1);
     expect(result).not.toBe(undefined);
     expect(result.success).toBe(false);
-  });
-
-  it('should set get subscriber amount from list correctly with apikey injected', async () => {
-    // Arrange
-    const listExist = {
-      data: {
-        listId: 27311899,
-        name: 'Shopify Contacto',
-        currentStatus: 'ready',
-        subscribersCount: 3,
-        creationDate: '2019-05-30T11:47:45.367Z',
-      },
-      status: 200,
-    };
-
-    const experimentalFeaturesData = {
-      DopplerAPI: { apikey: 'myapikey', listId: 455222 },
-    };
-    const storage = new FakeLocalStorage();
-    storage.setItem('dopplerExperimental', JSON.stringify(experimentalFeaturesData));
-    const experimentalFeatures = new ExperimentalFeatures(storage);
-
-    const request = jest.fn(async () => listExist);
-    const dopplerApiClient = createHttpDopplerApiClient({ request }, experimentalFeatures);
-
-    // Act
-    const result = await dopplerApiClient.getListData(27311899);
-
-    // Assert
-    expect(request).toBeCalledTimes(1);
-    expect(result).not.toBe(undefined);
   });
 });

--- a/src/services/doppler-api-client.ts
+++ b/src/services/doppler-api-client.ts
@@ -3,7 +3,6 @@ import { AxiosInstance, AxiosStatic } from 'axios';
 import { AppSession } from './app-session';
 import { RefObject } from 'react';
 import { SubscriberList, SubscriberListState } from './shopify-client';
-import { ExperimentalFeatures } from './experimental-features';
 
 export interface DopplerApiClient {
   getListData(idList: number, apikey: string): Promise<ResultWithoutExpectedErrors<SubscriberList>>;
@@ -17,25 +16,21 @@ export class HttpDopplerApiClient implements DopplerApiClient {
   private readonly axios: AxiosInstance;
   private readonly baseUrl: string;
   private readonly connectionDataRef: RefObject<AppSession>;
-  private readonly experimentalFeatures?: ExperimentalFeatures;
 
   constructor({
     axiosStatic,
     baseUrl,
     connectionDataRef,
-    experimentalFeatures,
   }: {
     axiosStatic: AxiosStatic;
     baseUrl: string;
     connectionDataRef: RefObject<AppSession>;
-    experimentalFeatures?: ExperimentalFeatures;
   }) {
     this.baseUrl = baseUrl;
     this.axios = axiosStatic.create({
       baseURL: this.baseUrl,
     });
     this.connectionDataRef = connectionDataRef;
-    this.experimentalFeatures = experimentalFeatures;
   }
 
   private getDopplerApiConnectionData(): DopplerApiConnectionData {
@@ -68,19 +63,11 @@ export class HttpDopplerApiClient implements DopplerApiClient {
 
   public async getListData(listId: number): Promise<ResultWithoutExpectedErrors<SubscriberList>> {
     try {
-      const dopplerAPIFeature =
-        this.experimentalFeatures && this.experimentalFeatures.getFeature('DopplerAPI');
-      const apikey =
-        dopplerAPIFeature && dopplerAPIFeature.apikey ? dopplerAPIFeature.apikey : null;
-
-      const { userAccount } = this.getDopplerApiConnectionData();
-      const jwtToken = apikey ? apikey : this.getDopplerApiConnectionData().jwtToken;
+      const { jwtToken, userAccount } = this.getDopplerApiConnectionData();
 
       const response = await this.axios.request({
         method: 'GET',
-        url: `/accounts/${userAccount}/lists/${
-          dopplerAPIFeature && dopplerAPIFeature.listId ? dopplerAPIFeature.listId : listId
-        }`,
+        url: `/accounts/${userAccount}/lists/${listId}`,
         headers: { Authorization: `token ${jwtToken}` },
       });
 

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -142,7 +142,6 @@ export class AppCompositionRoot implements AppServices {
           axiosStatic: this.axiosStatic,
           baseUrl: this.appConfiguration.dopplerApiUrl,
           connectionDataRef: this.appSessionRef,
-          experimentalFeatures: this.experimentalFeatures,
         }),
     );
   }


### PR DESCRIPTION
When jwtToken is ready for api, experimental feature will not be needed anymore, and in shopify we will always get amount of subscribers by dopplerApi.

#### This PR will remain open until jwtToken is enabled in DopplerApi.