### PR TITLE
DW-195: fix: remove some time filters for now

### DIFF
--- a/src/components/Reports/ReportsFilters/ReportsFilters.js
+++ b/src/components/Reports/ReportsFilters/ReportsFilters.js
@@ -88,6 +88,7 @@ const ReportsFilters = ({
                     >
                       {(message) => <option value="7">{message}</option>}
                     </FormattedMessage>
+                    {/* **temporarily remove until DH performance issues can be addresed
                     <FormattedMessage
                       id="reports_filters.week_with_plural"
                       values={{ weeksCount: 2 }}
@@ -99,7 +100,7 @@ const ReportsFilters = ({
                       values={{ weeksCount: 3 }}
                     >
                       {(message) => <option value="21">{message}</option>}
-                    </FormattedMessage>
+                    </FormattedMessage>*/}
                   </select>
                 </fieldset>
               </div>


### PR DESCRIPTION
Removed 2 weeks and 3 weeks options just for now.

![image](https://user-images.githubusercontent.com/2439363/73875998-f25e7f80-4834-11ea-9e57-1de5bd927cf6.png)
