### PR TITLE
fix: return the right month in getStartOfDate

### DIFF
--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -18,7 +18,7 @@ import { addDays } from '../../utils';
 const periodSelectedDaysDefault = 7;
 
 const getStartOfDate = (date) => {
-  return new Date(date.getFullYear(), date.getMonth() + 1, date.getDate());
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 };
 
 /**


### PR DESCRIPTION
Fix this:

![image](https://user-images.githubusercontent.com/1157864/67935409-8242bc80-fba8-11e9-9b2b-06105eac3f88.png)

Notice that the month is wrong. More details: https://makingsense.slack.com/archives/CGJ72QFQX/p1572470224155300

I will merge without review.