### PR TITLE
DW-458 get plan data for slider

### DIFF
--- a/src/components/DopplerPlus/PlanCalculator.js
+++ b/src/components/DopplerPlus/PlanCalculator.js
@@ -8,7 +8,7 @@ import { extractParameter } from '../../utils';
 import { useRouteMatch } from 'react-router-dom';
 
 const PlanCalculator = ({ location, dependencies: { dopplerPlanClient } }) => {
-  const safePromoId = extractParameter(location, queryString.parse, 'promoId') || '';
+  const safePromoId = extractParameter(location, queryString.parse, 'promo-code') || '';
   const discountId = extractParameter(location, queryString.parse, 'discountId') || 0;
   const typePlanId = parseInt(extractParameter(location, queryString.parse, 'selected-plan')) || 0;
   const { params } = useRouteMatch();
@@ -150,11 +150,12 @@ const PlanCalculator = ({ location, dependencies: { dopplerPlanClient } }) => {
             <div style={{ marginTop: '40px' }}>
               <a
                 className="dp-button button-medium primary-green"
-                href={
-                  _('common.control_panel_section_url') +
-                  `/AccountPreferences/UpgradeAccountStep2?IdUserTypePlan=${planData.plan.id}&fromStep1=True&IdDiscountPlan=${planData.discount?.id}` +
-                  `${safePromoId ? `&PromoCode=${safePromoId}` : ''}`
-                }
+                href={dopplerPlanClient.generateBuyLink(
+                  _('common.control_panel_section_url'),
+                  planData.plan,
+                  planData.discount?.monthsToPay,
+                  safePromoId,
+                )}
               >
                 Contratar
               </a>

--- a/src/components/DopplerPlus/PlanCalculator.js
+++ b/src/components/DopplerPlus/PlanCalculator.js
@@ -9,7 +9,7 @@ import { useRouteMatch } from 'react-router-dom';
 
 const PlanCalculator = ({ location, dependencies: { dopplerPlanClient } }) => {
   const safePromoId = extractParameter(location, queryString.parse, 'promo-code') || '';
-  const billingCycle = Number(extractParameter(location, queryString.parse, 'billing-cycle')) || 1;
+  const billingCycle = dopplerPlanClient.mapBillingCyleToMonths(extractParameter(location, queryString.parse, 'billing-cycle'));
   const selectedPlanId = parseInt(extractParameter(location, queryString.parse, 'selected-plan')) || 0;
   const { params } = useRouteMatch();
   const { planType, userType } = params;

--- a/src/components/NewFeatures/NewFeatures.js
+++ b/src/components/NewFeatures/NewFeatures.js
@@ -24,7 +24,7 @@ const NewFeatures = () => {
             <h3>Slider selector de planes</h3>
             <Link
               to={
-                '/plan-selection/standard-subscribers?selected-plan=20&billing-cycle=12&promo-code=ALLPLANS'
+                '/plan-selection/standard-subscribers?selected-plan=20&billing-cycle=yearly&promo-code=ALLPLANS'
               }
             >
               Standard mensual por suscriptores
@@ -32,7 +32,7 @@ const NewFeatures = () => {
             <br />
             <Link
               to={
-                '/plan-selection/standard-high_volume?selected-plan=18&billing-cycle=3&promo-code=ALLPLANS'
+                '/plan-selection/standard-high_volume?selected-plan=18&billing-cycle=quarterly&promo-code=ALLPLANS'
               }
             >
               Standard mensual por envíos alto volumen
@@ -40,7 +40,7 @@ const NewFeatures = () => {
             <br />
             <Link
               to={
-                '/plan-selection/standard-prepaid?selected-plan=18&billing-cycle=6&promo-code=ALLPLANS'
+                '/plan-selection/standard-prepaid?selected-plan=18&billing-cycle=half-yearly&promo-code=ALLPLANS'
               }
             >
               Standard prepagos

--- a/src/components/NewFeatures/NewFeatures.js
+++ b/src/components/NewFeatures/NewFeatures.js
@@ -24,7 +24,7 @@ const NewFeatures = () => {
             <h3>Slider selector de planes</h3>
             <Link
               to={
-                '/plan-selection/standard-subscribers?selected-plan=18&advanced-pay=year&promo-code=ALLPLANS'
+                '/plan-selection/standard-subscribers?selected-plan=20&billing-cycle=12&promo-code=ALLPLANS'
               }
             >
               Standard mensual por suscriptores
@@ -32,15 +32,15 @@ const NewFeatures = () => {
             <br />
             <Link
               to={
-                '/plan-selection/standard-high_volume?selected-plan=18&advanced-pay=year&promo-code=ALLPLANS'
+                '/plan-selection/standard-high_volume?selected-plan=18&billing-cycle=3&promo-code=ALLPLANS'
               }
             >
-              Standard mensual por contactos
+              Standard mensual por envíos alto volumen
             </Link>{' '}
             <br />
             <Link
               to={
-                '/plan-selection/standard-prepaid?selected-plan=18&advanced-pay=year&promo-code=ALLPLANS'
+                '/plan-selection/standard-prepaid?selected-plan=18&billing-cycle=6&promo-code=ALLPLANS'
               }
             >
               Standard prepagos
@@ -71,7 +71,7 @@ const NewFeatures = () => {
             <h3>Compra de planes</h3>
             <Link
               to={
-                '/plan-selection?selected-type=email&advanced-pay=year&promo-code=ALLPLANS&planId=18'
+                '/plan-selection?selected-type=email&advance-pay=year&promo-code=ALLPLANS&planId=18'
               }
             >
               Ir a Comprar Plan

--- a/src/components/NewFeatures/NewFeatures.js
+++ b/src/components/NewFeatures/NewFeatures.js
@@ -19,6 +19,35 @@ const NewFeatures = () => {
         </div>
       </HeaderSection>
       <section className="dp-container">
+        <div className="dp-block-wlp dp-box-shadow m-t-36 m-b-36">
+          <div style={{ marginLeft: '20px' }}>
+            <h3>Slider selector de planes</h3>
+            <Link
+              to={
+                '/plan-selection/standard-subscribers?selected-plan=18&advanced-pay=year&promo-code=ALLPLANS'
+              }
+            >
+              Standard mensual por suscriptores
+            </Link>{' '}
+            <br />
+            <Link
+              to={
+                '/plan-selection/standard-high_volume?selected-plan=18&advanced-pay=year&promo-code=ALLPLANS'
+              }
+            >
+              Standard mensual por contactos
+            </Link>{' '}
+            <br />
+            <Link
+              to={
+                '/plan-selection/standard-prepaid?selected-plan=18&advanced-pay=year&promo-code=ALLPLANS'
+              }
+            >
+              Standard prepagos
+            </Link>{' '}
+            <br />
+          </div>
+        </div>
         <div className="dp-block-wlp dp-box-shadow">
           <div style={{ marginLeft: '20px' }}>
             <h3>Maestro de Suscriptores</h3>
@@ -46,18 +75,6 @@ const NewFeatures = () => {
               }
             >
               Ir a Comprar Plan
-            </Link>
-          </div>
-        </div>
-        <div className="dp-block-wlp dp-box-shadow m-t-36 m-b-36">
-          <div style={{ marginLeft: '20px' }}>
-            <h3>Plan Calculator</h3>
-            <Link
-              to={
-                '/plan-selection/standard-subscribers?selected-plan=18&advanced-pay=year&promo-code=ALLPLANS'
-              }
-            >
-              Ir a calculadora de planes
             </Link>
           </div>
         </div>

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -75,6 +75,13 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
             discountPercentage: 0,
             monthsToPay: 1,
           },
+          {
+            id: 6,
+            idPlan: 12,
+            paymentType: 1,
+            discountPercentage: 5,
+            monthsToPay: 3,
+          },
         ],
       },
       {
@@ -108,7 +115,8 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
         fee: 444,
         userType: userType.SUBSCRIBERS_MONTHLY,
         type: planType.STANDARD,
-        emailsByMonth: 5000,
+        emailsByMonth: undefined,
+        subscribersByMonth: 1500,
         emailPrice: 0.0009,
         features: {
           emailParameter: true,
@@ -125,6 +133,20 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
             discountPercentage: 0,
             monthsToPay: 1,
           },
+          {
+            id: 68,
+            idPlan: 12,
+            paymentType: 1,
+            discountPercentage: 5,
+            monthsToPay: 3,
+          },
+          {
+            id: 69,
+            idPlan: 12,
+            paymentType: 1,
+            discountPercentage: 10,
+            monthsToPay: 6,
+          },
         ],
       },
       {
@@ -134,7 +156,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
         userType: userType.SUBSCRIBERS_MONTHLY,
         type: planType.STANDARD,
         emailsByMonth: undefined,
-        subscribersByMonth: 1500,
+        subscribersByMonth: 2500,
         emailPrice: undefined,
         features: {
           emailParameter: false,
@@ -154,7 +176,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
         userType: userType.SUBSCRIBERS_MONTHLY,
         type: planType.PLUS,
         emailsByMonth: undefined,
-        subscribersByMonth: 1500,
+        subscribersByMonth: 2500,
         emailPrice: undefined,
         features: {
           emailParameter: false,

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -322,7 +322,9 @@ export function mapPlan(json: any): PlanModel {
       smartCampaigns: json.SmartCampaignsEnabled,
       shippingLimit: json.ShippingLimitEnabled,
     },
-    advancedPayOptions: json.DiscountXPlan.map(mapAdvancedPay),
+    advancedPayOptions: json.DiscountXPlan.filter(
+      (payment: any) => payment.IdPaymentMethod === 1,
+    ).map(mapAdvancedPay),
   };
 }
 
@@ -366,7 +368,7 @@ export interface PlanModel {
     smartCampaigns?: boolean;
     shippingLimit?: boolean;
   };
-  advancedPayOptions?: [AdvancedPayOptions];
+  advancedPayOptions?: AdvancedPayOptions[];
 }
 
 export enum planType {

--- a/src/services/doppler-plan-client.test.js
+++ b/src/services/doppler-plan-client.test.js
@@ -23,10 +23,7 @@ describe('Doppler plan client', () => {
     const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
 
     // Act
-    const planByType = await dopplerPlanClient.getPlanListByType(
-      planType.STANDARD,
-      userType.SUBSCRIBERS_MONTHLY,
-    );
+    const planByType = await dopplerPlanClient.getPlanListByType('standard', 'subscribers');
 
     // Assert
     expect(planByType.length).toBeGreaterThan(0);
@@ -58,19 +55,6 @@ describe('Doppler plan client', () => {
     // Assert
     expect(planCompare.length).toBeGreaterThan(0);
     expect(planCompare.find((plan) => plan.type === planType.PLUS));
-  });
-
-  it('should get all standard plans of all types', async () => {
-    // Arrange
-    const dopplerLegacyClient = new HardcodedDopplerLegacyClient();
-    const dopplerPlanClient = new DopplerPlanClient({ dopplerLegacyClient });
-
-    // Act
-    const planByType = await dopplerPlanClient.getPlanListByType(planType.STANDARD);
-
-    // Assert
-    expect(planByType.length).toBeGreaterThan(0);
-    expect(planByType[0].type).toBe(planType.STANDARD);
   });
 
   it('should return empty for unexistent plan', async () => {

--- a/src/services/doppler-plan-client.ts
+++ b/src/services/doppler-plan-client.ts
@@ -1,4 +1,4 @@
-import { DopplerLegacyClient, PlanModel, planType } from './doppler-legacy-client';
+import { DopplerLegacyClient, PlanModel, planType, userType } from './doppler-legacy-client';
 
 export class DopplerPlanClient {
   private PlanList: PlanModel[] = [];
@@ -35,10 +35,54 @@ export class DopplerPlanClient {
     return result;
   }
 
-  async getPlanListByType(planType: number, userType?: number): Promise<PlanModel[]> {
+  mapPlanType(planTypeText: string): planType {
+    switch (planTypeText) {
+      case 'FREE': {
+        return planType.FREE;
+      }
+      case 'STANDARD': {
+        return planType.STANDARD;
+      }
+      case 'PLUS': {
+        return planType.PLUS;
+      }
+      case 'ENTERPRISE': {
+        return planType.ENTERPRISE;
+      }
+      default: {
+        return planType.FREE;
+      }
+    }
+  }
+
+  mapUserType(planTypeText: string): userType {
+    switch (planTypeText) {
+      case 'FREE': {
+        return userType.FREE;
+      }
+      case 'HIGH_VOLUME': {
+        return userType.HIGH_VOLUME;
+      }
+      case 'PREPAID': {
+        return userType.PREPAID;
+      }
+      case 'SUBSCRIBERS': {
+        return userType.SUBSCRIBERS_MONTHLY;
+      }
+      default: {
+        return userType.FREE;
+      }
+    }
+  }
+
+  async getPlanListByType(planTypeText: string, userTypeText: string): Promise<PlanModel[]> {
+    const searchPlanType: planType = this.mapPlanType(planTypeText.toUpperCase());
+    const searchUserType: userType = this.mapUserType(userTypeText.toUpperCase());
     const planList = await this.getPlanData();
     const result = planList.filter((plan) =>
-      !!userType ? plan.type === planType && plan.userType === userType : plan.type === planType,
+      !!userType
+        ? plan.type === searchPlanType && plan.userType === searchUserType
+        : plan.type === searchPlanType,
     );
     return result;
   }

--- a/src/services/doppler-plan-client.ts
+++ b/src/services/doppler-plan-client.ts
@@ -41,7 +41,7 @@ export class DopplerPlanClient {
     return result;
   }
 
-  mapPlanType(planTypeText: string): planType {
+  private mapPlanType(planTypeText: string): planType {
     switch (planTypeText) {
       case 'FREE': {
         return planType.FREE;
@@ -61,7 +61,7 @@ export class DopplerPlanClient {
     }
   }
 
-  mapUserType(planTypeText: string): userType {
+  private mapUserType(planTypeText: string): userType {
     switch (planTypeText) {
       case 'FREE': {
         return userType.FREE;
@@ -110,5 +110,25 @@ export class DopplerPlanClient {
       plan.id
     }&fromStep1=True${discountId ? '&IdDiscountPlan=' + discountId : ''}
     ${promoCode ? '&PromoCode=' + promoCode : ''}`;
+  }
+
+  public mapBillingCyleToMonths(cycle:string):number {
+    switch (cycle) {
+      case 'monthly': {
+        return 1;
+      }
+      case 'quarterly': {
+        return 3;
+      }
+      case 'half-yearly': {
+        return 6;
+      }
+      case 'yearly': {
+        return 12;
+      }
+      default: {
+        return 1;
+      }
+    }
   }
 }

--- a/src/services/doppler-plan-client.ts
+++ b/src/services/doppler-plan-client.ts
@@ -1,4 +1,10 @@
-import { DopplerLegacyClient, PlanModel, planType, userType } from './doppler-legacy-client';
+import {
+  DopplerLegacyClient,
+  PlanModel,
+  planType,
+  userType,
+  AdvancedPayOptions,
+} from './doppler-legacy-client';
 
 export class DopplerPlanClient {
   private PlanList: PlanModel[] = [];
@@ -87,5 +93,22 @@ export class DopplerPlanClient {
         (plan.subscribersByMonth || plan.emailsByMonth),
     );
     return result;
+  }
+
+  public generateBuyLink(
+    baseUrl: string,
+    plan: PlanModel,
+    monthsToPayDiscount?: number,
+    promoCode?: string,
+  ): string {
+    const discountId = monthsToPayDiscount
+      ? plan.advancedPayOptions?.find(
+          (discount: AdvancedPayOptions) => discount.monthsToPay === monthsToPayDiscount,
+        )?.id
+      : null;
+    return `${baseUrl}/AccountPreferences/UpgradeAccountStep2?IdUserTypePlan=${
+      plan.id
+    }&fromStep1=True${discountId ? '&IdDiscountPlan=' + discountId : ''}
+    ${promoCode ? '&PromoCode=' + promoCode : ''}`;
   }
 }

--- a/src/services/doppler-plan-client.ts
+++ b/src/services/doppler-plan-client.ts
@@ -79,10 +79,12 @@ export class DopplerPlanClient {
     const searchPlanType: planType = this.mapPlanType(planTypeText.toUpperCase());
     const searchUserType: userType = this.mapUserType(userTypeText.toUpperCase());
     const planList = await this.getPlanData();
-    const result = planList.filter((plan) =>
-      !!userType
-        ? plan.type === searchPlanType && plan.userType === searchUserType
-        : plan.type === searchPlanType,
+    const result = planList.filter(
+      (plan) =>
+        plan.type === searchPlanType &&
+        plan.userType === searchUserType &&
+        plan.fee &&
+        (plan.subscribersByMonth || plan.emailsByMonth),
     );
     return result;
   }


### PR DESCRIPTION
### Set plan data in slider screen
- Add discounts only by cc type payment
- Added type mapping
- Modified `PlanCalculator` component to adjust to data

Live working demo in int https://cdn.fromdoppler.com/doppler-webapp/int-build2614/#/new-features for all three types of plans we have right now:
- standard - subscribers
- standard high volume
- standard prepaid. 

Pending:

- [x] Sanitize plans (we have some plans with fees subscribers and emails in null that are exclusive plans)
- [ ]  Mark a plan as selected
- [ ] Improve component