### PR TITLE
fix: set nginx perfect forward secrecy config

### DIFF
--- a/conf/site-int.conf
+++ b/conf/site-int.conf
@@ -8,6 +8,8 @@ server{
         ssl_certificate         /run/secrets/site.crt;
         ssl_certificate_key     /run/secrets/site.key;
         ssl_protocols           TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
 
         error_page      497     https://$host:4443$request_uri;
 

--- a/conf/site-production.conf
+++ b/conf/site-production.conf
@@ -10,6 +10,8 @@ server {
         ssl_certificate         /run/secrets/site.crt;
         ssl_certificate_key     /run/secrets/site.key;
         ssl_protocols           TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
 
         gzip                    on;
         gzip_disable            "msie6";

--- a/conf/site-qa.conf
+++ b/conf/site-qa.conf
@@ -8,6 +8,8 @@ server{
         ssl_certificate         /run/secrets/site.crt;
         ssl_certificate_key     /run/secrets/site.key;
         ssl_protocols           TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
 
         error_page      497     https://$host:4444$request_uri;
 


### PR DESCRIPTION
This is for use PFS and avoid SSL Labs B Penalty
See [SSL Labs notes](https://blog.qualys.com/ssllabs/2018/02/02/forward-secrecy-authenticated-encryption-and-robot-grading-update?_ga=2.7343159.446459784.1582220207-1550278441.1582220207)
See [how implement](https://blog.qualys.com/ssllabs/2013/08/05/configuring-apache-nginx-and-openssl-for-forward-secrecy)

Here result of the [check](https://www.ssllabs.com/ssltest/analyze.html?d=app.fromdoppler.com)

Related to: [DM-335](https://makingsense.atlassian.net/browse/DM-335)