### PR TITLE
DW-158:feat: capture wrong captcha error from BE

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -140,6 +140,16 @@ const Login = ({ location, dependencies: { dopplerLegacyClient, sessionManager, 
         });
       } else if (result.expectedError && result.expectedError.invalidLogin) {
         setErrors({ _error: 'validation_messages.error_invalid_login' });
+      } else if (result.expectedError && result.expectedError.wrongCaptcha) {
+        setErrors({ _error: 'validation_messages.error_invalid_captcha' });
+        addLogEntry({
+          account: values[fieldNames.user],
+          origin: window.location.origin,
+          section: 'Login',
+          browser: window.navigator.userAgent,
+          error: result,
+        });
+        console.log('invalid captcha', result);
       } else {
         console.log('Unexpected error', result);
         setErrors({

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -354,6 +354,7 @@ export default {
       `,
     error_checkbox_policy: `Ouch! You haven't accepted the Doppler's Privacy Policy.`,
     error_email_already_exists: `Ouch! You already have a Doppler account.`,
+    error_invalid_captcha: `Ouch! We couldn't validate you are a human, please reload the page and try again.`,
     error_invalid_domain_to_register_account: `Ouch! Invalid Email to create an account.`,
     error_invalid_email_address: `Ouch! Enter a valid Email.`,
     error_invalid_login: `Ouch! There is an error in your Username or Password. Please, try again.`,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -356,6 +356,7 @@ export default {
       `,
     error_checkbox_policy: `¡Ouch! No has aceptado la Política de Privacidad de Doppler.`,
     error_email_already_exists: `¡Ouch! Ya posees una cuenta en Doppler.`,
+    error_invalid_captcha: `¡Ouch! No pudimos validar que seas humano, por favor refresca la pantalla e intenta nuevamente.`,
     error_invalid_domain_to_register_account: `¡Ouch! Email inválido para crear una cuenta.`,
     error_invalid_email_address: `¡Ouch! El formato del Email es incorrecto`,
     error_invalid_login: `¡Ouch! Hay un error en tu Usuario o Contraseña. Vuelve a intentarlo.`,

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -35,6 +35,12 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
     //   trace: new Error(),
     //   fullResponse: { test: 'test' },
     // };
+    // return {
+    //   expectedError: { wrongCaptcha: true },
+    //   message: 'response.data.error' || null,
+    //   trace: new Error(),
+    //   fullResponse: 'full header response',
+    // };
   }
 
   public async registerUser(model: UserRegistrationModel): Promise<UserRegistrationResult> {

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -39,6 +39,7 @@ export type LoginErrorResult =
       blockedAccountInvalidPassword?: false;
       invalidLogin?: false;
       maxLoginAttempts?: false;
+      wrongCaptcha?: false;
     }
   | {
       accountNotValidated: true;
@@ -47,6 +48,7 @@ export type LoginErrorResult =
       blockedAccountInvalidPassword?: false;
       invalidLogin?: false;
       maxLoginAttempts?: false;
+      wrongCaptcha?: false;
     }
   | {
       cancelatedAccount: true;
@@ -55,6 +57,7 @@ export type LoginErrorResult =
       blockedAccountInvalidPassword?: false;
       invalidLogin?: false;
       maxLoginAttempts?: false;
+      wrongCaptcha?: false;
     }
   | {
       blockedAccountInvalidPassword: true;
@@ -63,6 +66,7 @@ export type LoginErrorResult =
       cancelatedAccount?: false;
       invalidLogin?: false;
       maxLoginAttempts?: false;
+      wrongCaptcha?: false;
     }
   | {
       invalidLogin: true;
@@ -71,6 +75,7 @@ export type LoginErrorResult =
       accountNotValidated?: false;
       cancelatedAccount?: false;
       maxLoginAttempts?: false;
+      wrongCaptcha?: false;
     }
   | {
       blockedAccountInvalidPassword: true;
@@ -79,6 +84,16 @@ export type LoginErrorResult =
       cancelatedAccount?: false;
       invalidLogin?: false;
       maxLoginAttempts: true;
+      wrongCaptcha?: false;
+    }
+  | {
+      blockedAccountInvalidPassword: true;
+      blockedAccountNotPayed?: false;
+      accountNotValidated?: false;
+      cancelatedAccount?: false;
+      invalidLogin?: false;
+      maxLoginAttempts: true;
+      wrongCaptcha?: true;
     };
 
 export type LoginResult = Result<{ redirectUrl?: string }, LoginErrorResult>;
@@ -339,6 +354,14 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
           }
           case 'MaxLoginAttempts': {
             return { expectedError: { maxLoginAttempts: true } };
+          }
+          case 'WrongCatpcha': {
+            return {
+              expectedError: { wrongCaptcha: true },
+              message: response.data.error || null,
+              trace: new Error(),
+              fullResponse: response,
+            };
           }
           default: {
             return {


### PR DESCRIPTION
When captcha fails in back end, the error is displayed in the logs, but we are not warning de user about this kind of error, and we do not know what migth be triggering it. 

Informing the user can help us if he/she contacts support. They can provide with steps to reproduce this issue. 

![image](https://user-images.githubusercontent.com/2439363/72835891-52b4c500-3c6a-11ea-9e3b-9d55bf3d28c2.png)
