### PR TITLE
DW-452 add Doppler plan service

### DIFF
--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -10,6 +10,9 @@ import {
   ForgotPasswordModel,
   ForgotPasswordResult,
   ActivateSiteTrackingTrialResult,
+  PlanModel,
+  userType,
+  planType,
 } from './doppler-legacy-client';
 import headerDataJson from '../headerData.json';
 import { timeout } from '../utils';
@@ -42,6 +45,129 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
     //   trace: new Error(),
     //   fullResponse: 'full header response',
     // };
+  }
+
+  public async getAllPlans(): Promise<PlanModel[]> {
+    console.log('GetAllPlans');
+    await timeout(1500);
+    return [
+      {
+        id: 12,
+        description: '500,000',
+        fee: 444,
+        userType: userType.HIGH_VOLUME,
+        type: planType.STANDARD,
+        emailsByMonth: 500000,
+        subscribersByMonth: undefined,
+        emailPrice: 0.0009,
+        features: {
+          emailParameter: false,
+          cancelCampaign: false,
+          siteTracking: false,
+          smartCampaigns: false,
+          shippingLimit: false,
+        },
+        advancedPayOptions: [
+          {
+            id: 62,
+            idPlan: 12,
+            paymentType: 1,
+            discountPercentage: 0,
+            monthsToPay: 1,
+          },
+        ],
+      },
+      {
+        id: 14,
+        description: '500,000',
+        fee: 444,
+        userType: userType.HIGH_VOLUME,
+        type: planType.PLUS,
+        emailsByMonth: 500000,
+        emailPrice: 0.0009,
+        features: {
+          emailParameter: true,
+          cancelCampaign: false,
+          siteTracking: true,
+          smartCampaigns: false,
+          shippingLimit: false,
+        },
+        advancedPayOptions: [
+          {
+            id: 62,
+            idPlan: 12,
+            paymentType: 1,
+            discountPercentage: 0,
+            monthsToPay: 1,
+          },
+        ],
+      },
+      {
+        id: 19,
+        description: '500,000',
+        fee: 444,
+        userType: userType.SUBSCRIBERS_MONTHLY,
+        type: planType.STANDARD,
+        emailsByMonth: 5000,
+        emailPrice: 0.0009,
+        features: {
+          emailParameter: true,
+          cancelCampaign: false,
+          siteTracking: true,
+          smartCampaigns: false,
+          shippingLimit: false,
+        },
+        advancedPayOptions: [
+          {
+            id: 62,
+            idPlan: 12,
+            paymentType: 1,
+            discountPercentage: 0,
+            monthsToPay: 1,
+          },
+        ],
+      },
+      {
+        id: 18,
+        description: '501-1500',
+        fee: 15,
+        userType: userType.SUBSCRIBERS_MONTHLY,
+        type: planType.STANDARD,
+        emailsByMonth: undefined,
+        subscribersByMonth: 1500,
+        emailPrice: undefined,
+        features: {
+          emailParameter: false,
+          cancelCampaign: false,
+          siteTracking: false,
+          smartCampaigns: false,
+          shippingLimit: false,
+        },
+        advancedPayOptions: [
+          { id: 1, idPlan: 18, paymentType: 1, discountPercentage: 0, monthsToPay: 1 },
+        ],
+      },
+      {
+        id: 38,
+        description: '501-1500',
+        fee: 15,
+        userType: userType.SUBSCRIBERS_MONTHLY,
+        type: planType.PLUS,
+        emailsByMonth: undefined,
+        subscribersByMonth: 1500,
+        emailPrice: undefined,
+        features: {
+          emailParameter: false,
+          cancelCampaign: true,
+          siteTracking: false,
+          smartCampaigns: true,
+          shippingLimit: false,
+        },
+        advancedPayOptions: [
+          { id: 1, idPlan: 18, paymentType: 1, discountPercentage: 0, monthsToPay: 1 },
+        ],
+      },
+    ];
   }
 
   public async registerUser(model: UserRegistrationModel): Promise<UserRegistrationResult> {

--- a/src/services/doppler-plan-client.test.js
+++ b/src/services/doppler-plan-client.test.js
@@ -1,0 +1,99 @@
+import { HardcodedDopplerLegacyClient } from './doppler-legacy-client.doubles';
+import { DopplerPlanClient } from './doppler-plan-client';
+import { planType, userType } from './doppler-legacy-client';
+
+describe('Doppler plan client', () => {
+  it('should validate if call to get data only once', async () => {
+    // Arrange
+    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
+    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
+    const spyGetAllPlans = jest.spyOn(dopplerLegacyClient, 'getAllPlans');
+
+    // Act
+    await dopplerPlanClient.getPlanData();
+    await dopplerPlanClient.getPlanData();
+
+    // Assert
+    expect(spyGetAllPlans).toHaveBeenCalledTimes(1);
+  });
+
+  it('should get all standard plans monthly by subscribers', async () => {
+    // Arrange
+    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
+    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
+
+    // Act
+    const planByType = await dopplerPlanClient.getPlanListByType(
+      planType.STANDARD,
+      userType.SUBSCRIBERS_MONTHLY,
+    );
+
+    // Assert
+    expect(planByType.length).toBeGreaterThan(0);
+    expect(planByType[0].type).toBe(planType.STANDARD);
+    expect(planByType[0].userType).toBe(userType.SUBSCRIBERS_MONTHLY);
+  });
+
+  it('should get current plan and plus plan for a high volume plan', async () => {
+    // Arrange
+    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
+    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
+
+    // Act
+    const planCompare = await dopplerPlanClient.getFeaturedPlan(12);
+
+    // Assert
+    expect(planCompare.length).toBeGreaterThan(0);
+    expect(planCompare.find((plan) => plan.type === planType.PLUS));
+  });
+
+  it('should get current plan and plus plan for a monthly subscribers plan', async () => {
+    // Arrange
+    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
+    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
+
+    // Act
+    const planCompare = await dopplerPlanClient.getFeaturedPlan(18);
+
+    // Assert
+    expect(planCompare.length).toBeGreaterThan(0);
+    expect(planCompare.find((plan) => plan.type === planType.PLUS));
+  });
+
+  it('should get all standard plans of all types', async () => {
+    // Arrange
+    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
+    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
+
+    // Act
+    const planByType = await dopplerPlanClient.getPlanListByType(planType.STANDARD);
+
+    // Assert
+    expect(planByType.length).toBeGreaterThan(0);
+    expect(planByType[0].type).toBe(planType.STANDARD);
+  });
+
+  it('should return empty for unexistent plan', async () => {
+    // Arrange
+    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
+    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
+
+    // Act
+    const planCompare = await dopplerPlanClient.getFeaturedPlan(200000000);
+
+    // Assert
+    expect(planCompare.length).toBe(0);
+  });
+
+  it('should return one plan if there is no plus plan for selected plan', async () => {
+    // Arrange
+    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
+    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
+
+    // Act
+    const planCompare = await dopplerPlanClient.getFeaturedPlan(19);
+
+    // Assert
+    expect(planCompare.length).toBe(1);
+  });
+});

--- a/src/services/doppler-plan-client.ts
+++ b/src/services/doppler-plan-client.ts
@@ -1,0 +1,45 @@
+import { DopplerLegacyClient, PlanModel, planType } from './doppler-legacy-client';
+
+export class DopplerPlanClient {
+  private PlanList: PlanModel[] = [];
+  private readonly dopplerLegacyClient: DopplerLegacyClient;
+
+  constructor({ dopplerLegacyClient }: { dopplerLegacyClient: DopplerLegacyClient }) {
+    this.dopplerLegacyClient = dopplerLegacyClient;
+  }
+
+  async getPlanData(): Promise<PlanModel[]> {
+    return this.PlanList.length
+      ? this.PlanList
+      : (this.PlanList = await this.dopplerLegacyClient.getAllPlans());
+  }
+
+  async getFeaturedPlan(idPlan: number): Promise<PlanModel[]> {
+    const planList = await this.getPlanData();
+    const result = [];
+    const currentPlan = planList.find((plan) => plan.id === idPlan);
+    if (!currentPlan) {
+      return [];
+    }
+    const featuredPlan = planList.find(
+      (plan) =>
+        currentPlan.subscribersByMonth === plan.subscribersByMonth &&
+        currentPlan.emailsByMonth === plan.emailsByMonth &&
+        plan.type === planType.PLUS,
+    );
+
+    result.push(currentPlan);
+    if (!!featuredPlan) {
+      result.push(featuredPlan);
+    }
+    return result;
+  }
+
+  async getPlanListByType(planType: number, userType?: number): Promise<PlanModel[]> {
+    const planList = await this.getPlanData();
+    const result = planList.filter((plan) =>
+      !!userType ? plan.type === planType && plan.userType === userType : plan.type === planType,
+    );
+    return result;
+  }
+}

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -10,6 +10,7 @@ import { DopplerApiClient, HttpDopplerApiClient } from './doppler-api-client';
 import { DopplerSitesClient, HttpDopplerSitesClient } from './doppler-sites-client';
 import { IpinfoClient, HttpIpinfoClient } from './ipinfo-client';
 import { ExperimentalFeatures } from './experimental-features';
+import { DopplerPlanClient } from './doppler-plan-client';
 
 interface AppConfiguration {
   dopplerLegacyUrl: string;
@@ -42,6 +43,7 @@ export interface AppServices {
   experimentalFeatures: ExperimentalFeatures;
   dopplerApiClient: DopplerApiClient;
   ipinfoClient: IpinfoClient;
+  dopplerPlanClient: DopplerPlanClient;
 }
 
 /**
@@ -113,6 +115,13 @@ export class AppCompositionRoot implements AppServices {
           baseUrl: this.appConfiguration.dopplerLegacyUrl,
           window: this.window,
         }),
+    );
+  }
+
+  get dopplerPlanClient() {
+    return this.singleton(
+      'dopplerPlanClient',
+      () => new DopplerPlanClient({ dopplerLegacyClient: this.dopplerLegacyClient }),
     );
   }
 


### PR DESCRIPTION
### Add Doppler Plan Service
- Add call to get all raw data in doppler legacy client
- Add service to cache the request and admin petitions:
* get featured plan: get a standard plan data and it´s correspondant in plus and pro based on amount of emails or subscribers
* get plans filtered by type for slider: can get all standard high volume, or all plus high volume, or all plus, here we have two parameters plan type: (free | standard | plus | pro | enterprise), user type: usual user types we have in doppler. 

