### PR TITLE
feat(ReportsNew): add domains and date filters

### DIFF
--- a/src/components/Reports/ReportsFilters/ReportsFilters.js
+++ b/src/components/Reports/ReportsFilters/ReportsFilters.js
@@ -9,6 +9,7 @@ const ReportsFilters = ({
   changeDomain,
   changePeriod,
   periodSelectedDays,
+  isEnableWeeks,
 }) => {
   return (
     <header className="hero-banner report-filters">
@@ -89,19 +90,22 @@ const ReportsFilters = ({
                     >
                       {(message) => <option value="7">{message}</option>}
                     </FormattedMessage>
-                    {/* **temporarily remove until DH performance issues can be addresed
-                    <FormattedMessage
-                      id="reports_filters.week_with_plural"
-                      values={{ weeksCount: 2 }}
-                    >
-                      {(message) => <option value="14">{message}</option>}
-                    </FormattedMessage>
-                    <FormattedMessage
-                      id="reports_filters.week_with_plural"
-                      values={{ weeksCount: 3 }}
-                    >
-                      {(message) => <option value="21">{message}</option>}
-                    </FormattedMessage>*/}
+                    {isEnableWeeks ? (
+                      <>
+                        <FormattedMessage
+                          id="reports_filters.week_with_plural"
+                          values={{ weeksCount: 2 }}
+                        >
+                          {(message) => <option value="14">{message}</option>}
+                        </FormattedMessage>
+                        <FormattedMessage
+                          id="reports_filters.week_with_plural"
+                          values={{ weeksCount: 3 }}
+                        >
+                          {(message) => <option value="21">{message}</option>}
+                        </FormattedMessage>
+                      </>
+                    ) : null}
                   </select>
                 </fieldset>
               </div>

--- a/src/components/Reports/ReportsFilters/ReportsFilters.test.js
+++ b/src/components/Reports/ReportsFilters/ReportsFilters.test.js
@@ -43,7 +43,7 @@ describe('ReportsFilters component', () => {
     };
 
     // Act
-    const { container, getByText } = render(
+    const { container } = render(
       <DopplerIntlProvider>
         <ReportsFilters
           changeDomain={() => {}}
@@ -60,5 +60,60 @@ describe('ReportsFilters component', () => {
 
     // Assert
     expect(container).not.toContainHTML('reports_filters.verified_domain');
+  });
+
+  it('should show 2 and 3 weeks when isEnableWeeks true', async () => {
+    // Arrange
+    const domain = {
+      name: 'domain.localhost',
+      verified_date: new Date('2018-05-30T15:30:10Z'),
+    };
+
+    // Act
+    const { getAllByText } = render(
+      <DopplerIntlProvider>
+        <ReportsFilters
+          isEnableWeeks
+          changeDomain={() => {}}
+          domains={[domain]}
+          domainSelected={domain}
+          pages={[]}
+          pageSelected={null}
+          changePage={() => {}}
+          periodSelectedDays={7}
+          changePeriod={() => {}}
+        />
+      </DopplerIntlProvider>,
+    );
+
+    // Assert
+    expect(getAllByText('reports_filters.week_with_plural'));
+  });
+
+  it('should show 1 week when isEnableWeeks false', async () => {
+    // Arrange
+    const domain = {
+      name: 'domain.localhost',
+      verified_date: new Date('2018-05-30T15:30:10Z'),
+    };
+
+    // Act
+    const { getByText } = render(
+      <DopplerIntlProvider>
+        <ReportsFilters
+          changeDomain={() => {}}
+          domains={[domain]}
+          domainSelected={domain}
+          pages={[]}
+          pageSelected={null}
+          changePage={() => {}}
+          periodSelectedDays={7}
+          changePeriod={() => {}}
+        />
+      </DopplerIntlProvider>,
+    );
+
+    // Assert
+    expect(getByText('reports_filters.week_with_plural'));
   });
 });

--- a/src/components/Reports/ReportsNew.js
+++ b/src/components/Reports/ReportsNew.js
@@ -1,9 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { FormattedMessage, FormattedDate } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Helmet } from 'react-helmet';
 import { InjectAppServices } from '../../services/pure-di';
 import { Loading } from '../Loading/Loading';
 import { BoxMessage } from '../styles/messages';
+import { addDays, getStartOfDate } from '../../utils';
+import ReportsFilters from './ReportsFilters/ReportsFilters';
+import {
+  SiteTrackingRequired,
+  SiteTrackingNotAvailableReasons,
+} from '../SiteTrackingRequired/SiteTrackingRequired';
+import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
+
+// This value means the today date
+const periodSelectedDaysDefault = 1;
 
 /**
  * @param { Object } props
@@ -11,18 +21,41 @@ import { BoxMessage } from '../styles/messages';
  */
 
 const ReportsNew = ({ dependencies: { datahubClient } }) => {
-  const [state, setState] = useState({ loading: true });
+  const today = getStartOfDate(new Date());
+  const [state, setState] = useState({
+    loading: true,
+    periodSelectedDays: periodSelectedDaysDefault,
+    dateFrom: addDays(today, periodSelectedDaysDefault * -1),
+    dateTo: periodSelectedDaysDefault ? today : new Date(),
+  });
+
+  const changeDomain = async (name) => {
+    const domainFound = state.domains.find((item) => item.name === name);
+    setState((prevState) => ({ ...prevState, domainSelected: domainFound }));
+  };
+
+  const changePeriod = (daysToFilter) => {
+    const today = getStartOfDate(new Date());
+    setState((prevState) => ({
+      ...prevState,
+      periodSelectedDays: daysToFilter,
+      dateFrom: addDays(today, daysToFilter * -1),
+      dateTo: daysToFilter ? today : new Date(),
+      dailyView: !daysToFilter,
+    }));
+  };
 
   useEffect(() => {
     const fetchData = async () => {
       setState({ loading: true });
       const response = await datahubClient.getAccountDomains();
       if (response.success) {
-        setState({
+        setState((prevState) => ({
+          ...prevState,
           domains: response.value,
           domainSelected: response.value.length ? response.value[0] : null,
           loading: false,
-        });
+        }));
       } else {
         setState({ loading: false });
       }
@@ -40,28 +73,37 @@ const ReportsNew = ({ dependencies: { datahubClient } }) => {
           </Helmet>
         )}
       </FormattedMessage>
-
-      <section className="dp-container m-t-24">
-        <span>
-          <FormattedMessage id="reports_title" />
-        </span>
-        <div>
+      {state.domains && !state.domainSelected ? (
+        <SiteTrackingRequired reason={SiteTrackingNotAvailableReasons.thereAreNotDomains} />
+      ) : (
+        <>
+          <ReportsFilters
+            changeDomain={changeDomain}
+            domains={state.domains}
+            domainSelected={state.domainSelected}
+            periodSelectedDays={state.periodSelectedDays}
+            changePeriod={changePeriod}
+            isEnableWeeks
+          />
           {state.loading ? (
             <Loading />
           ) : state.domains ? (
-            state.domains.map((domain, index) => (
-              <div>
-                <span key={index}>{domain.name}</span>
-                <FormattedDate value={domain.verified_date} />
-              </div>
-            ))
+            <section className="dp-container">
+              {!state.domainSelected.verified_date ? (
+                <BoxMessage className="dp-msj-error bounceIn" spaceTopBottom>
+                  <p>
+                    <FormattedMessageMarkdown id="reports_filters.domain_not_verified_MD" />
+                  </p>
+                </BoxMessage>
+              ) : null}
+            </section>
           ) : (
             <BoxMessage className="dp-msj-error bounceIn" spaceTopBottom>
               <FormattedMessage id="common.unexpected_error" />
             </BoxMessage>
           )}
-        </div>
-      </section>
+        </>
+      )}
     </>
   );
 };

--- a/src/components/Reports/ReportsNew.test.js
+++ b/src/components/Reports/ReportsNew.test.js
@@ -25,7 +25,7 @@ describe('Reports New page', () => {
     );
 
     // Assert
-    await waitFor(() => expect(getByText('reports_title')));
+    await waitFor(() => expect(getByText('reports_filters.title')));
   });
 
   it('should show error when dont have domains', async () => {


### PR DESCRIPTION
- Add filters in the new reports page.
- Add the posibility to select 2 or 3 weeks in the new reports page.

![image](https://user-images.githubusercontent.com/8861133/80533646-5ac08700-8974-11ea-88ab-1e6418fd34cb.png)
