### PR TITLE
feat(datahub-client): refactor to add pagination in page ranking

### DIFF
--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -160,11 +160,15 @@ export class HardcodedDatahubClient implements DatahubClient {
   public async getPagesRankingByPeriod({
     domainName,
     dateFrom,
+    pageSize,
+    pageNumber,
   }: {
-    domainName: number;
+    domainName: string;
     dateFrom: Date;
+    pageSize: number;
+    pageNumber: number;
   }): Promise<PageRankingResult> {
-    console.log('getPagesRankingByPeriod', { domainName, dateFrom });
+    console.log('getPagesRankingByPeriod', { domainName, dateFrom, pageSize, pageNumber });
     await timeout(1500);
     const pages = fakePagesData.map((x) => ({
       name: x.name,
@@ -173,9 +177,19 @@ export class HardcodedDatahubClient implements DatahubClient {
       withEmail: x.withEmail,
     }));
 
+    let pagesSubArray = [];
+
+    if (pageSize) {
+      const indexStart = pageSize * (pageNumber - 1);
+      const indexEnd = indexStart + pageSize - 1;
+      pagesSubArray = pages.slice(indexStart, indexEnd);
+    } else {
+      pagesSubArray = pages;
+    }
+
     return {
       success: true,
-      value: pages,
+      value: pagesSubArray,
     };
 
     // return {

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -42,8 +42,10 @@ export interface DatahubClient {
     emailFilter?: emailFilterOptions;
   }): Promise<number>;
   getPagesRankingByPeriod(query: {
-    domainName: number;
+    domainName: string;
     dateFrom: Date;
+    pageSize: number;
+    pageNumber: number;
   }): Promise<PageRankingResult>;
   getTrafficSourcesByPeriod(query: {
     domainName: string;
@@ -140,9 +142,13 @@ export class HttpDatahubClient implements DatahubClient {
   public async getPagesRankingByPeriod({
     domainName,
     dateFrom,
+    pageSize,
+    pageNumber,
   }: {
-    domainName: number;
+    domainName: string;
     dateFrom: Date;
+    pageSize: number;
+    pageNumber: number;
   }): Promise<PageRankingResult> {
     try {
       const response = await this.customerGet<any>(
@@ -150,6 +156,8 @@ export class HttpDatahubClient implements DatahubClient {
         {
           startDate: dateFrom.toISOString(),
           sortBy: 'visitors',
+          pageSize: pageSize || 0,
+          pageNumber: pageNumber || 0,
         },
       );
 


### PR DESCRIPTION
- Refactor method to can add pagination. Add page size and page number
- Add test for Ranking pages by period
- Refactor double for local