### PR TITLE
Daily visits withemail without

### DIFF
--- a/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
+++ b/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
@@ -18,38 +18,52 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dependencies: { datahubClien
       show: false,
     },
     tooltip: {
-      format: {
-        title: (date) => {
-          return intl.formatDate(date, {
+      contents: function(data) {
+        if (data.length) {
+          const date = intl.formatDate(data[0].x, {
             timeZone: 'UTC',
             day: 'numeric',
             month: 'long',
             year: 'numeric',
             weekday: 'long',
           });
-        },
-        value: (value, ratio, id) => {
-          switch (id) {
-            case 'quantity':
-              return (
-                intl.formatMessage({
-                  id: 'reports_daily_visits.tooltip_page_views',
-                }) + value
-              );
-            case 'withEmail':
-              return (
-                intl.formatMessage({
-                  id: 'reports_daily_visits.tooltip_with_email',
-                }) + value
-              );
-            case 'withoutEmail':
-              return (
-                intl.formatMessage({
-                  id: 'reports_daily_visits.tooltip_without_email',
-                }) + value
-              );
-          }
-        },
+
+          const tooltipData = data.reduce((accumulator, item) => {
+            accumulator[item.id] = item.value;
+            return accumulator;
+          }, {});
+
+          tooltipData.quantity_label = intl.formatMessage({
+            id: 'reports_daily_visits.tooltip_page_views',
+          });
+          tooltipData.withEmail_label = intl.formatMessage({
+            id: 'reports_daily_visits.tooltip_with_email',
+          });
+          tooltipData.withoutEmail_label = intl.formatMessage({
+            id: 'reports_daily_visits.tooltip_without_email',
+          });
+
+          const valueTemplate = (value) => {
+            return `<div class='tooltip-value'>${value}</div>`;
+          };
+
+          return `
+          <div class="c3-tooltip">
+            <div class='tooltip-title'>${date}</div>
+            ${
+              tooltipData.withEmail === null
+                ? valueTemplate(tooltipData.quantity_label + tooltipData.quantity)
+                : ''
+            }
+            ${
+              tooltipData.withEmail !== null
+                ? valueTemplate(tooltipData.withEmail_label + tooltipData.withEmail) +
+                  valueTemplate(tooltipData.withoutEmail_label + tooltipData.withoutEmail)
+                : ''
+            }
+          </div>`;
+        }
+        return '';
       },
     },
     axis: {

--- a/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
+++ b/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
@@ -28,12 +28,27 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dependencies: { datahubClien
             weekday: 'long',
           });
         },
-        value: (value) => {
-          return (
-            intl.formatMessage({
-              id: 'reports_daily_visits.tooltip_page_views',
-            }) + value
-          );
+        value: (value, ratio, id) => {
+          switch (id) {
+            case 'quantity':
+              return (
+                intl.formatMessage({
+                  id: 'reports_daily_visits.tooltip_page_views',
+                }) + value
+              );
+            case 'withEmail':
+              return (
+                intl.formatMessage({
+                  id: 'reports_daily_visits.tooltip_with_email',
+                }) + value
+              );
+            case 'withoutEmail':
+              return (
+                intl.formatMessage({
+                  id: 'reports_daily_visits.tooltip_without_email',
+                }) + value
+              );
+          }
         },
       },
     },
@@ -78,7 +93,11 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dependencies: { datahubClien
             json: dailyVisitsData.value,
             keys: {
               x: 'from',
-              value: ['quantity'],
+              value: ['quantity', 'withEmail', 'withoutEmail'],
+            },
+            classes: {
+              withEmail: 'hide-graph',
+              withoutEmail: 'hide-graph',
             },
           },
         });

--- a/src/components/shared/C3Chart/C3Chart.styles.js
+++ b/src/components/shared/C3Chart/C3Chart.styles.js
@@ -69,7 +69,8 @@ export const C3ChartStyled = styled.div`
     opacity: 0.9;
   }
 
-  .c3-tooltip th {
+  .c3-tooltip th,
+  .c3-tooltip .tooltip-title {
     font-size: 11px;
     padding: 2px 5px;
     text-align: left;
@@ -78,7 +79,8 @@ export const C3ChartStyled = styled.div`
     line-height: 13px;
   }
 
