### PR TITLE
fix: set nginx config to only use TLSv1.2

### DIFF
--- a/conf/site-int.conf
+++ b/conf/site-int.conf
@@ -7,6 +7,7 @@ server{
         server_name             app.fromdoppler.com;
         ssl_certificate         /run/secrets/site.crt;
         ssl_certificate_key     /run/secrets/site.key;
+        ssl_protocols           TLSv1.2;
 
         error_page      497     https://$host:4443$request_uri;
 

--- a/conf/site-production.conf
+++ b/conf/site-production.conf
@@ -9,6 +9,7 @@ server {
         server_name             app.fromdoppler.com;
         ssl_certificate         /run/secrets/site.crt;
         ssl_certificate_key     /run/secrets/site.key;
+        ssl_protocols           TLSv1.2;
 
         gzip                    on;
         gzip_disable            "msie6";

--- a/conf/site-qa.conf
+++ b/conf/site-qa.conf
@@ -7,6 +7,7 @@ server{
         server_name             app.fromdoppler.com;
         ssl_certificate         /run/secrets/site.crt;
         ssl_certificate_key     /run/secrets/site.key;
+        ssl_protocols           TLSv1.2;
 
         error_page      497     https://$host:4444$request_uri;
 


### PR DESCRIPTION
This PR is for change the site config to force only accept TLSv1.2 in the web app.

The SSL Lab test right: https://www.ssllabs.com/ssltest/analyze.html?d=app.fromdoppler.com
and should be the same as https://www.ssllabs.com/ssltest/analyze.html?d=app2.fromdoppler.com

this change should solve this problem