### PR TITLE
Dw-155: gdpr list by subscriber

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://cdn.fromdoppler.com/doppler-ui-library/v3.31.3/css/styles.css"
+      href="https://cdn.fromdoppler.com/doppler-ui-library/v3.35.0/css/styles.css"
     />
     <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/zoho-chat.css" />
     <!--
@@ -71,7 +71,7 @@
     -->
     <script
       type="text/javascript"
-      src="https://cdn.fromdoppler.com/doppler-ui-library/v3.9.5/js/app.js"
+      src="https://cdn.fromdoppler.com/doppler-ui-library/v3.35.0/js/app.js"
     ></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
     <script

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import Shopify from './components/Integrations/Shopify/Shopify';
 import SignupConfirmation from './components/Signup/SignupConfirmation';
 import MasterSubscriber from './components/Reports/MasterSubscriber/MasterSubscriber';
 import SubscriberHistory from './components/Reports/SubscriberHistory/SubscriberHistory';
+import SubscriberGdpr from './components/Reports/GDPR/SubscriberGdpr';
 
 /**
  * @param { Object } props - props
@@ -93,6 +94,7 @@ const App = ({ locale, location, dependencies: { appSessionRef, sessionManager }
           <PrivateRoute path="/integrations/shopify" exact component={Shopify} />
           <PrivateRoute path="/reports/master-subscriber" exact component={MasterSubscriber} />
           <PrivateRoute path="/reports/subscriber-history" exact component={SubscriberHistory} />
+          <PrivateRoute path="/reports/subscriber-gdpr" exact component={SubscriberGdpr} />
           <PublicRouteWithLegacyFallback exact path="/login" />
           <PublicRouteWithLegacyFallback exact path="/signup" />
           <PublicRouteWithLegacyFallback exact path="/login/reset-password" />

--- a/src/components/Reports/GDPR/SubscriberGdpr.js
+++ b/src/components/Reports/GDPR/SubscriberGdpr.js
@@ -24,13 +24,18 @@ const SubscriberGdpr = ({ location, dependencies: { dopplerApiClient } }) => {
       const responseSubscriber = await dopplerApiClient.getSubscriber(email);
       if (responseSubscriber.success) {
         const subscriber = {
-          ...responseSubscriber.value,
           firstName: responseSubscriber.value.fields.find((x) => x.name === 'FIRSTNAME'),
           lastName: responseSubscriber.value.fields.find((x) => x.name === 'LASTNAME'),
+          email: responseSubscriber.value.email,
+          score: responseSubscriber.value.score,
+          status: responseSubscriber.value.status,
         };
         setState({
           loading: false,
           subscriber: subscriber,
+          fields: responseSubscriber.value.fields.filter(
+            (customField) => customField.type === 'permission' || customField.type === 'consent',
+          ),
           email: email,
         });
       } else {
@@ -129,48 +134,39 @@ const SubscriberGdpr = ({ location, dependencies: { dopplerApiClient } }) => {
                           </tr>
                         </thead>
                         <tbody>
-                          {state.subscriber.fields.some(
-                            (element) =>
-                              element.type === 'permission' || element.type === 'consent',
-                          ) ? (
+                          {state.fields.length ? (
                             <>
-                              {state.subscriber.fields
-                                .filter(
-                                  (customField) =>
-                                    customField.type === 'permission' ||
-                                    customField.type === 'consent',
-                                )
-                                .map((field, index) => (
-                                  <tr key={index}>
-                                    <td>{field.name}</td>
-                                    <td>
-                                      {field.permissionHTML ? (
-                                        <div
-                                          dangerouslySetInnerHTML={{
-                                            __html: field.permissionHTML
-                                              .replace('<p>', '<span>')
-                                              .replace('</p>', '</span>'),
-                                          }}
-                                        />
-                                      ) : (
-                                        <FormattedMessage id="subscriber_gdpr.empty_html_text" />
-                                      )}
-                                    </td>
-                                    <td>
-                                      {field.value.toLowerCase() === 'true' ? (
-                                        <div className="dp-icon-wrapper">
-                                          <span className="ms-icon icon-lock dp-lock-green"></span>
-                                          <FormattedMessage id="subscriber_gdpr.value_true" />
-                                        </div>
-                                      ) : (
-                                        <div className="dp-icon-wrapper">
-                                          <span className="ms-icon icon-lock dp-lock-red"></span>
-                                          <FormattedMessage id="subscriber_gdpr.value_false" />
-                                        </div>
-                                      )}
-                                    </td>
-                                  </tr>
-                                ))}
+                              {state.fields.map((field, index) => (
+                                <tr key={index}>
+                                  <td>{field.name}</td>
+                                  <td>
+                                    {field.permissionHTML ? (
+                                      <div
+                                        dangerouslySetInnerHTML={{
+                                          __html: field.permissionHTML
+                                            .replace('<p>', '<span>')
+                                            .replace('</p>', '</span>'),
+                                        }}
+                                      />
+                                    ) : (
+                                      <FormattedMessage id="subscriber_gdpr.empty_html_text" />
+                                    )}
+                                  </td>
+                                  <td>
+                                    {field.value.toLowerCase() === 'true' ? (
+                                      <div className="dp-icon-wrapper">
+                                        <span className="ms-icon icon-lock dp-lock-green"></span>
+                                        <FormattedMessage id="subscriber_gdpr.value_true" />
+                                      </div>
+                                    ) : (
+                                      <div className="dp-icon-wrapper">
+                                        <span className="ms-icon icon-lock dp-lock-red"></span>
+                                        <FormattedMessage id="subscriber_gdpr.value_false" />
+                                      </div>
+                                    )}
+                                  </td>
+                                </tr>
+                              ))}
                             </>
                           ) : (
                             <tr>

--- a/src/components/Reports/GDPR/SubscriberGdpr.js
+++ b/src/components/Reports/GDPR/SubscriberGdpr.js
@@ -1,19 +1,44 @@
-import React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import React, { useState, useEffect } from 'react';
+import { FormattedMessage, useIntl, FormattedDate } from 'react-intl';
 import { Helmet } from 'react-helmet';
-import { extractParameter } from './../../../utils';
+import { getSubscriberStatusCssClassName, extractParameter } from './../../../utils';
 import queryString from 'query-string';
 import { InjectAppServices } from '../../../services/pure-di';
+import { Loading } from '../../Loading/Loading';
+import { StarsScore } from '../../shared/StarsScore/StarsScore';
+import SafeRedirect from '../../SafeRedirect';
 
-const SubscriberGdpr = ({ location }) => {
+const SubscriberGdpr = ({ location, dependencies: { dopplerApiClient } }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const [state, setState] = useState({ loading: true });
 
   const replaceSpaceWithSigns = (url) => {
     return url ? url.replace(' ', '+') : '';
   };
 
-  const email = replaceSpaceWithSigns(extractParameter(location, queryString.parse, 'email'));
+  useEffect(() => {
+    const fetchData = async () => {
+      setState({ loading: true });
+      const email = replaceSpaceWithSigns(extractParameter(location, queryString.parse, 'email'));
+      const responseSubscriber = await dopplerApiClient.getSubscriber(email);
+      if (responseSubscriber.success) {
+        const subscriber = {
+          ...responseSubscriber.value,
+          firstName: responseSubscriber.value.fields.find((x) => x.name === 'FIRSTNAME'),
+          lastName: responseSubscriber.value.fields.find((x) => x.name === 'LASTNAME'),
+        };
+        setState({
+          loading: false,
+          subscriber: subscriber,
+          email: email,
+        });
+      } else {
+        setState({ loading: false });
+      }
+    };
+    fetchData();
+  }, [dopplerApiClient, location]);
 
   return (
     <>
@@ -25,19 +50,149 @@ const SubscriberGdpr = ({ location }) => {
           </Helmet>
         )}
       </FormattedMessage>
-      <header className="report-filters">
-        <div className="dp-container">
-          <div className="dp-rowflex">
-            <div className="col-sm-12 col-md-12 col-lg-12">
-              <h3>
-                <FormattedMessage id="subscriber_gdpr.header_title" />
-              </h3>
-              <span className="arrow" />
+      {state.loading ? (
+        <Loading />
+      ) : state.subscriber ? (
+        <>
+          <header className="report-filters">
+            <div className="dp-container">
+              <div className="dp-rowflex">
+                <div className="col-sm-12 col-md-12 col-lg-12">
+                  <h3>
+                    <FormattedMessage id="subscriber_gdpr.header_title" />
+                  </h3>
+                  <p>
+                    <FormattedMessage id="subscriber_gdpr.header_description" />
+                  </p>
+                  <span className="arrow" />
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      </header>
-      <section className="dp-container">{email}</section>
+          </header>
+          <section className="dp-container">
+            <div className="dp-rowflex">
+              <div className="col-sm-12 m-t-24 m-b-36">
+                <div className="dp-block-wlp dp-box-shadow m-t-36">
+                  <header className="dp-header-campaing dp-rowflex p-l-18">
+                    <div className="col-lg-6 col-md-12 m-b-24">
+                      <div className="dp-calification">
+                        <span className="dp-useremail-campaign">
+                          <strong>{state.subscriber.email}</strong>
+                        </span>
+                        <StarsScore score={state.subscriber.score} />
+                      </div>
+                      <span className="dp-username-campaing">
+                        {state.subscriber.firstName ? state.subscriber.firstName.value : ''}{' '}
+                        {state.subscriber.lastName ? state.subscriber.lastName.value : ''}
+                      </span>
+                      <span className="dp-subscriber-icon">
+                        <span
+                          className={
+                            'ms-icon icon-user ' +
+                            getSubscriberStatusCssClassName(state.subscriber.status)
+                          }
+                        ></span>
+                        <FormattedMessage id={'subscriber.status.' + state.subscriber.status} />
+                      </span>
+                      {state.subscriber.status.includes('unsubscribed') ? (
+                        <ul className="dp-rowflex col-sm-12 dp-subscriber-info">
+                          <li className="col-sm-12 col-md-4 col-lg-3">
+                            <span className="dp-block-info">
+                              <FormattedMessage id="subscriber_history.unsubscribed_date" />
+                            </span>
+                            <span>
+                              <FormattedDate value={state.subscriber.unsubscribedDate} />
+                            </span>
+                          </li>
+                        </ul>
+                      ) : null}
+                    </div>
+                  </header>
+                  <div>
+                    <div className="dp-table-responsive">
+                      <table
+                        className="dp-c-table"
+                        aria-label={_('subscriber_history.table_result.aria_label_table')}
+                        summary={_('subscriber_history.table_result.aria_label_table')}
+                      >
+                        <thead>
+                          <tr>
+                            <th scope="col">
+                              <FormattedMessage id="subscriber_gdpr.permission_name" />
+                            </th>
+                            <th scope="col">
+                              <FormattedMessage id="subscriber_gdpr.permission_description" />
+                            </th>
+                            <th scope="col">
+                              <FormattedMessage id="subscriber_gdpr.permission_value" />
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {state.subscriber.fields.some(
+                            (element) =>
+                              element.type === 'permission' || element.type === 'consent',
+                          ) ? (
+                            <>
+                              {state.subscriber.fields
+                                .filter(
+                                  (customField) =>
+                                    customField.type === 'permission' ||
+                                    customField.type === 'consent',
+                                )
+                                .map((field, index) => (
+                                  <tr key={index}>
+                                    <td>{field.name}</td>
+                                    <td>
+                                      {field.permissionHTML ? (
+                                        <div
+                                          dangerouslySetInnerHTML={{
+                                            __html: field.permissionHTML
+                                              .replace('<p>', '<span>')
+                                              .replace('</p>', '</span>'),
+                                          }}
+                                        />
+                                      ) : (
+                                        <FormattedMessage id="subscriber_gdpr.empty_html_text" />
+                                      )}
+                                    </td>
+                                    <td>
+                                      {field.value.toLowerCase() === 'true' ? (
+                                        <span className="status--opened">
+                                          <FormattedMessage id="subscriber_gdpr.value_true" />
+                                        </span>
+                                      ) : (
+                                        <span className="status--hard-bounced">
+                                          <FormattedMessage id="subscriber_gdpr.value_false" />
+                                        </span>
+                                      )}
+                                    </td>
+                                  </tr>
+                                ))}
+                            </>
+                          ) : (
+                            <tr>
+                              <td>
+                                <span className="bounceIn">
+                                  <FormattedMessage id="subscriber_gdpr.empty_data" />
+                                </span>
+                              </td>
+                              <td></td>
+                              <td></td>
+                            </tr>
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </>
+      ) : (
+        <SafeRedirect to="/Lists/MasterSubscriber/" />
+      )}
     </>
   );
 };

--- a/src/components/Reports/GDPR/SubscriberGdpr.js
+++ b/src/components/Reports/GDPR/SubscriberGdpr.js
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { FormattedMessage, useIntl, FormattedDate } from 'react-intl';
 import { Helmet } from 'react-helmet';
-import { getSubscriberStatusCssClassName, extractParameter } from './../../../utils';
+import {
+  getSubscriberStatusCssClassName,
+  extractParameter,
+  replaceSpaceWithSigns,
+} from './../../../utils';
 import queryString from 'query-string';
 import { InjectAppServices } from '../../../services/pure-di';
 import { Loading } from '../../Loading/Loading';
@@ -12,10 +16,6 @@ const SubscriberGdpr = ({ location, dependencies: { dopplerApiClient } }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
   const [state, setState] = useState({ loading: true });
-
-  const replaceSpaceWithSigns = (url) => {
-    return url ? url.replace(' ', '+') : '';
-  };
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/components/Reports/GDPR/SubscriberGdpr.js
+++ b/src/components/Reports/GDPR/SubscriberGdpr.js
@@ -158,13 +158,15 @@ const SubscriberGdpr = ({ location, dependencies: { dopplerApiClient } }) => {
                                     </td>
                                     <td>
                                       {field.value.toLowerCase() === 'true' ? (
-                                        <span className="status--opened">
+                                        <div className="dp-icon-wrapper">
+                                          <span className="ms-icon icon-lock dp-lock-green"></span>
                                           <FormattedMessage id="subscriber_gdpr.value_true" />
-                                        </span>
+                                        </div>
                                       ) : (
-                                        <span className="status--hard-bounced">
+                                        <div className="dp-icon-wrapper">
+                                          <span className="ms-icon icon-lock dp-lock-red"></span>
                                           <FormattedMessage id="subscriber_gdpr.value_false" />
-                                        </span>
+                                        </div>
                                       )}
                                     </td>
                                   </tr>

--- a/src/components/Reports/GDPR/SubscriberGdpr.js
+++ b/src/components/Reports/GDPR/SubscriberGdpr.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Helmet } from 'react-helmet';
+import { extractParameter } from './../../../utils';
+import queryString from 'query-string';
+import { InjectAppServices } from '../../../services/pure-di';
+
+const SubscriberGdpr = ({ location }) => {
+  const intl = useIntl();
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  const replaceSpaceWithSigns = (url) => {
+    return url ? url.replace(' ', '+') : '';
+  };
+
+  const email = replaceSpaceWithSigns(extractParameter(location, queryString.parse, 'email'));
+
+  return (
+    <>
+      <FormattedMessage id="subscriber_gdpr.page_title">
+        {(page_title) => (
+          <Helmet>
+            <title>{page_title}</title>
+            <meta name="description" content={_('subscriber_gdpr.page_description')} />
+          </Helmet>
+        )}
+      </FormattedMessage>
+      <header className="report-filters">
+        <div className="dp-container">
+          <div className="dp-rowflex">
+            <div className="col-sm-12 col-md-12 col-lg-12">
+              <h3>
+                <FormattedMessage id="subscriber_gdpr.header_title" />
+              </h3>
+              <span className="arrow" />
+            </div>
+          </div>
+        </div>
+      </header>
+      <section className="dp-container">{email}</section>
+    </>
+  );
+};
+export default InjectAppServices(SubscriberGdpr);

--- a/src/components/Reports/GDPR/SubscriberGdpr.test.js
+++ b/src/components/Reports/GDPR/SubscriberGdpr.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, cleanup, waitForDomChange } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import IntlProvider from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+import SubscriberGdpr from './SubscriberGdpr';
+import { AppServicesProvider } from '../../../services/pure-di';
+
+describe('SubscriberGdpr report component', () => {
+  afterEach(cleanup);
+
+  it('renders subscriber gdpr report without error', () => {
+    // Arrange
+    // Act
+    render(
+      <IntlProvider>
+        <SubscriberGdpr />
+      </IntlProvider>,
+    );
+    // Assert
+  });
+
+  it('renders subscriber gdpr intenationalized title', () => {
+    // Arrange
+    // Act
+    const { getByText } = render(
+      <IntlProvider>
+        <SubscriberGdpr />
+      </IntlProvider>,
+    );
+    // Assert
+    expect(getByText('subscriber_gdpr.header_title')).toBeInTheDocument();
+  });
+
+  it('component should have a page title defined', async () => {
+    // Arrange
+    // Act
+    render(
+      <IntlProvider>
+        <SubscriberGdpr />
+      </IntlProvider>,
+    );
+    await waitForDomChange();
+
+    //Assert
+    expect(document.title).toEqual('subscriber_gdpr.page_title');
+  });
+
+  it('should show subscriber email', async () => {
+    // Arrange
+    const subscriberEmail = 'email@email.com';
+    const dependencies = {
+      window: {
+        location: {
+          search: `?email=${subscriberEmail}`,
+        },
+      },
+    };
+
+    // Act
+    const { getByText } = render(
+      <AppServicesProvider forcedServices={dependencies}>
+        <IntlProvider>
+          <SubscriberGdpr />
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    await waitForDomChange();
+
+    // Assert
+    expect(getByText(subscriberEmail)).toBeInTheDocument();
+  });
+});

--- a/src/components/Reports/GDPR/SubscriberGdpr.test.js
+++ b/src/components/Reports/GDPR/SubscriberGdpr.test.js
@@ -6,27 +6,69 @@ import SubscriberGdpr from './SubscriberGdpr';
 import { AppServicesProvider } from '../../../services/pure-di';
 
 describe('SubscriberGdpr report component', () => {
+  const subscriber = {
+    email: 'test@test.com',
+    fields: [
+      {
+        name: 'FIRSTNAME',
+        value: 'Manuel',
+        predefined: true,
+        private: true,
+        readonly: true,
+        type: 'boolean',
+      },
+    ],
+    unsubscribedDate: '2019-11-27T18:05:40.847Z',
+    unsubscriptionType: 'hardBounce',
+    manualUnsubscriptionReason: 'administrative',
+    unsubscriptionComment: 'test',
+    status: 'active',
+    score: 0,
+  };
+
+  const dopplerApiClientDouble = {
+    getSubscriberSentCampaigns: async () => {
+      return { success: true, value: campaignDeliveryCollection };
+    },
+    getSubscriber: async () => {
+      return { success: true, value: subscriber };
+    },
+  };
+
   afterEach(cleanup);
 
   it('renders subscriber gdpr report without error', () => {
     // Arrange
     // Act
     render(
-      <IntlProvider>
-        <SubscriberGdpr />
-      </IntlProvider>,
+      <AppServicesProvider
+        forcedServices={{
+          dopplerApiClient: dopplerApiClientDouble,
+        }}
+      >
+        <IntlProvider>
+          <SubscriberGdpr />
+        </IntlProvider>
+      </AppServicesProvider>,
     );
     // Assert
   });
 
-  it('renders subscriber gdpr intenationalized title', () => {
+  it('renders subscriber gdpr intenationalized title', async () => {
     // Arrange
     // Act
     const { getByText } = render(
-      <IntlProvider>
-        <SubscriberGdpr />
-      </IntlProvider>,
+      <AppServicesProvider
+        forcedServices={{
+          dopplerApiClient: dopplerApiClientDouble,
+        }}
+      >
+        <IntlProvider>
+          <SubscriberGdpr />
+        </IntlProvider>
+      </AppServicesProvider>,
     );
+    await waitForDomChange();
     // Assert
     expect(getByText('subscriber_gdpr.header_title')).toBeInTheDocument();
   });
@@ -35,9 +77,15 @@ describe('SubscriberGdpr report component', () => {
     // Arrange
     // Act
     render(
-      <IntlProvider>
-        <SubscriberGdpr />
-      </IntlProvider>,
+      <AppServicesProvider
+        forcedServices={{
+          dopplerApiClient: dopplerApiClientDouble,
+        }}
+      >
+        <IntlProvider>
+          <SubscriberGdpr />
+        </IntlProvider>
+      </AppServicesProvider>,
     );
     await waitForDomChange();
 
@@ -47,18 +95,14 @@ describe('SubscriberGdpr report component', () => {
 
   it('should show subscriber email', async () => {
     // Arrange
-    const subscriberEmail = 'email@email.com';
-    const dependencies = {
-      window: {
-        location: {
-          search: `?email=${subscriberEmail}`,
-        },
-      },
-    };
 
     // Act
     const { getByText } = render(
-      <AppServicesProvider forcedServices={dependencies}>
+      <AppServicesProvider
+        forcedServices={{
+          dopplerApiClient: dopplerApiClientDouble,
+        }}
+      >
         <IntlProvider>
           <SubscriberGdpr />
         </IntlProvider>
@@ -66,8 +110,7 @@ describe('SubscriberGdpr report component', () => {
     );
 
     await waitForDomChange();
-
     // Assert
-    expect(getByText(subscriberEmail)).toBeInTheDocument();
+    expect(getByText(subscriber.email)).toBeInTheDocument();
   });
 });

--- a/src/components/Reports/SubscriberHistory/SubscriberHistory.js
+++ b/src/components/Reports/SubscriberHistory/SubscriberHistory.js
@@ -3,7 +3,11 @@ import { InjectAppServices } from '../../../services/pure-di';
 import { Loading } from '../../Loading/Loading';
 import { FormattedMessage, useIntl, FormattedDate } from 'react-intl';
 import queryString from 'query-string';
-import { getSubscriberStatusCssClassName, extractParameter } from '../../../utils';
+import {
+  getSubscriberStatusCssClassName,
+  extractParameter,
+  replaceSpaceWithSigns,
+} from '../../../utils';
 import { StarsScore } from '../../shared/StarsScore/StarsScore';
 import { Pagination } from '../../shared/Pagination/Pagination';
 import SafeRedirect from '../../SafeRedirect';
@@ -27,10 +31,6 @@ const getDeliveryStatusCssClassName = (deliveryStatus) => {
       break;
   }
   return deliveryCssClass;
-};
-
-const replaceSpaceWithSigns = (url) => {
-  return url ? url.replace(' ', '+') : '';
 };
 
 const campaignsPerPage = 10;

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -313,6 +313,11 @@ export default {
       unsubscribed_by_subscriber: 'Removed by Subscriber',
     },
   },
+  subscriber_gdpr: {
+    header_title: 'Subscriber GDPR state',
+    page_description: 'Subscriber GDPR permission state.',
+    page_title: 'Subscriber GDPR state',
+  },
   subscriber_history: {
     alt_image: 'Campaign Preview',
     delivery_status: {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -314,9 +314,17 @@ export default {
     },
   },
   subscriber_gdpr: {
+    empty_data: 'This Subscriber has not given or denied any permission.',
+    empty_html_text: 'With no legal text defined',
+    header_description: 'Here you can find all permissions given by a Subscriber. You will see data only if the Subscriber has either accepter or rejected a consent.',
     header_title: 'Subscriber GDPR state',
     page_description: 'Subscriber GDPR permission state.',
     page_title: 'Subscriber GDPR state',
+    permission_description: 'Custom text',
+    permission_name: 'Field Name',
+    permission_value: 'Value',
+    value_false: 'Rejected',
+    value_true: 'Accepted',
   },
   subscriber_history: {
     alt_image: 'Campaign Preview',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -316,9 +316,17 @@ export default {
     },
   },
   subscriber_gdpr: {
+    empty_data: 'Este Suscriptor no ha aceptado ni rechazado ningun permiso.',
+    empty_html_text: 'Sin texto legal definido',
+    header_description: 'Aquí encontrarás los consentimientos dados por tu Suscriptor. Solo verás datos si el Suscriptor ha aceptado o rechazado permisos.',
     header_title: 'Estado GDPR del Suscriptor',
     page_description: 'Estado de permisos GDPR del Suscriptor',
     page_title: 'Estado GDPR del Suscriptor',
+    permission_description: 'Texto personalizado',
+    permission_name: 'Nombre del campo',
+    permission_value: 'Valor',
+    value_false: 'Rechazado',
+    value_true: 'Aceptado',
   },
   subscriber_history: {
     alt_image: 'Preview de la Campaña',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -315,6 +315,11 @@ export default {
       unsubscribed_by_subscriber: 'Removido por el Suscriptor',
     },
   },
+  subscriber_gdpr: {
+    header_title: 'Estado GDPR del Suscriptor',
+    page_description: 'Estado de permisos GDPR del Suscriptor',
+    page_title: 'Estado GDPR del Suscriptor',
+  },
   subscriber_history: {
     alt_image: 'Preview de la Campaña',
     delivery_status: {

--- a/src/services/doppler-api-client.double.ts
+++ b/src/services/doppler-api-client.double.ts
@@ -40,6 +40,58 @@ const subscriber = {
       readonly: true,
       type: 'string',
     },
+    {
+      name: 'BIRTHDAY',
+      value: '1983-09-28',
+      predefined: true,
+      private: false,
+      readonly: false,
+      type: 'date',
+    },
+    {
+      name: 'CONSENT',
+      value: 'False',
+      predefined: true,
+      private: false,
+      readonly: false,
+      type: 'consent',
+    },
+    {
+      name: 'Permiso2',
+      value: 'true',
+      predefined: false,
+      private: false,
+      readonly: false,
+      type: 'permission',
+      permissionHTML:
+        '<p>Acepta las promociones indicadas <a href="http://www.google.com">aqui</a></p>',
+    },
+    {
+      name: 'lalo',
+      value: 'true',
+      predefined: false,
+      private: false,
+      readonly: false,
+      type: 'permission',
+    },
+    {
+      name: 'ddddSssss',
+      value: 'true',
+      predefined: false,
+      private: true,
+      readonly: false,
+      type: 'permission',
+    },
+    {
+      name: 'AceptaPromociones',
+      value: 'true',
+      predefined: false,
+      private: false,
+      readonly: false,
+      type: 'permission',
+      permissionHTML:
+        '<p>Haciendo click en el checkbox confirma y acepta nuestras <a href="google.com">bases y condiciones.</a></p>',
+    },
   ],
   unsubscribedDate: '2019-11-27T18:05:40.847Z',
   unsubscriptionType: 'hardBounce',
@@ -48,6 +100,26 @@ const subscriber = {
   status: 'unsubscribed_by_hard',
   score: 2,
 };
+
+// const subscriberWithNoGDPR = {
+//   email: 'test@fromdoppler.com',
+//   fields: [
+//     {
+//       name: 'FIRSTNAME',
+//       value: 'Manuel',
+//       predefined: true,
+//       private: false,
+//       readonly: true,
+//       type: 'string',
+//     },
+//   ],
+//   unsubscribedDate: '2019-11-27T18:05:40.847Z',
+//   unsubscriptionType: 'hardBounce',
+//   manualUnsubscriptionReason: 'administrative',
+//   unsubscriptionComment: 'test',
+//   status: 'unsubscribed_by_hard',
+//   score: 2,
+// };
 
 const getDeliveryStatus = (statusNumber: number) => {
   switch (statusNumber) {
@@ -158,6 +230,11 @@ export class HardcodedDopplerApiClient implements DopplerApiClient {
       success: true,
       value: subscriber,
     };
+
+    // return {
+    //   success: true,
+    //   value: subscriberWithNoGDPR,
+    // };
 
     // return {
     //   success: false,

--- a/src/services/doppler-api-client.ts
+++ b/src/services/doppler-api-client.ts
@@ -119,6 +119,7 @@ export class HttpDopplerApiClient implements DopplerApiClient {
       private: x.private,
       readonly: x.readonly,
       type: x.type,
+      permissionHTML: x.permissionHTML,
     }));
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -162,3 +162,7 @@ export function isWhitelisted(url: string) {
   ];
   return !!url && loginWhitelist.some((element) => url.startsWith(element));
 }
+
+export const replaceSpaceWithSigns = (url: string) => {
+  return url ? url.replace(' ', '+') : '';
+};


### PR DESCRIPTION
### Gdpr permission report

Add Gdpr permission fields and consent field with its value for a selected Subscriber.

![image](https://user-images.githubusercontent.com/2439363/74868400-f4e0cf00-5334-11ea-9835-57c1ae44a861.png)

This report will be corner stone for later implementation of a permission's historial listing.

- Add double with data for permission fields
- Add component for report
- Add route
- Add tests 

link for testing https://cdn.fromdoppler.com/doppler-webapp/int-build2188/#/reports/subscriber-gdpr?email=cbernat+c56@getcs.com