### PR TITLE
fix(semanitc-release): fix script to build inside container

### DIFF
--- a/verify-n-generate-release-w-docker.sh
+++ b/verify-n-generate-release-w-docker.sh
@@ -15,16 +15,14 @@ cd $(dirname $0)
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
-sh ./verify-w-docker.sh
-
 # build production package and generate version number
+
+docker build --tag webapp_sources:current --target test -f Dockerfile.swarm .
 docker run --rm \
     -e GH_TOKEN \
     -e "NPM_TOKEN=00000000-0000-0000-0000-000000000000" \
-    -v `pwd`:/work \
-    -w /work \
-    node:12.16.1 \
+    -v `pwd`/.git:/app/.git \
+    webapp_sources:current \
     /bin/sh -c "\
-        yarn \
-        && yarn semantic-release \
+        yarn semantic-release \
     "


### PR DESCRIPTION
### Fix release version script
In order to avoid issues with jenkins workspace better try to run this into a docker container. Mapping .git folder seems to do the trick.

This approach then can be done in ui library as well. 😄 