### PR TITLE
feat(log): add trace and fullResponse in unexpected error to be logged

### DIFF
--- a/src/doppler-types.ts
+++ b/src/doppler-types.ts
@@ -1,10 +1,4 @@
-export type UnexpectedError = {
-  success?: false;
-  message?: string;
-  trace?: any;
-  fullResponse?: any;
-  error?: any;
-};
+export type UnexpectedError = { success?: false } | { success?: false; [key: string]: any };
 export type ErrorResult<TError> = { success?: false; expectedError: TError } | UnexpectedError;
 export type Result<TResult, TError> = { success: true; value: TResult } | ErrorResult<TError>;
 export type ResultWithoutExpectedErrors<TResult> =

--- a/src/doppler-types.ts
+++ b/src/doppler-types.ts
@@ -1,4 +1,10 @@
-export type UnexpectedError = { success?: false; message?: string | null; error?: any };
+export type UnexpectedError = {
+  success?: false;
+  message?: string;
+  trace?: any;
+  fullResponse?: any;
+  error?: any;
+};
 export type ErrorResult<TError> = { success?: false; expectedError: TError } | UnexpectedError;
 export type Result<TResult, TError> = { success: true; value: TResult } | ErrorResult<TError>;
 export type ResultWithoutExpectedErrors<TResult> =

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -28,6 +28,12 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
     // return { expectedError: { invalidLogin: true } };
     // return { expectedError: { blockedAccountInvalidPassword: true } };
     // return { success: false, error: 'Error code' };
+    // return {
+    //   success: false,
+    //   message: 'Error code',
+    //   trace: new Error(),
+    //   fullResponse: { test: 'test' },
+    // };
   }
 
   public async registerUser(model: UserRegistrationModel): Promise<UserRegistrationResult> {

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -310,6 +310,8 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
           default: {
             return {
               message: response.data.error || null,
+              trace: new Error(),
+              fullResponse: response,
             };
           }
         }


### PR DESCRIPTION
### Weird wrong captcha error in log
Logging unexpected errors we found some weird wrongCaptcha error, that needed more data to be understanded. Why? because it's nearly impossible to reproduce, the captcha does not allow to send a wrong captcha to BE and the message is sent from BE. 

In loggly:

![image](https://user-images.githubusercontent.com/2439363/71527369-dc66b200-28b9-11ea-9d80-85f3ee81dc9b.png)

Message from BE in doppler --> https://github.com/MakingSense/Doppler/blob/develop/Doppler.Presentation.MVC/Controllers/WebAppPublicController.cs#L312

### Data added:
- trace from FE
- full response from service call
