### PR TITLE
fix(build): publish final images to docker hub with the right tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,7 @@ pipeline {
             }
         }
         stage('Build final version images') {
-            when {
-                tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP"
-            }
+            when { allOf { buildingTag(); tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP" } }
             steps {
                 // TODO: add missing environments (development, qa, int)
                 // TODO: remove build differences based on environments to allow reducing the
@@ -49,9 +47,7 @@ pipeline {
             }
         }
         stage('Publish final version images') {
-            when {
-                tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP"
-            }
+            when { allOf { buildingTag(); tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP" } }
             steps {
                 // TODO: add missing environments (development, qa, int)
                 sh 'sh publish-commit-image-to-dockerhub.sh production ${GIT_COMMIT} ${TAG_NAME}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,11 @@ pipeline {
             }
         }
         stage('Build final version images') {
-            when { allOf { buildingTag(); tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP" } }
+            when {
+                expression {
+                    return !isVersionTag(readCurrentTag())
+                }
+            }
             steps {
                 // TODO: add missing environments (development, qa, int)
                 // TODO: remove build differences based on environments to allow reducing the
@@ -47,7 +51,11 @@ pipeline {
             }
         }
         stage('Publish final version images') {
-            when { allOf { buildingTag(); tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP" } }
+            when {
+                expression {
+                    return !isVersionTag(readCurrentTag())
+                }
+            }
             steps {
                 // TODO: add missing environments (development, qa, int)
                 sh 'sh publish-commit-image-to-dockerhub.sh production ${GIT_COMMIT} ${TAG_NAME}'
@@ -64,4 +72,23 @@ pipeline {
             }
         }
     }
+}
+
+def boolean isVersionTag(String tag) {
+    echo "checking version tag $tag"
+
+    if (tag == null) {
+        return false
+    }
+
+    // use your preferred pattern
+    def tagMatcher = tag =~ /v\d+\.\d+\.\d+/
+
+    return tagMatcher.matches()
+}
+
+// https://stackoverflow.com/questions/56030364/buildingtag-always-returns-false
+// workaround https://issues.jenkins-ci.org/browse/JENKINS-55987
+def String readCurrentTag() {
+    return sh(returnStdout: true, script: "git describe --tags --match v?*.?*.?* --abbrev=0").trim()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,10 +53,9 @@ pipeline {
                 tag pattern: "v\\d+\\.\\d+\\.\\d+", comparator: "REGEXP"
             }
             steps {
-                // TODO: add all required tags depending on version
                 // TODO: add missing environments (development, qa, int)
-                sh 'docker push fromdoppler/doppler-webapp:production-commit-${GIT_COMMIT}'
-                sh 'docker push fromdoppler/doppler-webapp:demo-commit-${GIT_COMMIT}'
+                sh 'sh publish-commit-image-to-dockerhub.sh production ${GIT_COMMIT} ${TAG_NAME}'
+                sh 'sh publish-commit-image-to-dockerhub.sh demo ${GIT_COMMIT} ${TAG_NAME}'
             }
         }
         stage('Generate version') {

--- a/publish-commit-image-to-dockerhub.sh
+++ b/publish-commit-image-to-dockerhub.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+environment=$1
+commit=$2
+version=$3
+versionPre=$4
+# Examples:
+#   sh publish-to-dockerhub.sh develop 94f85efb9c3689f409104ef7cde6813652ca59fb v12.34.5
+#   sh publish-to-dockerhub.sh production 94f85efb9c3689f409104ef7cde6813652ca59fb v12.34.5 beta1
+#   sh publish-to-dockerhub.sh demo 94f85efb9c3689f409104ef7cde6813652ca59fb v12.34.5 pr123
+
+if [ -z ${environment} ]
+then
+  echo "Missing environment (1st parameter)"
+  exit 1
+fi
+if [ -z ${commit} ]
+then
+  echo "Missing commit (2nd parameter)"
+  exit 1
+fi
+if [ -z ${version} ]
+then
+  echo "Missing version (3th parameter)"
+  exit 1
+fi
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd $(dirname $0)
+
+# To avoid issues with MINGW y Git Bash, see:
+# https://github.com/docker/toolbox/issues/673
+# https://gist.github.com/borekb/cb1536a3685ca6fc0ad9a028e6a959e3
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+versionBuild=${commit}
+# Ugly code to deal with versions
+# Input:
+#   version=v12.34.5
+#   versionBuild=94f85efb9c
+#   versionPre=0pr
+# Output:
+#   preReleasePrefix= "pre-" | ""
+#   versionMayor=v12
+#   versionMayorMinor=v12.34
+#   versionMayorMinorPatch=v12.34.5
+#   versionMayorMinorPatchPre=v12.34.5-0pr
+#   versionFull=v12.34.5-0pr+94f85efb9c
+#   versionFullForTag=v12.34.5-0pr_94f85efb9c
+# region Ugly code to deal with versions
+
+versionFull=${version}
+
+if [ ! -z ${versionPre} ]
+then
+  versionFull=${versionFull}-${versionPre}
+fi
+
+if [ ! -z ${versionBuild} ]
+then
+  versionFull=${versionFull}+${versionBuild}
+fi
+
+# https://semver.org/spec/v2.0.0.html#backusnaur-form-grammar-for-valid-semver-versions
+# <valid semver> ::= <version core>
+#                  | <version core> "-" <pre-release>
+#                  | <version core> "+" <build>
+#                  | <version core> "-" <pre-release> "+" <build>
+#
+# <version core> ::= <major> "." <minor> "." <patch>
+versionBuild="$(echo ${versionFull}+ | cut -d'+' -f2)"
+versionMayorMinorPatchPre="$(echo ${versionFull} | cut -d'+' -f1)" # v0.0.0-xxx (ignoring `+` if exists)
+versionPre="$(echo ${versionMayorMinorPatchPre}- | cut -d'-' -f2)"
+versionMayorMinorPatch="$(echo ${versionMayorMinorPatchPre} | cut -d'-' -f1)" # v0.0.0 (ignoring `-` if exists)
+versionMayor="$(echo ${versionMayorMinorPatch} | cut -d'.' -f1)" # v0
+versionMinor="$(echo ${versionMayorMinorPatch} | cut -d'.' -f2)"
+versionMayorMinor=${versionMayor}.${versionMinor} # v0.0
+versionPatch="$(echo ${versionMayorMinorPatch} | cut -d'.' -f3)"
+
+if [ -z ${versionBuild} ]
+then
+  versionFullForTag=${versionMayorMinorPatchPre}
+else
+  versionFullForTag=${versionMayorMinorPatchPre}_${versionBuild}
+fi
+
+if [ ! -z ${versionPre} ]
+then
+  preReleasePrefix="pre-"
+else
+  preReleasePrefix=""
+fi
+# endregion Ugly code to deal with versions
+
+docker tag fromdoppler/doppler-webapp:${environment}-commit-${commit} fromdoppler/doppler-webapp:${preReleasePrefix}${environment}
+docker tag fromdoppler/doppler-webapp:${environment}-commit-${commit} fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayor}
+docker tag fromdoppler/doppler-webapp:${environment}-commit-${commit} fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayorMinor}
+docker tag fromdoppler/doppler-webapp:${environment}-commit-${commit} fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayorMinorPatch}
+docker tag fromdoppler/doppler-webapp:${environment}-commit-${commit} fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayorMinorPatchPre}
+docker tag fromdoppler/doppler-webapp:${environment}-commit-${commit} fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionFullForTag}
+
+dockerhub_writter_username=$DOCKER_WRITTER_USERNAME
+dockerhub_writter_password=$DOCKER_WRITTER_PASSWORD
+
+docker login -u="${dockerhub_writter_username}" -p="${dockerhub_writter_password}"
+
+docker push fromdoppler/doppler-webapp:${preReleasePrefix}${environment}
+docker push fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayor}
+docker push fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayorMinor}
+docker push fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayorMinorPatch}
+docker push fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionMayorMinorPatchPre}
+docker push fromdoppler/doppler-webapp:${preReleasePrefix}${environment}-${versionFullForTag}


### PR DESCRIPTION
With this change, I am trying to add the right tags to final version images, for example:

* `docker tag fromdoppler/doppler-webapp:production-commit-94f85efb9c3689f409104ef7cde6813652ca59fb fromdoppler/doppler-webapp:production`
* `docker tag fromdoppler/doppler-webapp:production-commit-94f85efb9c3689f409104ef7cde6813652ca59fb fromdoppler/doppler-webapp:production-v12`
* `docker tag fromdoppler/doppler-webapp:production-commit-94f85efb9c3689f409104ef7cde6813652ca59fb fromdoppler/doppler-webapp:production-v12.34`
* `docker tag fromdoppler/doppler-webapp:production-commit-94f85efb9c3689f409104ef7cde6813652ca59fb fromdoppler/doppler-webapp:production-v12.34.5`
* `docker tag fromdoppler/doppler-webapp:production-commit-94f85efb9c3689f409104ef7cde6813652ca59fb fromdoppler/doppler-webapp:production-v12.34.5`
* `docker tag fromdoppler/doppler-webapp:production-commit-94f85efb9c3689f409104ef7cde6813652ca59fb fromdoppler/doppler-webapp:production-v12.34.5_94f85efb9c3689f409104ef7cde6813652ca59fb`

