### PR TITLE
fix(Promotions): change fromdoppler to fromdoppler/es

### DIFF
--- a/src/services/doppler-sites-client.ts
+++ b/src/services/doppler-sites-client.ts
@@ -36,7 +36,7 @@ export class HttpDopplerSitesClient implements DopplerSitesClient {
       const response: any = await this.axios.get(
         `${
           this.baseUrl
-        }/wp-json/doppler2019/v1/getbanner?filter[lang]=${lang}&filter[type]=${type}&filter[page]=${page ||
+        }/es/wp-json/doppler2019/v1/getbanner?filter[lang]=${lang}&filter[type]=${type}&filter[page]=${page ||
           ''}`,
       );
       if (!response || !response.data) {


### PR DESCRIPTION
- Change request in doppler sites from `fromdoppler.com` to `fromdoppler.com/es` to fix the CORS problem