### PR TITLE
DW-421: set cache headers in nginx

### DIFF
--- a/conf/site-local.conf
+++ b/conf/site-local.conf
@@ -19,18 +19,23 @@ server {
 
         location /static/ {
                 root /usr/share/nginx/html;
+                expires 1y;
+                add_header Cache-Control "public, immutable";
         }
 
         location ~* ^.+\.html$ {
-                expires 1h;
                 root    /usr/share/nginx/html;
                 index   index.html index.html;
+                expires off;
+                add_header Cache-Control "no-store";
         }
 
         location / {
                 root   /usr/share/nginx/html;
                 index   index.html index.html;
                 try_files $uri $uri/ /index.html;
+                expires off;
+                add_header Cache-Control "no-store";
         }
 
 

--- a/conf/site-swarm.conf
+++ b/conf/site-swarm.conf
@@ -13,16 +13,21 @@ server {
 
         location /static/ {
                 root /usr/share/nginx/html;
+                expires 1y;
+                add_header Cache-Control "public, immutable";
         }
 
         location ~* ^.+\.html$ {
-                expires 1h;
                 root    /usr/share/nginx/html;
                 index   index.html index.html;
+                expires off;
+                add_header Cache-Control "no-store";
         }
         location / {
                 root    /usr/share/nginx/html;
                 index   index.html index.html;
                 try_files $uri $uri/ /index.html;
+                expires off;
+                add_header Cache-Control "no-store";
         }
 }

--- a/request-testing.http
+++ b/request-testing.http
@@ -1,0 +1,8 @@
+###
+# Should not cache all requests outside of /static/
+http://localhost:8080/login
+
+###
+# It should cache aggressively al content in /static/
+http://localhost:8080/static/js/main.ed1f8fc4.chunk.js
+


### PR DESCRIPTION
### Add cache control headers in nginx
We had an issue in production with coudflare strong caching of non static resources like html, but the rule `Origin Cache Control: On` allows to do the caching according to the headers sent by our servers. We didn´t have any headers set, now we will.

For all resources outside static:

![image](https://user-images.githubusercontent.com/2439363/88397293-1b9aaa00-cd9a-11ea-8a47-59d42ace0152.png)

For static requests:

![image](https://user-images.githubusercontent.com/2439363/88397583-85b34f00-cd9a-11ea-8306-86a350290542.png)

#### Changes
- headers on local conf
- headers on swarm production conf
- some testing links that may be used later also