### PR TITLE
feat: DW-202 set default filter to today temporarily

### DIFF
--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -18,7 +18,7 @@ import { addDays, getStartOfDate } from '../../utils';
 import { BoxMessage } from '../styles/messages';
 
 // This value means the today date
-const periodSelectedDaysDefault = 7;
+const periodSelectedDaysDefault = 0; /* set this value temporarily for datahub performance issue */
 
 /**
  * @param { Object } props


### PR DESCRIPTION
Set default time filter in reports page to today to mitigate datahub performance issue. 

![image](https://user-images.githubusercontent.com/2439363/74039316-5fdaef00-49a0-11ea-8d4f-6ca1f9243a48.png)
