### PR TITLE
fix(login): map max login attempts in service

### DIFF
--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -337,6 +337,9 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
           case 'InvalidLogin': {
             return { expectedError: { invalidLogin: true } };
           }
+          case 'MaxLoginAttempts': {
+            return { expectedError: { maxLoginAttempts: true } };
+          }
           default: {
             return {
               message: response.data.error || null,


### PR DESCRIPTION
Add map for max login attempts in service that was missing.

In loggly console it was still showing the error:

![image](https://user-images.githubusercontent.com/2439363/72831445-a7077700-3c61-11ea-9ace-2a0acf1e6b4a.png)
