### PR TITLE
Dw-117 jenkins pipeline conditional build for dependabot 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,17 @@
 pipeline {
     agent any
     stages {
+        stage('Confirmation') {
+            when {
+                beforeInput true
+                changeRequest author: 'dependabot-preview'
+            }
+            steps {
+                timeout(time: 180, unit: 'SECONDS') {
+                    input('Continue build?')
+                }
+            }
+        }
         stage('Restore') {
             steps {
                 sh 'docker build --target restore -f Dockerfile.swarm .'


### PR DESCRIPTION
Added condition in jenkins pipeline, to prevent automatic build. 
If we would want to make a rebuild, we need to wait by blue view to accept the build (because it will timeout in 60 seconds window)
Else it will fail by timeout.