### PR TITLE
DW-362: chore: add upload to new cdn

### DIFF
--- a/Dockerfile.BUILDS_AND_CDN
+++ b/Dockerfile.BUILDS_AND_CDN
@@ -32,3 +32,22 @@ RUN AKAMAI_CDN_HOSTNAME=$cdn_hostname \
   AKAMAI_CDN_PASSWORD=$cdn_password \
   AKAMAI_CDN_CPCODE=$cdn_cpcode \
   node cdn-uploader.js /source doppler-webapp ${env_version}
+
+## Publish into new CDN using SFTP
+## Using a third party image here, with specific digest (f7f7607...) to avoid unwanted changes
+FROM ttionya/openssh-client@sha256:f7f7607d56f09a7c42e246e9c256ff51cf2f0802e3b2d88da6537bea516fe142
+COPY --from=build /app/build /source
+ARG env_version
+ARG CDN_SFTP_PORT
+ARG CDN_SFTP_USERNAME
+ARG CDN_SFTP_HOSTNAME
+ARG CDN_SFTP_BASE
+ARG SSH_PRIVATE_KEY
+ARG SSH_KNOWN_HOSTS
+RUN mkdir /root/.ssh/ &&\
+    echo "${SSH_PRIVATE_KEY}" > /root/.ssh/id_rsa &&\
+    chmod 600 /root/.ssh/id_rsa &&\
+    echo "${SSH_KNOWN_HOSTS}" > /root/.ssh/known_hosts &&\
+    chmod 600 /root/.ssh/known_hosts
+RUN scp -P "${CDN_SFTP_PORT}" -r /source "${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/doppler-webapp/${env_version}"
+RUN echo "Files published on http://cdn.fromdoppler.com/doppler-webapp/${env_version}"

--- a/Dockerfile.RELEASES
+++ b/Dockerfile.RELEASES
@@ -46,6 +46,26 @@ RUN AKAMAI_CDN_HOSTNAME=$cdn_hostname \
   AKAMAI_CDN_CPCODE=$cdn_cpcode \
   node cdn-uploader.js /source doppler-webapp ${environment}-${pkgVersion}
 
+## Publish into new CDN using SFTP
+## Using a third party image here, with specific digest (f7f7607...) to avoid unwanted changes
+FROM ttionya/openssh-client@sha256:f7f7607d56f09a7c42e246e9c256ff51cf2f0802e3b2d88da6537bea516fe142
+COPY --from=build_cdn /app/build /source
+ARG environment
+ARG pkgVersion
+ARG CDN_SFTP_PORT
+ARG CDN_SFTP_USERNAME
+ARG CDN_SFTP_HOSTNAME
+ARG CDN_SFTP_BASE
+ARG SSH_PRIVATE_KEY
+ARG SSH_KNOWN_HOSTS
+RUN mkdir /root/.ssh/ &&\
+    echo "${SSH_PRIVATE_KEY}" > /root/.ssh/id_rsa &&\
+    chmod 600 /root/.ssh/id_rsa &&\
+    echo "${SSH_KNOWN_HOSTS}" > /root/.ssh/known_hosts &&\
+    chmod 600 /root/.ssh/known_hosts
+RUN scp -P "${CDN_SFTP_PORT}" -r /source "${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/doppler-webapp/${environment}-${pkgVersion}"
+RUN echo "Files published on http://cdn.fromdoppler.com/doppler-webapp/${environment}-${pkgVersion}"
+
 
 # Runtime layer (Host project in nginx)
 FROM nginx:1.17.10-alpine

--- a/build-n-publish-release-w-docker.sh
+++ b/build-n-publish-release-w-docker.sh
@@ -71,6 +71,12 @@ for environment in ${environments}; do
         --build-arg cdn_username=$AKAMAI_CDN_USERNAME \
         --build-arg cdn_password=$AKAMAI_CDN_PASSWORD \
         --build-arg cdn_cpcode=$AKAMAI_CDN_CPCODE \
+        --build-arg CDN_SFTP_PORT=$CDN_SFTP_PORT \
+        --build-arg CDN_SFTP_USERNAME=$CDN_SFTP_USERNAME \
+        --build-arg CDN_SFTP_HOSTNAME=$CDN_SFTP_HOSTNAME \
+        --build-arg CDN_SFTP_BASE=$CDN_SFTP_BASE \
+        --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" \
+        --build-arg SSH_KNOWN_HOSTS="$(cat ~/.ssh/known_hosts)" \
         -f Dockerfile.RELEASES \
         .
 

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -52,6 +52,12 @@ for environment in ${environments}; do
         --build-arg cdn_username=$AKAMAI_CDN_USERNAME \
         --build-arg cdn_password=$AKAMAI_CDN_PASSWORD \
         --build-arg cdn_cpcode=$AKAMAI_CDN_CPCODE \
+        --build-arg CDN_SFTP_PORT=$CDN_SFTP_PORT \
+        --build-arg CDN_SFTP_USERNAME=$CDN_SFTP_USERNAME \
+        --build-arg CDN_SFTP_HOSTNAME=$CDN_SFTP_HOSTNAME \
+        --build-arg CDN_SFTP_BASE=$CDN_SFTP_BASE \
+        --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" \
+        --build-arg SSH_KNOWN_HOSTS="$(cat ~/.ssh/known_hosts)" \
         -f Dockerfile.BUILDS_AND_CDN \
         .
 


### PR DESCRIPTION
### File upload to new CDN

Add upload to new cdn hosted in `108.166.10.14` to be mapped onto domain `cdn.fromdoppler.com`, to test the map this ip into the domain on host file in windows.


https://cdn.fromdoppler.com/doppler-webapp/build2433/#/login --> working for akamai and new cdn. 

- Add upload for each PR
- Add upload for release