### PR TITLE
fix(ReportsPageRanking.test): remove test because duplicated

### DIFF
--- a/src/components/Reports/ReportsPageRanking/ReportsPageRanking.test.js
+++ b/src/components/Reports/ReportsPageRanking/ReportsPageRanking.test.js
@@ -33,27 +33,8 @@ const fakePagesData = {
   },
 };
 
-const emptyResponse = {
-  success: false,
-  value: [],
-};
-
 describe('Reports pages ranking', () => {
   afterEach(cleanup);
-
-  it('render component without pages', () => {
-    const datahubClientDouble = {
-      getPagesRankingByPeriod: async () => emptyResponse,
-    };
-
-    render(
-      <AppServicesProvider forcedServices={{ datahubClient: datahubClientDouble }}>
-        <DopplerIntlProvider>
-          <ReportsPageRanking />
-        </DopplerIntlProvider>
-      </AppServicesProvider>,
-    );
-  });
 
   it('should render pages ranking', async () => {
     const datahubClientDouble = {


### PR DESCRIPTION
- Remove the test to check page ranking without pages because we already have a test to test this scenario.
- When remove this fix 1 'act' warning 💃 