### PR TITLE
Dw-216 gdpr report with all permission fields for doppler user

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://cdn.fromdoppler.com/doppler-ui-library/v3.37.1/css/styles.css"
+      href="https://cdn.fromdoppler.com/doppler-ui-library/v3.38.0/css/styles.css"
     />
     <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/zoho-chat.css" />
     <!--
@@ -71,7 +71,7 @@
     -->
     <script
       type="text/javascript"
-      src="https://cdn.fromdoppler.com/doppler-ui-library/v3.35.0/js/app.js"
+      src="https://cdn.fromdoppler.com/doppler-ui-library/v3.38.0/js/app.js"
     ></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
     <script

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -9,7 +9,9 @@ const Header = ({
   userData: { user, nav, alert, notifications, emptyNotificationText },
   location: { pathname },
 }) => {
-  const inactiveSection = pathname.match(/^\/integrations\/*/) !== null;
+  const inactiveSection =
+    pathname.match(/^\/integrations\/*/) !== null ||
+    pathname.match(/^\/reports\/subscriber-gdpr*/) !== null;
   return (
     <div>
       {alert ? <HeaderMessages alert={alert} user={user} /> : null}

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -342,7 +342,7 @@ export default {
   subscriber_gdpr: {
     empty_data: 'This Subscriber has not given or denied any permission.',
     empty_html_text: 'With no legal text defined',
-    header_description: 'Here you can find all permissions given by a Subscriber. You will see data only if the Subscriber has either accepter or rejected a consent.',
+    header_description: 'Here you can find all permissions given by your Subscriber.',
     header_title: 'Subscriber GDPR state',
     page_description: 'Subscriber GDPR permission state.',
     page_title: 'Subscriber GDPR state',
@@ -350,6 +350,7 @@ export default {
     permission_name: 'Field Name',
     permission_value: 'Value',
     value_false: 'Rejected',
+    value_none: 'No response',
     value_true: 'Accepted',
   },
   subscriber_history: {

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -344,7 +344,7 @@ export default {
   subscriber_gdpr: {
     empty_data: 'Este Suscriptor no ha aceptado ni rechazado ningun permiso.',
     empty_html_text: 'Sin texto legal definido',
-    header_description: 'Aquí encontrarás los consentimientos dados por tu Suscriptor. Solo verás datos si el Suscriptor ha aceptado o rechazado permisos.',
+    header_description: 'Aquí encontrarás todos los consentimientos dados por tu Suscriptor.',
     header_title: 'Estado GDPR del Suscriptor',
     page_description: 'Estado de permisos GDPR del Suscriptor',
     page_title: 'Estado GDPR del Suscriptor',
@@ -352,6 +352,7 @@ export default {
     permission_name: 'Nombre del campo',
     permission_value: 'Valor',
     value_false: 'Rechazado',
+    value_none: 'Sin respuesta',
     value_true: 'Aceptado',
   },
   subscriber_history: {

--- a/src/services/doppler-api-client.double.ts
+++ b/src/services/doppler-api-client.double.ts
@@ -5,6 +5,7 @@ import {
   SubscriberCollection,
   CampaignSummaryResults,
   CampaignInfo,
+  Fields,
 } from './doppler-api-client';
 import { SubscriberList } from './shopify-client';
 import { ResultWithoutExpectedErrors } from '../doppler-types';
@@ -67,14 +68,6 @@ const subscriber = {
       type: 'permission',
       permissionHTML:
         '<p>Acepta las promociones indicadas <a href="http://www.google.com">aqui</a></p>',
-    },
-    {
-      name: 'lalo',
-      value: 'true',
-      predefined: false,
-      private: false,
-      readonly: false,
-      type: 'permission',
     },
     {
       name: 'ddddSssss',
@@ -347,5 +340,103 @@ export class HardcodedDopplerApiClient implements DopplerApiClient {
     //   success: false,
     //   error: new Error('Dummy error'),
     // };
+  }
+
+  public async getUserFields(): Promise<ResultWithoutExpectedErrors<Fields[]>> {
+    console.log('getCampaignNameAndSubject');
+    await timeout(1500);
+    // const fieldsNoPermission = [
+    //   {
+    //     name: 'FIRSTNAME',
+    //     value: 'Pepe',
+    //     predefined: true,
+    //     private: false,
+    //     readonly: true,
+    //     type: 'string',
+    //   },
+    //   {
+    //     name: 'LASTNAME',
+    //     value: 'Gonzales',
+    //     predefined: true,
+    //     private: false,
+    //     readonly: true,
+    //     type: 'string',
+    //   },
+    // ];
+
+    const fieldsPermission = [
+      {
+        name: 'FIRSTNAME',
+        value: 'Pepe',
+        predefined: true,
+        private: false,
+        readonly: true,
+        type: 'string',
+      },
+      {
+        name: 'LASTNAME',
+        value: 'Gonzales',
+        predefined: true,
+        private: false,
+        readonly: true,
+        type: 'string',
+      },
+      {
+        name: 'BIRTHDAY',
+        value: '1983-09-28',
+        predefined: true,
+        private: false,
+        readonly: false,
+        type: 'date',
+      },
+      {
+        name: 'CONSENT',
+        value: 'False',
+        predefined: true,
+        private: false,
+        readonly: false,
+        type: 'consent',
+      },
+      {
+        name: 'Permiso2',
+        value: 'true',
+        predefined: false,
+        private: false,
+        readonly: false,
+        type: 'permission',
+        permissionHTML:
+          '<p>Acepta las promociones indicadas <a href="http://www.google.com">aqui</a></p>',
+      },
+      {
+        name: 'lalo',
+        value: 'true',
+        predefined: false,
+        private: false,
+        readonly: false,
+        type: 'permission',
+      },
+      {
+        name: 'ddddSssss',
+        value: 'true',
+        predefined: false,
+        private: true,
+        readonly: false,
+        type: 'permission',
+      },
+      {
+        name: 'AceptaPromociones',
+        value: 'true',
+        predefined: false,
+        private: false,
+        readonly: false,
+        type: 'permission',
+        permissionHTML:
+          '<p>Haciendo click en el checkbox confirma y acepta nuestras <a href="google.com">bases y condiciones.</a></p>',
+      },
+    ];
+    return {
+      success: true,
+      value: fieldsPermission,
+    };
   }
 }

--- a/src/services/doppler-api-client.test.ts
+++ b/src/services/doppler-api-client.test.ts
@@ -475,4 +475,58 @@ describe('HttpDopplerApiClient', () => {
       expect(result.value.subject).toEqual('Subject test');
     });
   });
+
+  describe('getUserFields', () => {
+    it('should get and error', async () => {
+      // Arrange
+      const request = jest.fn(async () => {});
+      const dopplerApiClient = createHttpDopplerApiClient({ request });
+
+      // Act
+      const result = await dopplerApiClient.getUserFields();
+
+      // Assert
+      expect(request).toBeCalledTimes(1);
+      expect(result).not.toBe(undefined);
+      expect(result.success).toBe(false);
+    });
+
+    it('should get correct data', async () => {
+      // Arrange
+      const fieldsResult = {
+        data: {
+          items: [
+            {
+              name: 'FIRSTNAME',
+              value: 'Pepe',
+              predefined: true,
+              private: false,
+              readonly: true,
+              type: 'string',
+            },
+            {
+              name: 'LASTNAME',
+              value: 'Gonzales',
+              predefined: true,
+              private: false,
+              readonly: true,
+              type: 'string',
+            },
+          ],
+          _links: [],
+        },
+      };
+      const request = jest.fn(async () => fieldsResult);
+      const dopplerApiClient = createHttpDopplerApiClient({ request });
+
+      // Act
+      const result = await dopplerApiClient.getUserFields();
+
+      // Assert
+      expect(request).toBeCalledTimes(1);
+      expect(result).not.toBe(undefined);
+      expect(result.success).toBe(true);
+      expect(result.value).not.toBe(null);
+    });
+  });
 });

--- a/src/services/doppler-api-client.ts
+++ b/src/services/doppler-api-client.ts
@@ -17,13 +17,14 @@ export interface DopplerApiClient {
     idCampaign: number,
   ): Promise<ResultWithoutExpectedErrors<CampaignSummaryResults>>;
   getCampaignNameAndSubject(campaignId: number): Promise<ResultWithoutExpectedErrors<CampaignInfo>>;
+  getUserFields(): Promise<ResultWithoutExpectedErrors<Fields[]>>;
 }
 interface DopplerApiConnectionData {
   jwtToken: string;
   userAccount: string;
 }
 
-interface Fields {
+export interface Fields {
   name: string;
   value: string;
   predefined: boolean;
@@ -427,6 +428,28 @@ export class HttpDopplerApiClient implements DopplerApiClient {
       return {
         success: true,
         value: { name: data.name, subject: data.subject },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error,
+      };
+    }
+  }
+
+  public async getUserFields(): Promise<ResultWithoutExpectedErrors<Fields[]>> {
+    try {
+      const { jwtToken, userAccount } = this.getDopplerApiConnectionData();
+
+      const { data } = await this.axios.request({
+        method: 'GET',
+        url: `/accounts/${userAccount}/fields/`,
+        headers: { Authorization: `token ${jwtToken}` },
+      });
+
+      return {
+        success: true,
+        value: this.mapSubscriberFields(data.items),
       };
     } catch (error) {
       return {


### PR DESCRIPTION
Now we show all fields for the user, and when de subscriber never agreed nor rejected the permission we show a no response label. Showing all permissions here also allows a user to see the legal text (this cannot be seen if the permission is in use by at least one subscriber)

![image](https://user-images.githubusercontent.com/2439363/75908444-ea403280-5e28-11ea-8de0-a67d813e72b8.png)


http://localhost:3000/reports/subscriber-gdpr?email=cbernat@makingsense.com

https://cdn.fromdoppler.com/doppler-webapp/build2205/#/reports/subscriber-gdpr?email=cbernat@makingsense.com