### PR TITLE
fix: chart adjustment of reports daily visits

### DIFF
--- a/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
+++ b/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
@@ -81,7 +81,7 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dependencies: { datahubClien
       pattern: ['#B58FC1'],
     },
     point: {
-      r: 5,
+      r: 3,
     },
     grid: {
       y: {

--- a/src/components/shared/C3Chart/C3Chart.styles.js
+++ b/src/components/shared/C3Chart/C3Chart.styles.js
@@ -27,9 +27,9 @@ export const C3ChartStyled = styled.div`
   }
 
   .c3-line {
-    stroke-width: 4px;
+    stroke-width: 2px;
     position: relative;
-    transition: all 2s ease-in-out;
+    transition: all 0.5s ease-in-out;
   }
 
   .c3-event-rect {
@@ -44,9 +44,24 @@ export const C3ChartStyled = styled.div`
   .c3-xgrid-focus {
     stroke: ${colors.darkPurple};
     transition: all 1s ease-in-out;
+    opacity: 1;
   }
 
   .c3-shapes-quantity {
+    fill: ${colors.darkPurple};
+    opacity: 1;
+  }
+
+  .c3-areas {
+    fill: ${colors.darkPurple};
+    opacity: 0.3;
+  }
+
+  .c3-target-withEmail {
+    fill: ${colors.darkPurple};
+  }
+
+  .c3-target-withoutEmail {
     fill: ${colors.darkPurple};
   }
 


### PR DESCRIPTION
Every time a new `key` is added (example: `witoutEmail`), c3 automatically generates a `class` with the new `key` (example: `c3-target-witoutEmail`) to which we will have to add the corresponding color of the data we want to paint.
The code example is in the image.
Design adjustments were made for a better visualization of the grouped data.
Design validated with @santiagopaolucci 

**Linear graph example**
![example-01](https://user-images.githubusercontent.com/46735526/65460340-06768700-de28-11e9-80c2-4ea46ea1e162.jpg)


**Example area chart**
![example-02](https://user-images.githubusercontent.com/46735526/65460404-2b6afa00-de28-11e9-8005-57739c58119c.jpg)


**Example code**
![c3](https://user-images.githubusercontent.com/46735526/65460415-345bcb80-de28-11e9-8a91-d7f6b8bcaee5.jpg)

