### PR TITLE
fix: update plan calculator url

### DIFF
--- a/src/components/NewFeatures/NewFeatures.js
+++ b/src/components/NewFeatures/NewFeatures.js
@@ -43,10 +43,12 @@ const NewFeatures = () => {
             <Link to={'/plans/18/discounts/2/promotions/ALLPLANS/buy'}>Ir a Comprar Plan</Link>
           </div>
         </div>
-        <div className="dp-block-wlp dp-box-shadow m-t-36">
+        <div className="dp-block-wlp dp-box-shadow m-t-36 m-b-36">
           <div style={{ marginLeft: '20px' }}>
             <h3>Plan Calculator</h3>
-            <Link to={'/plan-calculator'}>Ir a calculadora de planes</Link>
+            <Link to={'/plan-calculator/1/buy?promoId=EXAMPLE&discountId=1'}>
+              Ir a calculadora de planes
+            </Link>
           </div>
         </div>
       </section>


### PR DESCRIPTION
It updates plan-calculator url in new-features page.
Also, a margin was added to separate the content box from the footer. 