### PR TITLE
fix(Login): check redirect parameter behaviour like page parameter

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -26,9 +26,17 @@ const fieldNames = {
   password: 'password',
 };
 
+function extractPageFromRedirect(location) {
+  const redirectParameter = extractParameter(location, queryString.parse, 'redirect');
+  return /doppleracademy/.exec(redirectParameter) ? 'doppler-academy' : null;
+}
+
 /** Extract the page parameter from url*/
 function extractPage(location) {
-  return extractParameter(location, queryString.parse, 'page', 'Page');
+  return (
+    extractParameter(location, queryString.parse, 'page', 'Page') ||
+    extractPageFromRedirect(location)
+  );
 }
 
 const extractLegacyRedirectUrl = (location) => {


### PR DESCRIPTION
- When has `redirect=https://doppleracademy.com` in the url call `getBanner` with the `page=doppler-academy` parameter

![image](https://user-images.githubusercontent.com/8861133/77198738-562bc780-6ac6-11ea-8eea-ed3c52942693.png)
