### PR TITLE
DW-79: add endDate for daily/hourly visits reports

### DIFF
--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -29,7 +29,7 @@ class Reports extends React.Component {
       domains: null,
       domainSelected: null,
       periodSelectedDays: 7,
-      dateTo: new Date(),
+      dateTo: null,
       dateFrom: null,
     };
 
@@ -40,12 +40,13 @@ class Reports extends React.Component {
   async componentDidMount() {
     const domains = await this.datahubClient.getAccountDomains();
     const domainSelected = domains.length ? domains[0] : null;
-    const dateFrom = new Date();
-    dateFrom.setDate(dateFrom.getDate() - parseInt(this.state.periodSelectedDays));
+    const now = new Date();
+    const dateFrom = this.addDays(now, parseInt(this.state.periodSelectedDays) * -1);
     this.setState({
       domains: domains,
       domainSelected: domainSelected,
       dateFrom: dateFrom,
+      dateTo: now,
     });
   }
 
@@ -54,10 +55,15 @@ class Reports extends React.Component {
     this.setState({ domainSelected: domainFound });
   };
 
+  addDays = (date, days) => {
+    const newDate = new Date(date);
+    return newDate.setDate(date.getDate() + days);
+  };
+
   changePeriod = (days) => {
-    const dateFrom = new Date();
-    dateFrom.setDate(dateFrom.getDate() - days);
-    this.setState({ periodSelectedDays: days, dateFrom: dateFrom, dateTo: new Date() });
+    const now = new Date();
+    const dateFrom = this.addDays(now, days * -1);
+    this.setState({ periodSelectedDays: days, dateFrom: dateFrom, dateTo: now });
   };
 
   render = () => (

--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -13,6 +13,7 @@ import {
 } from '../SiteTrackingRequired/SiteTrackingRequired';
 import { Helmet } from 'react-helmet';
 import { Loading } from '../Loading/Loading';
+import { addDays } from '../../utils';
 
 class Reports extends React.Component {
   /**
@@ -41,7 +42,7 @@ class Reports extends React.Component {
     const domains = await this.datahubClient.getAccountDomains();
     const domainSelected = domains.length ? domains[0] : null;
     const now = new Date();
-    const dateFrom = this.addDays(now, parseInt(this.state.periodSelectedDays) * -1);
+    const dateFrom = addDays(now, parseInt(this.state.periodSelectedDays) * -1);
     this.setState({
       domains: domains,
       domainSelected: domainSelected,
@@ -55,14 +56,9 @@ class Reports extends React.Component {
     this.setState({ domainSelected: domainFound });
   };
 
-  addDays = (date, days) => {
-    const newDate = new Date(date);
-    return newDate.setDate(date.getDate() + days);
-  };
-
   changePeriod = (days) => {
     const now = new Date();
-    const dateFrom = this.addDays(now, days * -1);
+    const dateFrom = addDays(now, days * -1);
     this.setState({ periodSelectedDays: days, dateFrom: dateFrom, dateTo: now });
   };
 

--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -40,7 +40,7 @@ class Reports extends React.Component {
   async componentDidMount() {
     const domains = await this.datahubClient.getAccountDomains();
     const domainSelected = domains.length ? domains[0] : null;
-    let dateFrom = new Date();
+    const dateFrom = new Date();
     dateFrom.setDate(dateFrom.getDate() - parseInt(this.state.periodSelectedDays));
     this.setState({
       domains: domains,
@@ -55,7 +55,7 @@ class Reports extends React.Component {
   };
 
   changePeriod = (days) => {
-    let dateFrom = new Date();
+    const dateFrom = new Date();
     dateFrom.setDate(dateFrom.getDate() - days);
     this.setState({ periodSelectedDays: days, dateFrom: dateFrom, dateTo: new Date() });
   };
@@ -102,6 +102,7 @@ class Reports extends React.Component {
               <ReportsDailyVisits
                 domainName={this.state.domainSelected.name}
                 dateFrom={this.state.dateFrom}
+                dateTo={this.state.dateTo}
               />
               <ReportsTrafficSources
                 domainName={this.state.domainSelected.name}

--- a/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
+++ b/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
@@ -10,7 +10,7 @@ const chartDataOptions = {
   json: {},
 };
 
-const ReportsDailyVisits = ({ domainName, dateFrom, dependencies: { datahubClient } }) => {
+const ReportsDailyVisits = ({ domainName, dateFrom, dateTo, dependencies: { datahubClient } }) => {
   const [state, setState] = useState({ loading: true });
 
   const intl = useIntl();
@@ -98,6 +98,7 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dependencies: { datahubClien
       const dailyVisitsData = await datahubClient.getVisitsQuantitySummarizedByPeriod({
         domainName: domainName,
         dateFrom: dateFrom,
+        dateTo: dateTo,
         periodBy: 'days',
       });
       if (!dailyVisitsData.success) {
@@ -121,7 +122,7 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dependencies: { datahubClien
     };
 
     fetchData();
-  }, [datahubClient, dateFrom, domainName]);
+  }, [datahubClient, dateFrom, dateTo, domainName]);
 
   return (
     <div className="wrapper-reports-box">

--- a/src/components/Reports/ReportsHoursVisits/ReportsHoursVisits.js
+++ b/src/components/Reports/ReportsHoursVisits/ReportsHoursVisits.js
@@ -28,7 +28,7 @@ const FormatWeekDayIndex = ({ value, format }) => {
   );
 };
 
-const ReportsHoursVisits = ({ domainName, dateFrom, dependencies: { datahubClient } }) => {
+const ReportsHoursVisits = ({ domainName, dateFrom, dateTo, dependencies: { datahubClient } }) => {
   const [state, setState] = useState({ loading: true });
 
   useEffect(() => {
@@ -37,6 +37,7 @@ const ReportsHoursVisits = ({ domainName, dateFrom, dependencies: { datahubClien
       const hoursVisitsdata = await datahubClient.getVisitsQuantitySummarizedByPeriod({
         domainName: domainName,
         dateFrom: dateFrom,
+        dateTo: dateTo,
         periodBy: 'hours',
       });
       if (!hoursVisitsdata.success) {
@@ -60,7 +61,7 @@ const ReportsHoursVisits = ({ domainName, dateFrom, dependencies: { datahubClien
     };
 
     fetchData();
-  }, [datahubClient, dateFrom, domainName]);
+  }, [datahubClient, dateFrom, dateTo, domainName]);
 
   return (
     <S.WrapperBoxContainer className="wrapper-reports-box">

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -227,13 +227,15 @@ export class HardcodedDatahubClient implements DatahubClient {
   public async getVisitsQuantitySummarizedByPeriod({
     domainName,
     dateFrom,
+    dateTo,
     periodBy,
   }: {
     domainName: string;
     dateFrom: Date;
+    dateTo: Date;
     periodBy: filterByPeriodOptions;
   }): Promise<VisitsQuantitySummarizedResult> {
-    console.log('getVisitsQuantitySummarizedByPeriod', { domainName, dateFrom });
+    console.log('getVisitsQuantitySummarizedByPeriod', { domainName, dateFrom, dateTo });
     await timeout(1000);
 
     const data = periodBy === 'days' ? fakeDailyVisitsData : getFakeHoursVisitsData();

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -235,7 +235,7 @@ export class HardcodedDatahubClient implements DatahubClient {
     dateTo: Date;
     periodBy: filterByPeriodOptions;
   }): Promise<VisitsQuantitySummarizedResult> {
-    console.log('getVisitsQuantitySummarizedByPeriod', { domainName, dateFrom, dateTo });
+    console.log('getVisitsQuantitySummarizedByPeriod', { domainName, dateFrom, dateTo, periodBy });
     await timeout(1000);
 
     const data = periodBy === 'days' ? fakeDailyVisitsData : getFakeHoursVisitsData();

--- a/src/services/datahub-client.test.ts
+++ b/src/services/datahub-client.test.ts
@@ -155,10 +155,16 @@ describe('HttpDataHubClient', () => {
       const dataHubClient = createHttpDataHubClient({ request });
       const domainName = 'doppler.test';
       const dateFrom = new Date('2019-01-01');
+      const dateTo = new Date('2019-01-08');
       const periodBy = 'days';
 
       // Act
-      await dataHubClient.getVisitsQuantitySummarizedByPeriod({ domainName, dateFrom, periodBy });
+      await dataHubClient.getVisitsQuantitySummarizedByPeriod({
+        domainName,
+        dateFrom,
+        dateTo,
+        periodBy,
+      });
 
       // Assert
       expect(request).toBeCalledTimes(1);
@@ -170,6 +176,7 @@ describe('HttpDataHubClient', () => {
           method: 'GET',
           params: {
             startDate: '2019-01-01T00:00:00.000Z',
+            endDate: '2019-01-08T00:00:00.000Z',
             periodBy: 'days',
           },
           url:
@@ -185,12 +192,14 @@ describe('HttpDataHubClient', () => {
       const dataHubClient = createHttpDataHubClient({ request });
       const domainName = 'doppler.test';
       const dateFrom = new Date('2019-01-01');
+      const dateTo = new Date('2019-01-08');
       const periodBy = 'days';
 
       // Act
       const response = await dataHubClient.getVisitsQuantitySummarizedByPeriod({
         domainName,
         dateFrom,
+        dateTo,
         periodBy,
       });
       // Assert
@@ -203,6 +212,7 @@ describe('HttpDataHubClient', () => {
           method: 'GET',
           params: {
             startDate: '2019-01-01T00:00:00.000Z',
+            endDate: '2019-01-08T00:00:00.000Z',
             periodBy: 'days',
           },
           url:
@@ -242,12 +252,14 @@ describe('HttpDataHubClient', () => {
       const dataHubClient = createHttpDataHubClient({ request });
       const domainName = 'doppler.test';
       const dateFrom = new Date('2019-01-01');
+      const dateTo = new Date('2019-01-08');
       const periodBy = 'days';
 
       // Act
       const response = await dataHubClient.getVisitsQuantitySummarizedByPeriod({
         domainName,
         dateFrom,
+        dateTo,
         periodBy,
       });
 
@@ -261,6 +273,7 @@ describe('HttpDataHubClient', () => {
           method: 'GET',
           params: {
             startDate: '2019-01-01T00:00:00.000Z',
+            endDate: '2019-01-08T00:00:00.000Z',
             periodBy: 'days',
           },
           url:

--- a/src/services/datahub-client.ts
+++ b/src/services/datahub-client.ts
@@ -220,10 +220,12 @@ export class HttpDatahubClient implements DatahubClient {
   public async getVisitsQuantitySummarizedByPeriod({
     domainName,
     dateFrom,
+    dateTo,
     periodBy,
   }: {
     domainName: string;
     dateFrom: Date;
+    dateTo: Date;
     periodBy: filterByPeriodOptions;
   }): Promise<VisitsQuantitySummarizedResult> {
     try {
@@ -231,6 +233,7 @@ export class HttpDatahubClient implements DatahubClient {
         `domains/${domainName}/events/quantity-summarized-by-period`,
         {
           startDate: dateFrom.toISOString(),
+          endDate: dateTo.toISOString(),
           periodBy: periodBy,
         },
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,3 +70,8 @@ export class ResponseCache {
     return this._cachedResults[functionName].value;
   }
 }
+
+export function addDays(date: Date, days: number) {
+  const newDate = new Date(date);
+  return newDate.setDate(date.getDate() + days);
+}


### PR DESCRIPTION
Add explicitly endDate, to avoid getting some extra minutes in datahub. 

**Now:**
![image](https://user-images.githubusercontent.com/2439363/66679375-6cdf1000-ec44-11e9-9039-baebf0a894f7.png)

**Request:**
![image](https://user-images.githubusercontent.com/2439363/66679657-16be9c80-ec45-11e9-82ce-a5089ddcacbc.png)


**In prod we can see the difference **
![image](https://user-images.githubusercontent.com/2439363/66679454-95670a00-ec44-11e9-81f6-e8f8469ce64b.png)
**Request:**
![image](https://user-images.githubusercontent.com/2439363/66679543-cc3d2000-ec44-11e9-975f-9d24235260ee.png)


https://cdn.fromdoppler.com/doppler-webapp/build1705/#/reports

Issue: DW-79

