### PR TITLE
fix: add nginx config file per environment

### DIFF
--- a/Dockerfile.swarm
+++ b/Dockerfile.swarm
@@ -21,9 +21,10 @@ ENV PUBLIC_URL=$public_url
 RUN yarn build:$environment
 
 FROM nginx:1.19.0-alpine AS final
+ARG environment
 WORKDIR /app
 RUN rm /etc/nginx/conf.d/default.conf
-COPY conf/site-swarm.conf /etc/nginx/conf.d/site.conf
+COPY conf/site-$environment.conf /etc/nginx/conf.d/site.conf
 COPY --from=build /app/build /usr/share/nginx/html
 ARG version=unknown
 RUN echo $version > /usr/share/nginx/html/version.txt


### PR DESCRIPTION
### Update nginx config file for each env

In images made for `fromdoppler` in jenkinsfile we were using by default a signle config file: `site-swarm.conf`, this conf file is very similar to production, but lacks all the port mapping for int and qa as well as the security improvements made. (That is the reason why `fromdoppler/webapp:int-v1` works locally but does not work when deploying into the swarm service)

For example int service is created like this:
```
sudo docker service create --mode global --name WEBAPP-INT --update-delay 2m30s --publish published=8080,target=80 --publish published=4443,target=443 ... fromdoppler/doppler-webapp:int-v1
```
`site-swarm.conf` exposes only port 80 like `site-production.conf`, here in int we need port 8080 exposed.