-  .c3-tooltip th::first-letter {
+  .c3-tooltip th::first-letter,
+  .c3-tooltip .tooltip-title::first-letter {
     text-transform: capitalize;
   }
 
@@ -86,7 +88,8 @@ export const C3ChartStyled = styled.div`
     display: none;
   }
 
-  .c3-tooltip td {
+  .c3-tooltip td,
+  .c3-tooltip .tooltip-value {
     font-size: 13px;
     padding: 3px 6px;
     color: ${colors.darkGrey};

--- a/src/components/shared/C3Chart/C3Chart.styles.js
+++ b/src/components/shared/C3Chart/C3Chart.styles.js
@@ -95,6 +95,10 @@ export const C3ChartStyled = styled.div`
     line-height: 16px;
   }
 
+  .c3-target-hide-graph {
+    display: none;
+  }
+
   @media (max-width: 768px) {
     .c3-chart {
       width: 95%;

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -153,6 +153,8 @@ export default {
   reports_daily_visits: {
     title: `Unique Page views`,
     tooltip_page_views: `Pageviews: `,
+    tooltip_with_email: `Users with Email: `,
+    tooltip_without_email: `Users without Email: `,
   },
   reports_filters: {
     all_pages: `All pages`,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -153,6 +153,8 @@ export default {
   reports_daily_visits: {
     title: `Páginas vistas únicas`,
     tooltip_page_views: `Páginas vistas: `,
+    tooltip_with_email: `Usuarios con Email: `,
+    tooltip_without_email: `Usuarios sin Email: `,
   },
   reports_filters: {
     all_pages: `Todas las paginas`,

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -95,24 +95,28 @@ const fakeDailyVisitsData = [
     from: '2018-10-10T03:00:00.000Z',
     to: '2018-10-11T03:00:00.000Z',
     quantity: 20,
+    withEmail: 3,
   },
   {
     periodNumber: 1,
     from: '2018-10-11T03:00:00.000Z',
     to: '2018-10-12T03:00:00.000Z',
     quantity: 40,
+    withEmail: 10,
   },
   {
     periodNumber: 2,
     from: '2018-10-12T03:00:00.000Z',
     to: '2018-10-13T03:00:00.000Z',
     quantity: 70,
+    withEmail: 2,
   },
   {
     periodNumber: 3,
     from: '2018-10-13T03:00:00.000Z',
     to: '2018-10-14T03:00:00.000Z',
     quantity: 80,
+    withEmail: 40,
   },
 ];
 
@@ -208,6 +212,8 @@ export class HardcodedDatahubClient implements DatahubClient {
       from: new Date(x.from),
       to: new Date(x.to),
       quantity: x.quantity,
+      withEmail: x.withEmail,
+      withoutEmail: x.quantity - x.withEmail,
     }));
 
     return {

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -231,7 +231,7 @@ export class HttpDatahubClient implements DatahubClient {
         to: new Date(x.to),
         quantity: x.quantity,
         withEmail: x.withEmail,
-        withoutEmail: x.quantity - x.withEmail,
+        withoutEmail: x.withEmail !== undefined ? x.quantity - x.withEmail : x.withEmail,
       }));
 
       return {

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -230,6 +230,8 @@ export class HttpDatahubClient implements DatahubClient {
         from: new Date(x.from),
         to: new Date(x.to),
         quantity: x.quantity,
+        withEmail: x.withEmail,
+        withoutEmail: x.quantity - x.withEmail,
       }));
 
       return {


### PR DESCRIPTION
Report daily visit graphic without datahub new data, and with classification for email and no email. 

![image](https://user-images.githubusercontent.com/2439363/65065723-5bfaf180-d959-11e9-86c4-9563f5bd0f02.png)


- Add with emails in datahub double
- Add values into graphic
- Hide graph for with Email and without
- Fine tune format for value to show a label for each case
