### PR TITLE
fix: add error in box shadow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://cdn.fromdoppler.com/doppler-ui-library/v3.23.3/css/styles.css"
+      href="https://cdn.fromdoppler.com/doppler-ui-library/build649/css/styles.css"
     />
     <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/zoho-chat.css" />
     <!--

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://cdn.fromdoppler.com/doppler-ui-library/build649/css/styles.css"
+      href="https://cdn.fromdoppler.com/doppler-ui-library/v3.23.6/css/styles.css"
     />
     <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/zoho-chat.css" />
     <!--

--- a/src/components/Reports/ReportsBox/ReportsBox.js
+++ b/src/components/Reports/ReportsBox/ReportsBox.js
@@ -65,7 +65,9 @@ const ReportsBox = ({
           </p>
         </>
       ) : (
-        <span>Unexpected error</span>
+        <p className="dp-boxshadow--error">
+          <FormattedMessage id="trafficSources.error" />
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
Related to: https://github.com/FromDoppler/Doppler-UI-System/pull/207

![error-box-shadow](https://user-images.githubusercontent.com/46735526/68859781-ce245400-06c6-11ea-8df4-f404a0c28bc2.jpg)
