### PR TITLE
feat(login): map max attemps error into message

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -128,7 +128,11 @@ const Login = ({ location, dependencies: { dopplerLegacyClient, sessionManager, 
         setErrors({
           _error: <FormattedHTMLMessage id="validation_messages.error_account_is_canceled_HTML" />,
         });
-      } else if (result.expectedError && result.expectedError.blockedAccountInvalidPassword) {
+      } else if (
+        result.expectedError &&
+        (result.expectedError.blockedAccountInvalidPassword ||
+          result.expectedError.maxLoginAttempts)
+      ) {
         setErrors({
           _error: (
             <FormattedHTMLMessage id="validation_messages.error_account_is_blocked_invalid_pass_HTML" />

--- a/src/components/Login/Login.test.js
+++ b/src/components/Login/Login.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, cleanup, waitForDomChange, fireEvent, wait } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import IntlProvider from '../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+import { MemoryRouter as Router } from 'react-router-dom';
+import Login from './Login';
+import { AppServicesProvider } from '../../services/pure-di';
+import { Formik } from 'formik';
+
+describe('Login component', () => {
+  afterEach(cleanup);
+
+  it('renders Login without error', async () => {
+    // Arrange
+    const dependencies = {
+      window: {
+        location: {},
+      },
+    };
+    const location = {
+      state: {
+        email: '',
+      },
+    };
+
+    // Act
+    const { container, getByText } = render(
+      <AppServicesProvider forcedServices={dependencies}>
+        <IntlProvider>
+          <Router>
+            <Login location={location} />
+          </Router>
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    await waitForDomChange();
+    console.log(container);
+    expect(getByText('login.button_login')).toBeInTheDocument();
+  });
+});

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -27,6 +27,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
     // return { expectedError: { cancelatedAccount: true } };
     // return { expectedError: { invalidLogin: true } };
     // return { expectedError: { blockedAccountInvalidPassword: true } };
+    // return { expectedError: { maxLoginAttempts: true } };
     // return { success: false, error: 'Error code' };
     // return {
     //   success: false,

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -38,6 +38,7 @@ export type LoginErrorResult =
       cancelatedAccount?: false;
       blockedAccountInvalidPassword?: false;
       invalidLogin?: false;
+      maxLoginAttempts?: false;
     }
   | {
       accountNotValidated: true;
@@ -45,6 +46,7 @@ export type LoginErrorResult =
       blockedAccountNotPayed?: false;
       blockedAccountInvalidPassword?: false;
       invalidLogin?: false;
+      maxLoginAttempts?: false;
     }
   | {
       cancelatedAccount: true;
@@ -52,6 +54,7 @@ export type LoginErrorResult =
       accountNotValidated?: false;
       blockedAccountInvalidPassword?: false;
       invalidLogin?: false;
+      maxLoginAttempts?: false;
     }
   | {
       blockedAccountInvalidPassword: true;
@@ -59,6 +62,7 @@ export type LoginErrorResult =
       accountNotValidated?: false;
       cancelatedAccount?: false;
       invalidLogin?: false;
+      maxLoginAttempts?: false;
     }
   | {
       invalidLogin: true;
@@ -66,6 +70,15 @@ export type LoginErrorResult =
       blockedAccountNotPayed?: false;
       accountNotValidated?: false;
       cancelatedAccount?: false;
+      maxLoginAttempts?: false;
+    }
+  | {
+      blockedAccountInvalidPassword: true;
+      blockedAccountNotPayed?: false;
+      accountNotValidated?: false;
+      cancelatedAccount?: false;
+      invalidLogin?: false;
+      maxLoginAttempts: true;
     };
 
 export type LoginResult = Result<{ redirectUrl?: string }, LoginErrorResult>;


### PR DESCRIPTION
Add message for login maximum attempts reached, instead of unexpected error message. 

![image](https://user-images.githubusercontent.com/2439363/72074908-86d6d000-32d1-11ea-9c36-aa1948bc4fce.png)

Issue: DW-157