### PR TITLE
fix(shopify): prevent re render when data does not change

### DIFF
--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -112,17 +112,15 @@ const Shopify = ({ dependencies: { shopifyClient, dopplerApiClient, experimental
     delay: 20000,
     callback: async () => {
       const result = await getShopifyData();
-      if (!result.success) {
+      if (!result.success && !shopifyState.error) {
         setShopifyState({
           error: <FormattedHTMLMessage id="validation_messages.error_unexpected_HTML" />,
         });
-      } else if (result.value && result.value.length) {
+      } else if (result.value !== shopifyState.shops) {
         setShopifyState({
           shops: result.value,
-          isConnected: true,
+          isConnected: !!result.value.length,
         });
-      } else {
-        setShopifyState({ shops: [] });
       }
     },
   });

--- a/src/services/shopify-client.test.ts
+++ b/src/services/shopify-client.test.ts
@@ -33,6 +33,7 @@ describe('HttpShopifyClient', () => {
   it('should set connected shop without list correctly', async () => {
     // Arrange
     const connectedWithoutListResponse = {
+      headers: {},
       data: [
         {
           connectedOn: '2019-08-09T19:45:43.821Z',
@@ -59,6 +60,7 @@ describe('HttpShopifyClient', () => {
   it('should set connected shop with list connected correctly', async () => {
     // Arrange
     const connectedWithListReadyResponse = {
+      headers: {},
       data: [
         {
           connectedOn: '2019-08-09T15:13:52.262Z',
@@ -92,6 +94,7 @@ describe('HttpShopifyClient', () => {
   it('should set connected shop with list connected correctly even if sync flag is bool', async () => {
     // Arrange
     const connectedWithListReadyResponseBool = {
+      headers: {},
       data: [
         {
           connectedOn: '2019-08-09T15:13:52.262Z',
@@ -125,6 +128,7 @@ describe('HttpShopifyClient', () => {
   it('should set connected shop with list connected but synchronizing contacts', async () => {
     // Arrange
     const connectedWithListSyncResponse = {
+      headers: {},
       data: [
         {
           connectedOn: '2019-08-09T15:13:52.262Z',
@@ -158,6 +162,7 @@ describe('HttpShopifyClient', () => {
   it('should set connected shop with list connected but synchronizing contacts even if sync flag is bool', async () => {
     // Arrange
     const connectedWithListSyncResponseBool = {
+      headers: {},
       data: [
         {
           connectedOn: '2019-08-09T15:13:52.262Z',
@@ -191,6 +196,7 @@ describe('HttpShopifyClient', () => {
   it('should set not connected shop', async () => {
     // Arrange
     const notConnected = {
+      headers: {},
       data: [],
     };
     const request = jest.fn(async () => notConnected);
@@ -224,5 +230,61 @@ describe('HttpShopifyClient', () => {
     expect(result).not.toBe(undefined);
     expect(result.success).toBe(false);
     expect(result.error).not.toBe(undefined);
+  });
+
+  it('should not change data by new request when etag is the same', async () => {
+    // Arrange
+    const connectedWithoutListResponse = {
+      headers: {
+        etag: 'FirstEtag',
+      },
+      data: [
+        {
+          connectedOn: '2019-08-09T19:45:43.821Z',
+          importedCustomersCount: '0',
+          shopName: 'dopplerdevshop.myshopify.com',
+          shopifyAccessToken: '861f44ee45f6a3affcf50477d9774d20',
+        },
+      ],
+    };
+    const request = jest.fn();
+
+    const shopifyClient = createHttpShopifyClient({ request });
+
+    // Act
+    request.mockResolvedValue(connectedWithoutListResponse);
+    const result1 = await shopifyClient.getShopifyData();
+    request.mockResolvedValue({ ...connectedWithoutListResponse, headers: { etag: 'FirstEtag' } });
+    const result2 = await shopifyClient.getShopifyData();
+    // Assert
+    expect(result2).toBe(result1);
+  });
+
+  it('should change data by new request when etag is different', async () => {
+    // Arrange
+    const connectedWithoutListResponse = {
+      headers: {
+        etag: 'FirstEtag',
+      },
+      data: [
+        {
+          connectedOn: '2019-08-09T19:45:43.821Z',
+          importedCustomersCount: '0',
+          shopName: 'dopplerdevshop.myshopify.com',
+          shopifyAccessToken: '861f44ee45f6a3affcf50477d9774d20',
+        },
+      ],
+    };
+    const request = jest.fn();
+
+    const shopifyClient = createHttpShopifyClient({ request });
+
+    // Act
+    request.mockResolvedValue(connectedWithoutListResponse);
+    const result1 = await shopifyClient.getShopifyData();
+    request.mockResolvedValue({ ...connectedWithoutListResponse, headers: { etag: 'SecondEtag' } });
+    const result2 = await shopifyClient.getShopifyData();
+    // Assert
+    expect(result2).not.toBe(result1);
   });
 });


### PR DESCRIPTION
When state changes, react component is re rendered, in this case we are using polling to keep data up to date, and sometimes we received the same data.
- Added new feature in Utils,  `ResponseCache` to allow to cache responses when etag header is exposed. 
- Used this feature in shopify client
- Refactor shopify component to prevent re setting state when not needed.
- Fixed tests

https://cdn.fromdoppler.com/doppler-webapp/build1501/#/integrations/shopify