### PR TITLE
fix(DopplerAcademy): add qa environment in whitelist

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,6 +159,7 @@ export function isWhitelisted(url: string) {
     'https://localhost/',
     'https://appint.fromdoppler.com/',
     'https://appqa.fromdoppler.com/',
+    'https://qa.doppleracademy.com',
   ];
   return !!url && loginWhitelist.some((element) => url.startsWith(element));
 }


### PR DESCRIPTION
- Add in white list the `https://qa.doppleracademy.com` url