### PR TITLE
fix(build): move login to our old docker account just before pushing

### DIFF
--- a/build-n-publish-release-w-docker.sh
+++ b/build-n-publish-release-w-docker.sh
@@ -55,10 +55,6 @@ docker pull dopplerrelay/doppler-relay-akamai-publish
 for environment in ${environments}; do
     echo Publishing ${environment}...
 
-    # TODO: It could break concurrent deployments with different docker accounts
-    # It is inside the loop to mitigate collisions
-    docker login -u="$DOCKER_WEBAPP_USERNAME" -p="$DOCKER_WEBAPP_PASSWORD"
-
     docker build --pull \
         -t darosw/doppler-webapp:$environment \
         -t darosw/doppler-webapp:$environment-$versionMayor \
@@ -77,6 +73,10 @@ for environment in ${environments}; do
         --build-arg cdn_cpcode=$AKAMAI_CDN_CPCODE \
         -f Dockerfile.RELEASES \
         .
+
+    # TODO: It could break concurrent deployments with different docker accounts
+    # It is inside the loop to mitigate collisions
+    docker login -u="$DOCKER_WEBAPP_USERNAME" -p="$DOCKER_WEBAPP_PASSWORD"
 
     docker push darosw/doppler-webapp:$environment
     docker push darosw/doppler-webapp:$environment-$versionMayor


### PR DESCRIPTION
I am trying to mitigate this problem:

![image](https://user-images.githubusercontent.com/1157864/68587599-33c5d580-0466-11ea-8547-c33ea27e21e3.png)
