### PR TITLE
feat: allow build within docker container

### DIFF
--- a/Dockerfile.BUILDS_AND_CDN
+++ b/Dockerfile.BUILDS_AND_CDN
@@ -1,0 +1,31 @@
+## Build layer
+FROM node:10 as build
+WORKDIR /app
+COPY package.json yarn.lock ./
+
+# Download dependencies
+RUN yarn
+
+# Copy source files
+COPY . .
+
+# Run tests and verify other requirements
+RUN yarn verify
+
+# Build project
+ARG environment
+RUN yarn build:$environment
+
+## Publish to CDN layer
+FROM dopplerrelay/doppler-relay-akamai-publish
+COPY --from=build /app/build /source
+ARG env_version
+ARG cdn_hostname
+ARG cdn_username
+ARG cdn_password
+ARG cdn_cpcode
+RUN AKAMAI_CDN_HOSTNAME=$cdn_hostname \
+  AKAMAI_CDN_USERNAME=$cdn_username \
+  AKAMAI_CDN_PASSWORD=$cdn_password \
+  AKAMAI_CDN_CPCODE=$cdn_cpcode \
+  node cdn-uploader.js /source doppler-webapp ${env_version}

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -3,64 +3,56 @@
 pkgName="doppler-webapp"
 pkgVersion=${1:-"v0.0.0-build0"}
 cdnBaseUrl=${2:-"//cdn.fromdoppler.com/$pkgName"}
-pkgVersionQa="qa-$pkgVersion"
-pkgVersionInt="int-$pkgVersion"
-pkgVersionDevelopment="dev-$pkgVersion"
 pkgBuild=${4:-0}
 pkgCommitId=${5:-$(git rev-parse HEAD)}
+environments="int qa development production"
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
+
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
 
 # Lines added to get the script running in the script path shell context
 # reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
 cd $(dirname $0)
 
-sh ./verify-w-docker.sh
+# To avoid issues with MINGW y Git Bash, see:
+# https://github.com/docker/toolbox/issues/673
+# https://gist.github.com/borekb/cb1536a3685ca6fc0ad9a028e6a959e3
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+echo Publishing to Docker and Akamai...
+echo pkgName: $pkgName
+echo cdnBaseUrl: $cdnBaseUrl
+echo pkgVersion: $pkgVersion
+echo pkgBuild: $pkgBuild
+echo pkgCommitId: $pkgCommitId
 
 # Force pull the latest image version due to the cache not always is pruned immediately after an update is uploaded to docker hub
 docker pull dopplerrelay/doppler-relay-akamai-publish
 
-sh ./build-w-docker.sh $pkgVersion $cdnBaseUrl production $pkgVersion $pkgBuild $pkgCommitId
-docker run --rm \
-    -e AKAMAI_CDN_HOSTNAME \
-    -e AKAMAI_CDN_USERNAME \
-    -e AKAMAI_CDN_PASSWORD \
-    -e AKAMAI_CDN_CPCODE \
-    -e "PROJECT_NAME=$pkgName" \
-    -e "VERSION_NAME=$pkgVersion" \
-    -v `pwd`/build:/source \
-    dopplerrelay/doppler-relay-akamai-publish
+for environment in ${environments}; do
+    echo Publishing ${environment}...
 
-sh ./build-w-docker.sh $pkgVersion $cdnBaseUrl qa $pkgVersion $pkgBuild $pkgCommitId
-docker run --rm \
-    -e AKAMAI_CDN_HOSTNAME \
-    -e AKAMAI_CDN_USERNAME \
-    -e AKAMAI_CDN_PASSWORD \
-    -e AKAMAI_CDN_CPCODE \
-    -e "PROJECT_NAME=$pkgName" \
-    -e "VERSION_NAME=$pkgVersionQa" \
-    -v `pwd`/build:/source \
-    dopplerrelay/doppler-relay-akamai-publish
+    if test "$environment" = "production";
+    then  
+        env_version=$pkgVersion;
+    else
+        env_version=$environment-$pkgVersion;
+    fi
 
-sh ./build-w-docker.sh $pkgVersion $cdnBaseUrl int $pkgVersion $pkgBuild $pkgCommitId
-docker run --rm \
-    -e AKAMAI_CDN_HOSTNAME \
-    -e AKAMAI_CDN_USERNAME \
-    -e AKAMAI_CDN_PASSWORD \
-    -e AKAMAI_CDN_CPCODE \
-    -e "PROJECT_NAME=$pkgName" \
-    -e "VERSION_NAME=$pkgVersionInt" \
-    -v `pwd`/build:/source \
-    dopplerrelay/doppler-relay-akamai-publish
+    echo deploying into $env_version folder ...
 
-sh ./build-w-docker.sh $pkgVersion $cdnBaseUrl development $pkgVersion $pkgBuild $pkgCommitId
-docker run --rm \
-    -e AKAMAI_CDN_HOSTNAME \
-    -e AKAMAI_CDN_USERNAME \
-    -e AKAMAI_CDN_PASSWORD \
-    -e AKAMAI_CDN_CPCODE \
-    -e "PROJECT_NAME=$pkgName" \
-    -e "VERSION_NAME=$pkgVersionDevelopment" \
-    -v `pwd`/build:/source \
-    dopplerrelay/doppler-relay-akamai-publish
+    docker build --pull \
+        --build-arg environment=$environment \
+        --build-arg env_version=$env_version \
+        --build-arg cdn_hostname=$AKAMAI_CDN_HOSTNAME \
+        --build-arg cdn_username=$AKAMAI_CDN_USERNAME \
+        --build-arg cdn_password=$AKAMAI_CDN_PASSWORD \
+        --build-arg cdn_cpcode=$AKAMAI_CDN_CPCODE \
+        -f Dockerfile.BUILDS_AND_CDN \
+        .
+
+done


### PR DESCRIPTION
- Add docker file for builds.
- Use dockerfile from build-n-publish script

Output: cdn folder as we used (except for development enviroment)
* production --> buildxxx (https://cdn.fromdoppler.com/doppler-webapp/build15323/#/login)
* int --> int-buildxxx (https://cdn.fromdoppler.com/doppler-webapp/int-build1532/#/login)
* qa --> qa-buildxxx --> (https://cdn.fromdoppler.com/doppler-webapp/qa-build1532/#/login)
* development --> development-buildxxx (before it was dev-buildxxx) (https://cdn.fromdoppler.com/doppler-webapp/development-build1532/#/login)