### PR TITLE
feat(ReportsNew): add new reports page with new datahub endopoints

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,8 @@ import SubscriberHistory from './components/Reports/SubscriberHistory/Subscriber
 import SubscriberGdpr from './components/Reports/GDPR/SubscriberGdpr';
 import ReportsPartialsCampaigns from './components/Reports/ReportsPartialsCampaigns/ReportsPartialsCampaigns';
 import NewFeatures from './components/NewFeatures/NewFeatures';
+// Temporal until use the new datahub client endpoints
+import ReportsNew from './components/Reports/ReportsNew';
 
 /**
  * @param { Object } props - props
@@ -92,6 +94,7 @@ const App = ({ locale, location, dependencies: { appSessionRef, sessionManager }
               )
             }
           />
+          <PrivateRoute path="/reports-new/" exact requireSiteTracking component={ReportsNew} />
           <PrivateRoute path="/reports/" exact requireSiteTracking component={Reports} />
           <PrivateRoute path="/integrations/shopify" exact component={Shopify} />
           <PrivateRoute path="/reports/master-subscriber" exact component={MasterSubscriber} />

--- a/src/components/Reports/ReportsBox/ReportsBoxNew.js
+++ b/src/components/Reports/ReportsBox/ReportsBoxNew.js
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import { InjectAppServices } from '../../../services/pure-di';
+import { FormattedMessage } from 'react-intl';
+import { FormattedDateRangeText } from '../../shared/FormattedDateRangeText/FormattedDateRangeText';
+import { Loading } from '../../Loading/Loading';
+
+/**
+ * @param { Object } props - props
+ * @param { import('../../../services/pure-di').AppServices } props.dependencies
+ */
+const ReportsBoxNew = ({
+  domainName,
+  dateFrom,
+  dateTo,
+  emailFilter,
+  today,
+  dependencies: { datahubClientNew },
+}) => {
+  const [visits, setVisits] = useState(null);
+
+  useEffect(() => {
+    const fetchVisitsByPeriod = async (domainName, dateFrom, dateTo) => {
+      const asyncRequest = await datahubClientNew.getTotalVisitsOfPeriod({
+        domainName: domainName,
+        dateFrom: dateFrom,
+        dateTo: dateTo,
+        emailFilter: emailFilter,
+      });
+      setVisits(asyncRequest);
+    };
+    fetchVisitsByPeriod(domainName, dateFrom, dateTo);
+  }, [domainName, dateFrom, dateTo, datahubClientNew, emailFilter]);
+
+  return (
+    <div className={visits === 0 ? 'dp-box-shadow warning--kpi' : 'dp-box-shadow'}>
+      {visits === null ? (
+        <Loading />
+      ) : emailFilter === 'with_email' ? (
+        <>
+          <div className="box-border--bottom">
+            <h3 className="number-kpi">{visits}</h3>
+            <h6>
+              <FormattedMessage id="reports_box.visits_with_email" />
+            </h6>
+            <small className="date-range">
+              <FormattedDateRangeText dateFrom={dateFrom} dateTo={dateTo} today={today} />
+            </small>
+          </div>
+          <p className="text-kpi">
+            <FormattedMessage id="reports_box.visits_description_with_email" />
+          </p>
+        </>
+      ) : emailFilter === 'without_email' ? (
+        <>
+          <div className="box-border--bottom">
+            <h3 className="number-kpi">{visits}</h3>
+            <h6>
+              <FormattedMessage id="reports_box.visits_without_emails" />
+            </h6>
+            <small className="date-range">
+              <FormattedDateRangeText dateFrom={dateFrom} dateTo={dateTo} today={today} />
+            </small>
+          </div>
+          <p className="text-kpi">
+            <FormattedMessage id="reports_box.visits_description_without_emails" />
+          </p>
+        </>
+      ) : (
+        <p className="dp-boxshadow--error bounceIn">
+          <FormattedMessage id="common.unexpected_error" />
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default InjectAppServices(ReportsBoxNew);

--- a/src/components/Reports/ReportsDailyVisits/ReportsDailyVisitsNew.js
+++ b/src/components/Reports/ReportsDailyVisits/ReportsDailyVisitsNew.js
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+import { InjectAppServices } from '../../../services/pure-di';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Loading } from '../../Loading/Loading';
+import C3Chart from '../../shared/C3Chart/C3Chart';
+
+const chartDataOptions = {
+  json: {},
+};
+
+const ReportsDailyVisitsNew = ({
+  domainName,
+  dateFrom,
+  dateTo,
+  dependencies: { datahubClientNew },
+}) => {
+  const [state, setState] = useState({ loading: true });
+
+  const intl = useIntl();
+
+  const [chartConfig] = useState({
+    legend: {
+      show: false,
+    },
+    tooltip: {
+      contents: function (data) {
+        if (data.length) {
+          const date = intl.formatDate(data[0].x, {
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric',
+            weekday: 'long',
+          });
+
+          const tooltipData = data.reduce((accumulator, item) => {
+            accumulator[item.id] = item.value;
+            return accumulator;
+          }, {});
+
+          tooltipData.quantity_label = intl.formatMessage({
+            id: 'reports_daily_visits.tooltip_page_views',
+          });
+          tooltipData.withEmail_label = intl.formatMessage({
+            id: 'reports_daily_visits.tooltip_with_email',
+          });
+          tooltipData.withoutEmail_label = intl.formatMessage({
+            id: 'reports_daily_visits.tooltip_without_email',
+          });
+
+          const valueTemplate = (value) => {
+            return `<div class='tooltip-value'>${value}</div>`;
+          };
+
+          return `
+          <div class="c3-tooltip">
+            <div class='tooltip-title'>${date}</div>
+            ${
+              tooltipData.withEmail == null
+                ? valueTemplate(tooltipData.quantity_label + tooltipData.quantity)
+                : ''
+            }
+            ${
+              tooltipData.withEmail != null
+                ? valueTemplate(tooltipData.withEmail_label + tooltipData.withEmail) +
+                  valueTemplate(tooltipData.withoutEmail_label + tooltipData.withoutEmail)
+                : ''
+            }
+          </div>`;
+        }
+        return '';
+      },
+    },
+    axis: {
+      x: {
+        type: 'timeseries',
+        tick: {
+          culling: false,
+          format: (x) => {
+            return intl.formatDate(x, { month: 'short', day: '2-digit' });
+          },
+        },
+      },
+    },
+    color: {
+      pattern: ['#B58FC1'],
+    },
+    point: {
+      r: 3,
+    },
+    grid: {
+      y: {
+        show: true,
+      },
+    },
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setState({ loading: true });
+      const dailyVisitsData = await datahubClientNew.getVisitsQuantitySummarizedByDay({
+        domainName: domainName,
+        dateFrom: dateFrom,
+        dateTo: dateTo,
+      });
+      if (!dailyVisitsData.success) {
+        setState({ loading: false });
+      } else {
+        setState({
+          loading: false,
+          chartData: {
+            json: dailyVisitsData.value,
+            keys: {
+              x: 'from',
+              value: ['qVisitors', 'qVisitorsWithEmail', 'qVisitorsWithOutEmail'],
+            },
+            classes: {
+              withEmail: 'hide-graph',
+              withoutEmail: 'hide-graph',
+            },
+          },
+        });
+      }
+    };
+
+    fetchData();
+  }, [datahubClientNew, dateFrom, dateTo, domainName]);
+
+  return (
+    <div className="dp-box-shadow">
+      <div className="col-sm-12">
+        <h6>
+          <FormattedMessage id="reports_daily_visits.title" />
+        </h6>
+      </div>
+      {state.loading ? (
+        <Loading />
+      ) : !state.chartData ? (
+        <p className="dp-boxshadow--error bounceIn">
+          <FormattedMessage id="common.unexpected_error" />
+        </p>
+      ) : (
+        <C3Chart config={chartConfig} dataOptions={chartDataOptions} data={state.chartData} />
+      )}
+    </div>
+  );
+};
+
+export default InjectAppServices(ReportsDailyVisitsNew);

--- a/src/components/Reports/ReportsNew.js
+++ b/src/components/Reports/ReportsNew.js
@@ -1,0 +1,141 @@
+import React, { useState, useEffect } from 'react';
+import ReportsFilters from './ReportsFilters/ReportsFilters';
+import ReportsBox from './ReportsBox/ReportsBoxNew';
+import ReportsTrafficSources from './ReportsTrafficSources/ReportsTrafficSourcesNew';
+import ReportsDailyVisits from './ReportsDailyVisits/ReportsDailyVisits';
+// import ReportsHoursVisits from './ReportsHoursVisits/ReportsHoursVisits';
+import { InjectAppServices } from '../../services/pure-di';
+import { FormattedMessage } from 'react-intl';
+import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
+import {
+  SiteTrackingRequired,
+  SiteTrackingNotAvailableReasons,
+} from '../SiteTrackingRequired/SiteTrackingRequired';
+import { Helmet } from 'react-helmet';
+import { Loading } from '../Loading/Loading';
+import { addDays, getStartOfDate } from '../../utils';
+import { BoxMessage } from '../styles/messages';
+
+// This value means the today date
+const periodSelectedDaysDefault = 1; /* set this value temporarily for datahub performance issue */
+
+/**
+ * @param { Object } props
+ * @param { import('../../services/pure-di').AppServices } props.dependencies
+ */
+
+const ReportsNew = ({ dependencies: { datahubClient } }) => {
+  const today = getStartOfDate(new Date());
+  const [state, setState] = useState({
+    periodSelectedDays: periodSelectedDaysDefault,
+    dateFrom: addDays(today, periodSelectedDaysDefault * -1),
+    dateTo: periodSelectedDaysDefault ? today : new Date(),
+    dailyView: !periodSelectedDaysDefault,
+  });
+
+  const changeDomain = async (name) => {
+    const domainFound = state.domains.find((item) => item.name === name);
+    setState((prevState) => ({ ...prevState, domainSelected: domainFound }));
+  };
+
+  const changePeriod = (daysToFilter) => {
+    const today = getStartOfDate(new Date());
+    setState((prevState) => ({
+      ...prevState,
+      periodSelectedDays: daysToFilter,
+      dateFrom: addDays(today, daysToFilter * -1),
+      dateTo: daysToFilter ? today : new Date(),
+      dailyView: !daysToFilter,
+    }));
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const domains = await datahubClient.getAccountDomains();
+      setState((prevState) => ({
+        ...prevState,
+        domains: domains,
+        domainSelected: domains.length ? domains[0] : null,
+      }));
+    };
+
+    fetchData();
+  }, [datahubClient]);
+
+  return (
+    <>
+      <FormattedMessage id="reports_title">
+        {(reports_title) => (
+          <Helmet>
+            <title>{reports_title}</title>
+          </Helmet>
+        )}
+      </FormattedMessage>
+      {state.domains && !state.domainSelected ? (
+        <SiteTrackingRequired reason={SiteTrackingNotAvailableReasons.thereAreNotDomains} />
+      ) : (
+        <>
+          <ReportsFilters
+            changeDomain={changeDomain}
+            domains={state.domains}
+            domainSelected={state.domainSelected}
+            periodSelectedDays={state.periodSelectedDays}
+            changePeriod={changePeriod}
+          />
+          {!state.domains ? (
+            <Loading />
+          ) : (
+            <section className="dp-container">
+              {!state.domainSelected.verified_date ? (
+                <BoxMessage className="dp-msj-error bounceIn" spaceTopBottom>
+                  <p>
+                    <FormattedMessageMarkdown id="reports_filters.domain_not_verified_MD" />
+                  </p>
+                </BoxMessage>
+              ) : null}
+              <div className="dp-rowflex">
+                <div className="col-lg-6 col-md-6 col-sm-12 m-b-24">
+                  <ReportsBox
+                    domainName={state.domainSelected.name}
+                    periodSelectedDays={state.periodSelectedDays}
+                    dateTo={state.dateTo}
+                    dateFrom={state.dateFrom}
+                    today={state.dailyView}
+                    emailFilter={'without_email'}
+                  />
+                </div>
+                <div className="col-lg-6 col-md-6 col-sm-12 m-b-24">
+                  <ReportsBox
+                    domainName={state.domainSelected.name}
+                    dateTo={state.dateTo}
+                    dateFrom={state.dateFrom}
+                    today={state.dailyView}
+                    emailFilter={'with_email'}
+                  />
+                </div>
+                {!state.dailyView ? (
+                  <div className="col-sm-12 m-b-24">
+                    <ReportsDailyVisits
+                      domainName={state.domainSelected.name}
+                      dateFrom={state.dateFrom}
+                      dateTo={state.dateTo}
+                    />
+                  </div>
+                ) : null}
+                <div className="col-sm-12 m-b-24">
+                  <ReportsTrafficSources
+                    domainName={state.domainSelected.name}
+                    dateFrom={state.dateFrom}
+                    dateTo={state.dateTo}
+                  />
+                </div>
+              </div>
+            </section>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export default InjectAppServices(ReportsNew);

--- a/src/components/Reports/ReportsTrafficSources/ReportsTrafficSourcesNew.js
+++ b/src/components/Reports/ReportsTrafficSources/ReportsTrafficSourcesNew.js
@@ -1,0 +1,167 @@
+import React, { useEffect, useState } from 'react';
+import { InjectAppServices } from '../../../services/pure-di';
+import { FormattedMessage, FormattedNumber } from 'react-intl';
+import { Loading } from '../../Loading/Loading';
+import * as S from './ReportsTrafficSources.styles';
+
+const SafeDivide = (number, quantity) => {
+  return quantity ? number / quantity : 0;
+};
+
+const ReportsTrafficSourcesNew = function ({
+  domainName,
+  dateFrom,
+  dateTo,
+  dependencies: { datahubClientNew },
+}) {
+  const [state, setState] = useState({ loading: true });
+
+  const numberFormatOptions = {
+    style: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const trafficSourcesData = await datahubClientNew.getTrafficSourcesByPeriod({
+        domainName: domainName,
+        dateFrom: dateFrom,
+        dateTo: dateTo,
+      });
+      if (trafficSourcesData.success && trafficSourcesData.value) {
+        const total = trafficSourcesData.value.reduce(function (previous, item) {
+          return previous + item.qVisitors;
+        }, 0);
+        setState({
+          loading: false,
+          trafficSources: { total: total, items: trafficSourcesData.value },
+        });
+      } else {
+        setState({ loading: false });
+      }
+    };
+
+    fetchData();
+  }, [datahubClientNew, dateFrom, domainName, dateTo]);
+
+  return (
+    <div className="dp-box-shadow">
+      <div>
+        <h6 className="title-reports-box">
+          <FormattedMessage id="trafficSources.title" />
+        </h6>
+      </div>
+      <S.ContentContainer>
+        {state.loading ? (
+          <Loading />
+        ) : !state.trafficSources ? (
+          <p className="dp-boxshadow--error bounceIn">
+            <FormattedMessage id="common.unexpected_error" />
+          </p>
+        ) : state.trafficSources.items.length === 0 ? (
+          <p className="dp-boxshadow--usermsg bounceIn">
+            <FormattedMessage id="common.empty_data" />
+          </p>
+        ) : (
+          <S.ListContainer>
+            {state.trafficSources.items.map((trafficSource, index) => (
+              <S.ListItem key={index} className="col-md-4 col-sm-12">
+                <S.ListItemHeader>
+                  <p>
+                    <FormattedMessage
+                      defaultMessage={trafficSource.sourceType}
+                      id={`trafficSources.${trafficSource.sourceType.toLowerCase()}`}
+                    />
+                  </p>
+                  <span>
+                    {trafficSource.qVisitors}
+                    <span>
+                      (
+                      <FormattedNumber
+                        value={SafeDivide(trafficSource.qVisitors, state.trafficSources.total)}
+                        {...numberFormatOptions}
+                      />
+                      )
+                    </span>
+                  </span>
+                </S.ListItemHeader>
+                {trafficSource.qVisitorsWithEmail || trafficSource.qVisitorsWithEmail === 0 ? (
+                  <S.ListItemDetail>
+                    <div>
+                      <div>
+                        <p>
+                          <FormattedMessage id="trafficSources.users_with_email" />
+                        </p>
+                        <S.Bar
+                          primary
+                          style={{
+                            width:
+                              SafeDivide(
+                                trafficSource.qVisitorsWithEmail,
+                                trafficSource.qVisitors,
+                              ) *
+                                100 +
+                              '%',
+                          }}
+                        />
+                      </div>
+                      <span>
+                        {trafficSource.qVisitorsWithEmail}
+                        <span>
+                          (
+                          <FormattedNumber
+                            value={SafeDivide(
+                              trafficSource.qVisitorsWithEmail,
+                              trafficSource.qVisitors,
+                            )}
+                            {...numberFormatOptions}
+                          />
+                          )
+                        </span>
+                      </span>
+                    </div>
+                    <div>
+                      <div>
+                        <p>
+                          <FormattedMessage id="trafficSources.users_without_email" />
+                        </p>
+                        <S.Bar
+                          style={{
+                            width:
+                              SafeDivide(
+                                trafficSource.qVisitors - trafficSource.qVisitorsWithEmail,
+                                trafficSource.qVisitors,
+                              ) *
+                                100 +
+                              '%',
+                          }}
+                        />
+                      </div>
+                      <span>
+                        {trafficSource.qVisitors - trafficSource.qVisitorsWithEmail}
+                        <span>
+                          (
+                          <FormattedNumber
+                            value={SafeDivide(
+                              trafficSource.qVisitors - trafficSource.qVisitorsWithEmail,
+                              trafficSource.qVisitors,
+                            )}
+                            {...numberFormatOptions}
+                          />
+                          )
+                        </span>
+                      </span>
+                    </div>
+                  </S.ListItemDetail>
+                ) : null}
+              </S.ListItem>
+            ))}
+          </S.ListContainer>
+        )}
+      </S.ContentContainer>
+    </div>
+  );
+};
+
+export default InjectAppServices(ReportsTrafficSourcesNew);

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { HardcodedShopifyClient } from './services/shopify-client.doubles';
 import { getDataHubParams } from './utils';
 import { HardcodedDopplerApiClient } from './services/doppler-api-client.double';
 import { HardcodedIpinfoClient } from './services/ipinfo-client.doubles';
+import { HardcodedDatahubClientNew } from './services/datahub-client-new.doubles';
 
 polyfill();
 
@@ -35,6 +36,8 @@ const forcedServices =
         dopplerLegacyClient: new HardcodedDopplerLegacyClient(),
         dopplerSitesClient: new HardcodedDopplerSitesClient(),
         datahubClient: new HardcodedDatahubClient(),
+        // Temporal until use the new datahub client endpoints
+        datahubClientNew: new HardcodedDatahubClientNew(),
         shopifyClient: new HardcodedShopifyClient(),
         dopplerApiClient: new HardcodedDopplerApiClient(),
         ipinfoClient: new HardcodedIpinfoClient(),

--- a/src/services/datahub-client-new.doubles.ts
+++ b/src/services/datahub-client-new.doubles.ts
@@ -1,0 +1,203 @@
+import {
+  DatahubClientNew,
+  emailFilterOptions,
+  DomainEntry,
+  TrafficSourceResult,
+  VisitsQuantitySummarizedResult,
+} from './datahub-client-new';
+import { timeout } from '../utils';
+
+// TODO: use more realistic data
+const fakeData = [
+  {
+    name: 'www.fromdoppler.com',
+    verified_date: new Date('2010-12-17'),
+    pages: [],
+  },
+  {
+    name: 'www.makingsense.com',
+    verified_date: null,
+    pages: [],
+  },
+  {
+    name: 'www.google.com',
+    verified_date: new Date('2017-12-17'),
+    pages: [],
+  },
+];
+
+const fakeTrafficSourcesData = [
+  {
+    sourceType: 'Email',
+    qVisits: 2000,
+    qVisitsWithEmail: 500,
+    qVisitors: 1000,
+    qVisitorsWithEmail: 200,
+  },
+  {
+    sourceType: 'Social',
+    qVisits: 1000,
+    qVisitsWithEmail: 800,
+    qVisitors: 500,
+    qVisitorsWithEmail: 100,
+  },
+  {
+    sourceType: 'Paid',
+    qVisits: 250,
+    qVisitsWithEmail: 50,
+    qVisitors: 100,
+    qVisitorsWithEmail: 30,
+  },
+  {
+    sourceType: 'Organic',
+    qVisits: 100,
+    qVisitsWithEmail: 10,
+    qVisitors: 60,
+    qVisitorsWithEmail: 20,
+  },
+  {
+    sourceType: 'Referral',
+    qVisits: 50,
+    qVisitsWithEmail: 40,
+    qVisitors: 40,
+    qVisitorsWithEmail: 28,
+  },
+  {
+    sourceType: 'Direct',
+    qVisits: 100,
+    qVisitsWithEmail: 0,
+    qVisitors: 65,
+    qVisitorsWithEmail: 0,
+  },
+];
+
+const fakeDailyVisitsData = [
+  {
+    periodNumber: 0,
+    from: '2018-10-10T03:00:00.000Z',
+    to: '2018-10-11T03:00:00.000Z',
+    qVisitors: 20,
+    qVisitorsWithEmail: 3,
+    qVisits: 30,
+    qVisitsWithEmail: 10,
+  },
+  {
+    periodNumber: 1,
+    from: '2018-10-11T03:00:00.000Z',
+    to: '2018-10-12T03:00:00.000Z',
+    qVisitors: 40,
+    qVisitorsWithEmail: 10,
+    qVisits: 50,
+    qVisitsWithEmail: 20,
+  },
+  {
+    periodNumber: 2,
+    from: '2018-10-12T03:00:00.000Z',
+    to: '2018-10-13T03:00:00.000Z',
+    qVisitors: 70,
+    qVisitorsWithEmail: 2,
+    qVisits: 100,
+    qVisitsWithEmail: 10,
+  },
+  {
+    periodNumber: 3,
+    from: '2018-10-13T03:00:00.000Z',
+    to: '2018-10-14T03:00:00.000Z',
+    qVisitors: 80,
+    qVisitorsWithEmail: 40,
+    qVisits: 120,
+    qVisitsWithEmail: 40,
+  },
+];
+
+export class HardcodedDatahubClientNew implements DatahubClientNew {
+  public async getAccountDomains(): Promise<DomainEntry[]> {
+    console.log('getAccountDomains');
+    await timeout(1500);
+    return fakeData.map((x) => ({ name: x.name, verified_date: x.verified_date }));
+    // return [];
+  }
+
+  public async getTotalVisitsOfPeriod({
+    domainName,
+    dateFrom,
+    dateTo,
+    emailFilter,
+  }: {
+    domainName: number;
+    dateFrom: Date;
+    dateTo: Date;
+    emailFilter: emailFilterOptions;
+  }): Promise<number> {
+    console.log('getTotalVisitsOfPeriod', { domainName, dateFrom, emailFilter, dateTo });
+    await timeout(1500);
+    const visits = Math.round(Math.random() * (100 - 1) + 1);
+    return visits;
+  }
+
+  public async getTrafficSourcesByPeriod({
+    domainName,
+    dateFrom,
+    dateTo,
+  }: {
+    domainName: string;
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<TrafficSourceResult> {
+    console.log('getTrafficSourcesByPeriod', { domainName, dateFrom, dateTo });
+    await timeout(1000);
+    const trafficSources = fakeTrafficSourcesData.map((x) => ({
+      sourceType: x.sourceType,
+      qVisits: x.qVisits,
+      qVisitsWithEmail: x.qVisitsWithEmail,
+      qVisitors: x.qVisitors,
+      qVisitorsWithEmail: x.qVisitorsWithEmail,
+    }));
+
+    return {
+      success: true,
+      value: trafficSources,
+    };
+
+    //return {
+    //  success: false,
+    //  error: new Error('Dummy error'),
+    //};
+  }
+
+  public async getVisitsQuantitySummarizedByDay({
+    domainName,
+    dateFrom,
+    dateTo,
+  }: {
+    domainName: string;
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<VisitsQuantitySummarizedResult> {
+    console.log('getVisitsQuantitySummarizedByPeriod', { domainName, dateFrom, dateTo });
+    await timeout(1000);
+
+    const data = fakeDailyVisitsData;
+
+    const visitsByPeriod = data.map((x) => ({
+      periodNumber: x.periodNumber,
+      from: new Date(x.from),
+      to: new Date(x.to),
+      qVisitors: x.qVisitors,
+      qVisitorsWithEmail: x.qVisitorsWithEmail,
+      qVisitorsWithOutEmail: x.qVisitors - x.qVisitorsWithEmail,
+      qVisits: x.qVisits,
+      qVisitsWithEmail: x.qVisitsWithEmail,
+    }));
+
+    return {
+      success: true,
+      value: visitsByPeriod,
+    };
+
+    //return {
+    //  success: false,
+    //  error: new Error('Dummy error'),
+    //};
+  }
+}

--- a/src/services/datahub-client-new.ts
+++ b/src/services/datahub-client-new.ts
@@ -1,0 +1,229 @@
+import { AxiosInstance, AxiosStatic, AxiosPromise } from 'axios';
+import { RefObject } from 'react';
+import { AppSession, DatahubConnectionData } from './app-session';
+import { ResultWithoutExpectedErrors } from '../doppler-types';
+
+export interface DomainEntry {
+  name: string;
+  verified_date: Date | null;
+}
+
+export interface Page {
+  name: string;
+  totalVisitors: number;
+  url: string;
+  withEmail: number;
+}
+
+export interface PageRanking {
+  hasMorePages: boolean;
+  pages: Page[];
+}
+
+export interface TrafficSource {
+  sourceType: string;
+  qVisits: number;
+  qVisitsWithEmail: number;
+  qVisitors: number;
+  qVisitorsWithEmail: number;
+}
+
+export interface VisitsQuantitySummarized {
+  periodNumber: number;
+  from: Date;
+  to: Date;
+  qVisits: number;
+  qVisitsWithEmail: number;
+  qVisitors: number;
+  qVisitorsWithEmail: number;
+  qVisitorsWithOutEmail: number;
+}
+
+export type emailFilterOptions = 'with_email' | 'without_email' | null;
+
+export type filterByPeriodOptions = 'days' | 'hours';
+
+export interface DatahubClientNew {
+  getAccountDomains(): Promise<DomainEntry[]>;
+  getTotalVisitsOfPeriod(query: {
+    domainName: number;
+    dateFrom: Date;
+    dateTo: Date;
+    emailFilter?: emailFilterOptions;
+  }): Promise<number>;
+  getTrafficSourcesByPeriod(query: {
+    domainName: string;
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<TrafficSourceResult>;
+  getVisitsQuantitySummarizedByDay(query: {
+    domainName: string;
+    dateFrom: Date;
+  }): Promise<VisitsQuantitySummarizedResult>;
+}
+
+export type TrafficSourceResult = ResultWithoutExpectedErrors<TrafficSource[]>;
+
+export type VisitsQuantitySummarizedResult = ResultWithoutExpectedErrors<
+  VisitsQuantitySummarized[]
+>;
+
+export type PageRankingResult = ResultWithoutExpectedErrors<PageRanking>;
+
+export class HttpDatahubClientNew implements DatahubClientNew {
+  private readonly axios: AxiosInstance;
+  private readonly baseUrl: string;
+  private readonly connectionDataRef: RefObject<AppSession>;
+
+  constructor({
+    axiosStatic,
+    baseUrl,
+    connectionDataRef,
+  }: {
+    axiosStatic: AxiosStatic;
+    baseUrl: string;
+    connectionDataRef: RefObject<AppSession>;
+  }) {
+    this.baseUrl = baseUrl;
+    this.axios = axiosStatic.create({
+      baseURL: this.baseUrl,
+    });
+    this.connectionDataRef = connectionDataRef;
+  }
+
+  private getDatahubConnectionData(): DatahubConnectionData {
+    const connectionData = this.connectionDataRef.current;
+    if (
+      !connectionData ||
+      connectionData.status !== 'authenticated' ||
+      !connectionData.jwtToken ||
+      !connectionData.datahubCustomerId
+    ) {
+      throw new Error('DataHub connection data is not available');
+    }
+    return connectionData;
+  }
+
+  private customerGet<T>(subUrl: string, params?: any): AxiosPromise<T> {
+    const { datahubCustomerId: customerId, jwtToken } = this.getDatahubConnectionData();
+    return this.axios.request<T>({
+      method: 'GET',
+      url: `/cdhapi/customers/${customerId}/${subUrl}`,
+      params: params,
+      headers: { Authorization: `Bearer ${jwtToken}` },
+    });
+  }
+
+  public async getAccountDomains(): Promise<DomainEntry[]> {
+    const response = await this.customerGet<{ items: any[] }>('domains');
+    return response.data.items
+      .filter((x) => x.enabled)
+      .map((x) => ({
+        name: x.domainName,
+        verified_date: (x.lastNavigationEventTime && new Date(x.lastNavigationEventTime)) || null,
+      }));
+  }
+
+  public async getTotalVisitsOfPeriod({
+    domainName,
+    dateFrom,
+    dateTo,
+    emailFilter,
+  }: {
+    domainName: number;
+    dateFrom: Date;
+    dateTo: Date;
+    emailFilter: emailFilterOptions;
+  }): Promise<number> {
+    const response = await this.customerGet<{ qVisitorsWithEmail: number; qVisitors: number }>(
+      `domains/${domainName}/visitors/summarization`,
+      {
+        startDate: dateFrom.toISOString(),
+        endDate: dateTo.toISOString(),
+      },
+    );
+    const visitors_quantity =
+      emailFilter === 'with_email' ? response.data.qVisitorsWithEmail : response.data.qVisitors;
+    return visitors_quantity;
+  }
+
+  public async getTrafficSourcesByPeriod({
+    domainName,
+    dateFrom,
+    dateTo,
+  }: {
+    domainName: string;
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<TrafficSourceResult> {
+    try {
+      const response = await this.customerGet<{ items: TrafficSource[] }>(
+        `domains/${domainName}/events/summarized-by-type`,
+        {
+          startDate: dateFrom.toISOString(),
+          endDate: dateTo.toISOString(),
+        },
+      );
+
+      const trafficSources = response.data.items.map((x) => ({
+        sourceType: x.sourceType,
+        qVisits: x.qVisits,
+        qVisitsWithEmail: x.qVisitsWithEmail,
+        qVisitors: x.qVisitors,
+        qVisitorsWithEmail: x.qVisitorsWithEmail,
+      }));
+
+      return {
+        success: true,
+        value: trafficSources,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error,
+      };
+    }
+  }
+
+  public async getVisitsQuantitySummarizedByDay({
+    domainName,
+    dateFrom,
+    dateTo,
+  }: {
+    domainName: string;
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<VisitsQuantitySummarizedResult> {
+    try {
+      const response = await this.customerGet<any>(
+        `domains/${domainName}/events/summarized-by-day`,
+        {
+          startDate: dateFrom.toISOString(),
+          endDate: dateTo.toISOString(),
+        },
+      );
+
+      const visitsByPeriod = response.data.periods.map((x: any) => ({
+        periodNumber: x.periodNumber,
+        from: new Date(x.from),
+        to: new Date(x.to),
+        qVisitors: x.qVisitors,
+        qVisitorsWithEmail: x.qVisitorsWithEmail,
+        qVisitorsWithOutEmail:
+          x.qVisitorsWithEmail !== undefined
+            ? x.qVisitors - x.qVisitorsWithEmail
+            : x.qVisitorsWithEmail,
+      }));
+
+      return {
+        success: true,
+        value: visitsByPeriod,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error,
+      };
+    }
+  }
+}

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -10,6 +10,7 @@ import { DopplerApiClient, HttpDopplerApiClient } from './doppler-api-client';
 import { DopplerSitesClient, HttpDopplerSitesClient } from './doppler-sites-client';
 import { IpinfoClient, HttpIpinfoClient } from './ipinfo-client';
 import { ExperimentalFeatures } from './experimental-features';
+import { DatahubClientNew, HttpDatahubClientNew } from './datahub-client-new';
 
 interface AppConfiguration {
   dopplerLegacyUrl: string;
@@ -33,6 +34,8 @@ export interface AppServices {
   axiosStatic: AxiosStatic;
   appConfiguration: AppConfiguration;
   datahubClient: DatahubClient;
+  // Temporal until use the new datahub client endpoints
+  datahubClientNew: DatahubClientNew;
   dopplerLegacyClient: DopplerLegacyClient;
   sessionManager: SessionManager;
   localStorage: Storage;
@@ -97,6 +100,18 @@ export class AppCompositionRoot implements AppServices {
       'datahubClient',
       () =>
         new HttpDatahubClient({
+          axiosStatic: this.axiosStatic,
+          baseUrl: this.appConfiguration.datahubUrl,
+          connectionDataRef: this.appSessionRef,
+        }),
+    );
+  }
+  // Temporal until use the new datahub client endpoints
+  get datahubClientNew() {
+    return this.singleton(
+      'datahubClientNew',
+      () =>
+        new HttpDatahubClientNew({
           axiosStatic: this.axiosStatic,
           baseUrl: this.appConfiguration.datahubUrl,
           connectionDataRef: this.appSessionRef,


### PR DESCRIPTION
- Add new page `/reports-new` with the data with en new endpoints.
- Add new service `datahub-client-new` for the new endpoints
- Add new components with the new data, `ReportsBoxNew, ReportsTrafficSources, ReportsDailyVisits`

- TODO: Missing tests, the report for days and hours, and add in the new features pages the link
