### PR TITLE
fix(utils): parse email with + sign

### DIFF
--- a/src/components/Reports/SubscriberHistory/SubscriberHistory.js
+++ b/src/components/Reports/SubscriberHistory/SubscriberHistory.js
@@ -29,6 +29,10 @@ const getDeliveryStatusCssClassName = (deliveryStatus) => {
   return deliveryCssClass;
 };
 
+const replaceSpaceWithSigns = (url) => {
+  return url ? url.replace(' ', '+') : '';
+};
+
 const campaignsPerPage = 10;
 
 const SubscriberHistory = ({ location, dependencies: { dopplerApiClient } }) => {
@@ -39,7 +43,7 @@ const SubscriberHistory = ({ location, dependencies: { dopplerApiClient } }) => 
   useEffect(() => {
     const fetchData = async () => {
       setState({ loading: true });
-      const email = extractParameter(location, queryString.parse, 'email');
+      const email = replaceSpaceWithSigns(extractParameter(location, queryString.parse, 'email'));
       const currentPage = extractParameter(location, queryString.parse, 'page') || 1;
       const responseSubscriber = await dopplerApiClient.getSubscriber(email);
       if (responseSubscriber.success) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -226,6 +226,19 @@ describe('utils', () => {
       expect(param).toEqual('http://mypage.com');
     });
 
+    it('should map parameter with char +', () => {
+      // Arrange
+      var location = {
+        search: '?email=fcoronel+2@makingsense.com',
+      };
+
+      // Act
+      var param = extractParameter(location, queryString.parse, 'email');
+
+      // Assert
+      expect(param).toEqual('fcoronel 2@makingsense.com');
+    });
+
     it('should return null if parameter does not exist', () => {
       // Arrange
       var location = {


### PR DESCRIPTION
- the problem is when have and email with `+` the parser convert this in space and dont works. but if we encode the sign `+` works fine