### PR TITLE
fix(deploy): add enviroment arg to use in copy

### DIFF
--- a/Dockerfile.RELEASES
+++ b/Dockerfile.RELEASES
@@ -39,6 +39,7 @@ RUN AKAMAI_CDN_HOSTNAME=$cdn_hostname \
 
 
 # Runtime layer (Host project in nginx)
+ARG environment
 FROM nginx
 WORKDIR /app
 COPY conf/site${environment}.conf /etc/nginx/conf.d/site.conf


### PR DESCRIPTION
Fix release error see http://104.131.79.81:8080/job/doppler-webapp/job/publish-releases/197/console

```
Step 25/35 : COPY conf/site${environment}.conf /etc/nginx/conf.d/site.conf
COPY failed: stat /var/lib/docker/tmp/docker-builder038373511/conf/site.conf: no such file or directory
```

Add environment as arg before copy to fix this issue.

Issue: DW-84