### PR TITLE
Offline link

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import ReportsPartialsCampaigns from './components/Reports/ReportsPartialsCampai
 import NewFeatures from './components/NewFeatures/NewFeatures';
 // Temporal until use the new datahub client endpoints
 import ReportsNew from './components/Reports/ReportsNew';
+import Offline from './components/Offline/Offline';
 
 /**
  * @param { Object } props - props
@@ -110,6 +111,7 @@ const App = ({ locale, location, dependencies: { appSessionRef, sessionManager }
           <PublicRouteWithLegacyFallback exact path="/signup" />
           <PublicRouteWithLegacyFallback exact path="/login/reset-password" />
           <Route path="/signup/confirmation" exact component={SignupConfirmation} />
+          <Route path="/offline" exact component={Offline} />
           <RedirectWithQuery exact from="/ingresa" to="/login?lang=es" />
           <RedirectWithQuery exact from="/registrate" to="/signup?lang=es" />
           <RedirectWithQuery exact from="/ingresa/cambiar-clave" to="/forgot-password?lang=es" />

--- a/src/components/NewFeatures/NewFeatures.js
+++ b/src/components/NewFeatures/NewFeatures.js
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 const NewFeatures = () => {
-  const [campaignId, setCampaignId] = useState(0);
   return (
     <>
       <header className="hero-banner report-filters">
@@ -28,42 +27,11 @@ const NewFeatures = () => {
         </div>
         <div className="dp-block-wlp dp-box-shadow m-t-36">
           <div style={{ marginLeft: '20px' }}>
-            <h3>Campañas parcialmente enviadas</h3>
-            <p>
-              Como encuentro el id de mi Campaña enviada?{' '}
-              <span class="ms-icon icon-tip-icon dp-tooltip-right">
-                <span class="tooltiptext">
-                  Ir a Campañas &gt; Enviadas y al acceder al Reporte que se visualiza en la grilla.
-                  Se ve en la url similar a
-                  https://app2.fromdoppler.com/Campaigns/Reports/Dashboard?idCampaign=10011359 en
-                  este caso el id es 10011359
-                </span>
-              </span>
-            </p>
-            <p>
-              Como encuentro el id de mi Campaña en progreso?{' '}
-              <span class="ms-icon icon-tip-icon dp-tooltip-right">
-                <span class="tooltiptext">
-                  Antes de ponerla a enviar, desde el summary de la Campaña se visualiza en la url,
-                  algo similar a esta url
-                  https://app2.fromdoppler.com/Campaigns/Summary?IdCampaign=10264783 aqui el id es
-                  10264783
-                </span>
-              </span>
-            </p>
-            <input
-              style={{ width: '400px' }}
-              type="text"
-              placeholder="Ingresa el id de la Campaña enviada o en progreso"
-              onChange={(e) => {
-                const { value } = e.target;
-                setCampaignId(value);
-              }}
-            ></input>{' '}
-            <Link to={`/reports/partials-campaigns?campaignId=${campaignId}`}>Ir al Reporte</Link>
+            <h3>Página offline</h3>
+            <Link to={'/offline'}>Ir a página offline</Link>
           </div>
         </div>
-        <div className="dp-block-wlp dp-box-shadow">
+        <div className="dp-block-wlp dp-box-shadow m-t-36">
           <div style={{ marginLeft: '20px' }}>
             <h3>Reportes con lo viejo de datahub</h3>
             <Link to={`/reports-old`}>Link</Link>

--- a/src/components/Offline/Offline.js
+++ b/src/components/Offline/Offline.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Offline = () => (
-  <div>
+  <div className='dp-app-container'>
     <header style={{ height: '84px' }}></header>
     <main style={{ display: 'block', widht: '100%' }}>
       <section class="section__block image__main">

--- a/src/components/Offline/Offline.js
+++ b/src/components/Offline/Offline.js
@@ -1,18 +1,18 @@
 import React from 'react';
 
 const Offline = () => (
-  <div className='dp-app-container'>
+  <div className="dp-app-container">
     <header style={{ height: '84px' }}></header>
     <main style={{ display: 'block', widht: '100%' }}>
-      <section class="section__block image__main">
-        <div class="wrapper" style={{ width: '800px', margin: 'auto' }}>
-          <h1 style={{ 'padding-bottom': '0' }}>Experimentamos dificultades técnicas.</h1>
+      <section className="section__block image__main">
+        <div className="wrapper" style={{ width: '800px', margin: 'auto' }}>
+          <h1 style={{ paddingBottom: '0' }}>Experimentamos dificultades técnicas.</h1>
           <h2
             style={{
-              'font-size': '18px',
-              'font-weight': '400',
-              'line-height': '1.2',
-              'letter-spacing': '0',
+              fontSize: '18px',
+              fontWeight: '400',
+              lineHeight: '1.2',
+              letterSpacing: '0',
               color: '#525845',
               padding: '0 0 10px',
             }}


### PR DESCRIPTION
### Offline page
- Added offline page to be accesible via url, in `/offline`
- Added link into new features page
- Fixed classes in offline page that were seen as warnings in console ( class by className, style properties without middle dash: `padding-bottom` changed by `paddingBottom`. 
- Added white background to avoid spinner showing 
- Remove `Campañas parcialmente enviadas` since it's already in production.

![image](https://user-images.githubusercontent.com/2439363/83422062-5a962a00-a3ff-11ea-803b-4577a26e78cb.png)

![image](https://user-images.githubusercontent.com/2439363/83422086-6255ce80-a3ff-11ea-921e-1fe12da50420.png)


https://cdn.fromdoppler.com/doppler-webapp/demo-build2386/#/new-features
https://cdn.fromdoppler.com/doppler-webapp/demo-build2386/#/offline
https://cdn.fromdoppler.com/doppler-webapp/build2386/#/offline