### PR TITLE
fix: change regex for subscriber sections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -101,7 +101,7 @@ const App = ({ locale, location, dependencies: { appSessionRef, sessionManager }
           {/* TODO: delete this when urls change in MasterSubscribers */}
           {/* This is to keep backward compatibility with /reports/subscriber-history and /reports/subscriber-history */}
           <PrivateRoute
-            path="/reports/:subscriber-:section"
+            path="/reports/subscriber-:section"
             exact
             component={SubscribersLegacyUrlRedirect}
           />


### PR DESCRIPTION
Fix issue with subscriber pages redirection.
It was redirecting all URL's like: /reports/XXXX-XXXXX

Now it will redirec only: /reports/subscriber-XXXXX

http://cdn.fromdoppler.com/doppler-webapp/build2536/#/reports/partials-campaigns
