### PR TITLE
Fix https issue with ipinfo.io

### DIFF
--- a/src/services/ipinfo-client.test.ts
+++ b/src/services/ipinfo-client.test.ts
@@ -83,7 +83,7 @@ describe('HttpIpinfoClient', () => {
     expect(result).toBe(countryCode);
     expect(request).toHaveBeenCalledWith({
       method: 'GET',
-      url: 'http://ipinfo.io/json',
+      url: 'https://ipinfo.io/json',
     });
   });
 });

--- a/src/services/ipinfo-client.ts
+++ b/src/services/ipinfo-client.ts
@@ -16,7 +16,7 @@ export class HttpIpinfoClient implements IpinfoClient {
     try {
       const response = await this.axios.request({
         method: 'GET',
-        url: 'http://ipinfo.io/json',
+        url: 'https://ipinfo.io/json',
       });
       const countryCode = (response.data && response.data.country) || defaultCountryCode;
       return countryCode;


### PR DESCRIPTION
It wasn't working because I was using http instead https to call ipinfo.io API. 