### PR TITLE
New CI process for our swarm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ build
 .vscode
 *.log
 .git
+Dockerfile*

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ build
 *.log
 .git
 Dockerfile*
+Jenkinsfile

--- a/Dockerfile.swarm
+++ b/Dockerfile.swarm
@@ -1,0 +1,31 @@
+FROM node:10 As restore
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . .
+
+FROM restore AS test
+RUN yarn verify
+
+FROM restore AS build
+# development | demo | int | qa | production
+ARG environment=production
+# For CDN: --build-arg react_app_router=hash
+# For Server: --build-arg react_app_router=browser
+ARG react_app_router=browser
+ENV REACT_APP_ROUTER=$react_app_router
+# For CDN: --build-arg public_url="."
+# For Server: --build-arg public_url="/"
+ARG public_url="/"
+ENV PUBLIC_URL=$public_url
+RUN yarn build:$environment
+
+FROM nginx AS final
+WORKDIR /app
+RUN rm /etc/nginx/conf.d/default.conf
+COPY conf/site-swarm.conf /etc/nginx/conf.d/site.conf
+COPY --from=build /app/build /usr/share/nginx/html
+ARG version=unknown
+RUN echo $version > /usr/share/nginx/html/version.txt
+ENTRYPOINT ["nginx", "-g", "daemon off;"]
+EXPOSE 80

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,72 @@
+pipeline {
+    agent any
+    stages {
+        stage('Restore') {
+            steps {
+                sh 'docker build --target restore -f Dockerfile.swarm .'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'docker build --target test -f Dockerfile.swarm .'
+            }
+        }
+        stage('Build') {
+            steps {
+                sh '''docker build \\
+                    --target build \\
+                    --build-arg environment=production \\
+                    --build-arg react_app_router=browser \\
+                    --build-arg public_url="/" \\
+                    -f Dockerfile.swarm \\
+                    .'''
+            }
+        }
+        stage('Build final version images') {
+            when {
+                tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP"
+            }
+            steps {
+                // TODO: add missing environments (development, qa, int)
+                // TODO: remove build differences based on environments to allow reducing the
+                // number of different images. Maybe `demo` and `production` cold be enought
+                sh '''docker build \
+                    -t "fromdoppler/doppler-webapp:production-commit-${GIT_COMMIT}" \\
+                    --build-arg environment=production \\
+                    --build-arg react_app_router=browser \\
+                    --build-arg public_url="/" \\
+                    --build-arg version=production-${TAG_NAME}+${GIT_COMMIT} \\
+                    -f Dockerfile.swarm \\
+                    .'''
+                sh '''docker build \
+                    -t "fromdoppler/doppler-webapp:demo-commit-${GIT_COMMIT}" \\
+                    --build-arg environment=demo \\
+                    --build-arg react_app_router=browser \\
+                    --build-arg public_url="/" \\
+                    --build-arg version=demo-${TAG_NAME}+${GIT_COMMIT} \\
+                    -f Dockerfile.swarm \\
+                    .'''
+            }
+        }
+        stage('Publish final version images') {
+            when {
+                tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP"
+            }
+            steps {
+                // TODO: add all required tags depending on version
+                // TODO: add missing environments (development, qa, int)
+                sh 'docker push fromdoppler/doppler-webapp:production-commit-${GIT_COMMIT}'
+                sh 'docker push fromdoppler/doppler-webapp:demo-commit-${GIT_COMMIT}'
+            }
+        }
+        stage('Generate version') {
+            when {
+                branch 'master'
+            }
+            steps {
+                // TODO: by the moment this work is being done by another Jenkins task
+                sh 'echo TODO: Run semantic release to generate version tag and github release'
+            }
+        }
+    }
+}

--- a/build-n-publish-release-w-docker.sh
+++ b/build-n-publish-release-w-docker.sh
@@ -17,8 +17,6 @@ versionPatch="$(echo $versionFull | cut -d'-' -f1)" # v0.0.0 (ignoring `-` if ex
 versionMayor="$(echo $versionPatch | cut -d'.' -f1)" # v0
 versionMinor="$versionMayor.$(echo $versionPatch | cut -d'.' -f2)" # v0.0
 environments="int qa production"
