### PR TITLE
fix(Promotions): don't call the api when page is null

### DIFF
--- a/src/components/shared/Promotions/Promotions.js
+++ b/src/components/shared/Promotions/Promotions.js
@@ -37,7 +37,11 @@ const Promotions = function ({ type, page, dependencies: { dopplerSitesClient } 
       }
     };
 
-    fetchData();
+    if (page) {
+      fetchData();
+    } else {
+      setState({ loading: false, bannerData: getDefaultBannerData(intl) });
+    }
   }, [dopplerSitesClient, page, intl, type]);
 
   return (


### PR DESCRIPTION
- check the parameter page before do the request to de doppler sites to prevent many request.