-dockerhub_writter_username=$DOCKER_WRITTER_USERNAME
-dockerhub_writter_password=$DOCKER_WRITTER_PASSWORD
 
 # Stop script on NZEC
 set -e
@@ -85,38 +83,4 @@ for environment in ${environments}; do
     docker push darosw/doppler-webapp:$environment-$versionMinor
     docker push darosw/doppler-webapp:$environment-$versionPatch
     docker push darosw/doppler-webapp:$environment-$versionFull
-done
-
-for environment in ${environments}; do
-    echo Publishing ${environment} to DockerHub...
-
-    # TODO: It could break concurrent deployments with different docker accounts
-    # It is inside the loop to mitigate collisions
-    docker login -u="$dockerhub_writter_username" -p="$dockerhub_writter_password"
-
-    # TODO: verify if it publish to akamai twice
-    docker build --pull \
-        -t fromdoppler/doppler-webapp:$environment \
-        -t fromdoppler/doppler-webapp:$environment-$versionMayor \
-        -t fromdoppler/doppler-webapp:$environment-$versionMinor \
-        -t fromdoppler/doppler-webapp:$environment-$versionPatch \
-        -t fromdoppler/doppler-webapp:$environment-$versionFull \
-        --build-arg environment=$environment \
-        --build-arg cdnBaseUrl=$cdnBaseUrl \
-        --build-arg pkgVersion=$pkgVersion \
-        --build-arg versionFull=$versionFull \
-        --build-arg pkgBuild=$pkgBuild \
-        --build-arg pkgCommitId=$pkgCommitId \
-        --build-arg cdn_hostname=$AKAMAI_CDN_HOSTNAME \
-        --build-arg cdn_username=$AKAMAI_CDN_USERNAME \
-        --build-arg cdn_password=$AKAMAI_CDN_PASSWORD \
-        --build-arg cdn_cpcode=$AKAMAI_CDN_CPCODE \
-        -f Dockerfile.RELEASES \
-        .
-
-    docker push fromdoppler/doppler-webapp:$environment
-    docker push fromdoppler/doppler-webapp:$environment-$versionMayor
-    docker push fromdoppler/doppler-webapp:$environment-$versionMinor
-    docker push fromdoppler/doppler-webapp:$environment-$versionPatch
-    docker push fromdoppler/doppler-webapp:$environment-$versionFull
 done

--- a/conf/site-swarm.conf
+++ b/conf/site-swarm.conf
@@ -1,0 +1,24 @@
+server {
+        listen                  80 default_server;
+        server_name             localhost;
+
+        gzip                    on;
+        gzip_disable            "msie6";
+        gzip_vary               on;
+        gzip_proxied            any;
+        gzip_comp_level         6;
+        gzip_buffers            16 8k;
+        gzip_http_version       1.1;
+        gzip_types              text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
+
+        location ~* ^.+\.html$ {
+                expires 1h;
+                root    /usr/share/nginx/html;
+                index   index.html index.html;
+        }
+        location / {
+                root    /usr/share/nginx/html;
+                index   index.html index.html;
+                try_files $uri $uri/ /index.html;
+        }
+}


### PR DESCRIPTION
Hi team, 

I am working on a simplified CI flow that also generates the right images with the right tags for our new [FromDoppler Docker Hub Organization](https://hub.docker.com/orgs/fromdoppler).

~~It is not ready to be merged, but I want to start testing the process.~~

Well, I think that it is enough ready to be merged.

This does simple steps in each PR, commit, etc:
* Restore
* Test
* Build (with production parameters)

Then, when a tag is detected, it should:
* Build images for demo and production environments, including _version.txt_ file with a content like this: `production-v1.57.3+4f195f865aa57e782913346dd54bee748dd28755`
* Upload those images to docker hub

Pending:
* Test if tag detection is working fine (I cannot test it without merging)
* Assign the right tag to final versions, for example `production`, `production-v1`, `production-v1.57`, `production-v1.57.3` and `production-v1.57.3+4f195f865aa57e782913346dd54bee748dd28755`
* Generate and upload docker hub images for non-final versions


CC: @cbernat @elsupergomez @swidzinskiMS @fgchaio @javierburger 