### PR TITLE
feat: get plan data from service

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import NewFeatures from './components/NewFeatures/NewFeatures';
 import Offline from './components/Offline/Offline';
 import PushNotifications from './components/PushNotifications/PushNotifications';
 import SubscribersLegacyUrlRedirect from './components/Reports/Subscribers/SubscribersLegacyUrlRedirect';
-import { ChangePlan } from './components/ChangePlan/ChangePlan';
+import ChangePlan from './components/ChangePlan/ChangePlan';
 import PlanCalculator from './components/DopplerPlus/PlanCalculator';
 
 /**

--- a/src/components/ChangePlan/Card.js
+++ b/src/components/ChangePlan/Card.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 
 export const Card = ({ children, className, highlighted, ...rest }) => {
   return (
@@ -15,9 +16,9 @@ export const Card = ({ children, className, highlighted, ...rest }) => {
 
 export const CardAction = ({ url, children, ...rest }) => {
   return (
-    <a href={url} className="dp-button button-medium primary-green" {...rest}>
+    <Link to={url} className="dp-button button-medium primary-green" {...rest}>
       {children}
-    </a>
+    </Link>
   );
 };
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -35,6 +35,29 @@ const urlMasterSubscriber = `${urlDopplerLegacy}/Lists/MasterSubscriber/`;
 export default {
   change_plan: {
     calculate_price: 'Calculate Price',
+    card: {
+      agencies: {
+        cta: 'Consult',
+        description: 'Amplifica tu programa de correo electrónico con el apoyo adicional de nuestro equipo.',
+        link: 'https://www.fromdoppler.com/en/email-marketing-for-agencies//#demo',
+        title: 'Agencies',
+      },
+      free: {
+        cta: 'Actual plan',
+        description: 'Prueba Doppler GRATIS sin contratos ni tarjetas de crédito. Hasta 500 Contactos.',
+        title: 'Free',
+      },
+      plus: {
+        cta: 'Calc price',
+        description: 'Funciones avanzadas para profesionales que necesitan más personalización.',
+        title: 'PLUS',
+      },
+      standard: {
+        cta: 'Calc price',
+        description: '¿Realizas envíos periódicamente o un Newsletter al mes. Hasta 100.000 Contactos.',
+        title: 'STANDARD',
+      },
+    },
     description: 'Do you send periodically or one newsletter per month?',
     per_month: 'per month',
     recommended: 'Recommended',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -35,6 +35,29 @@ const urlMasterSubscriber = `${urlDopplerLegacy}/Lists/MasterSubscriber/`;
 export default {
   change_plan: {
     calculate_price: 'Calcular Precio',
+    card: {
+      agencies: {
+        cta: 'Consultar',
+        description: 'Amplifica tu programa de correo electrónico con el apoyo adicional de nuestro equipo.',
+        link: 'https://www.fromdoppler.com/es/email-marketing-agencias/#demo',
+        title: 'Agencias',
+      },
+      free: {
+        cta: 'Plan actual',
+        description: 'Prueba Doppler GRATIS sin contratos ni tarjetas de crédito. Hasta 500 Contactos.',
+        title: 'Gratuito',
+      },
+      plus: {
+        cta: 'Calcular precio',
+        description: 'Funciones avanzadas para profesionales que necesitan más personalización.',
+        title: 'Plus',
+      },
+      standard: {
+        cta: 'Calcular precio',
+        description: '¿Realizas envíos periódicamente o un Newsletter al mes. Hasta 100.000 Contactos.',
+        title: 'Standard',
+      },
+    },
     description: '¿Realizas envíos periodicamente o un newsletter al mes?',
     per_month: 'por mes',
     recommended: 'Recomendado',

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -57,7 +57,33 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
         fee: 444,
         userType: userType.HIGH_VOLUME,
         type: planType.STANDARD,
-        emailsByMonth: 500000,
+        emailsQty: 500000,
+        subscribersByMonth: undefined,
+        emailPrice: 0.0009,
+        features: {
+          emailParameter: false,
+          cancelCampaign: false,
+          siteTracking: false,
+          smartCampaigns: false,
+          shippingLimit: false,
+        },
+        advancedPayOptions: [
+          {
+            id: 62,
+            idPlan: 12,
+            paymentType: 1,
+            discountPercentage: 0,
+            monthsToPay: 1,
+          },
+        ],
+      },
+      {
+        id: 13,
+        description: '500,000',
+        fee: 900,
+        userType: userType.PREPAID,
+        type: planType.STANDARD,
+        emailsQty: 500000,
         subscribersByMonth: undefined,
         emailPrice: 0.0009,
         features: {
@@ -80,10 +106,10 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
       {
         id: 14,
         description: '500,000',
-        fee: 444,
+        fee: 600,
         userType: userType.HIGH_VOLUME,
         type: planType.PLUS,
-        emailsByMonth: 500000,
+        emailsQty: 500000,
         emailPrice: 0.0009,
         features: {
           emailParameter: true,
@@ -108,7 +134,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
         fee: 444,
         userType: userType.SUBSCRIBERS_MONTHLY,
         type: planType.STANDARD,
-        emailsByMonth: 5000,
+        emailsQty: 5000,
         emailPrice: 0.0009,
         features: {
           emailParameter: true,
@@ -133,7 +159,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
         fee: 15,
         userType: userType.SUBSCRIBERS_MONTHLY,
         type: planType.STANDARD,
-        emailsByMonth: undefined,
+        emailsQty: undefined,
         subscribersByMonth: 1500,
         emailPrice: undefined,
         features: {
@@ -150,10 +176,10 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
       {
         id: 38,
         description: '501-1500',
-        fee: 15,
+        fee: 45,
         userType: userType.SUBSCRIBERS_MONTHLY,
         type: planType.PLUS,
-        emailsByMonth: undefined,
+        emailsQty: undefined,
         subscribersByMonth: 1500,
         emailPrice: undefined,
         features: {

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -312,7 +312,7 @@ export function mapPlan(json: any): PlanModel {
     fee: json.Fee,
     userType: json.IdUserType,
     type: json.PlanType,
-    emailsByMonth: json.EmailQty,
+    emailsQty: json.EmailQty,
     subscribersByMonth: json.SubscribersQty,
     emailPrice: json.ExtraEmailCost,
     features: {
@@ -353,7 +353,7 @@ export interface AdvancedPayOptions {
 export interface PlanModel {
   id: number;
   description: string;
-  emailsByMonth?: number;
+  emailsQty?: number;
   subscribersByMonth?: number;
   fee: number;
   emailPrice?: number;

--- a/src/services/doppler-plan-client.ts
+++ b/src/services/doppler-plan-client.ts
@@ -1,4 +1,4 @@
-import { DopplerLegacyClient, PlanModel, planType } from './doppler-legacy-client';
+import { DopplerLegacyClient, PlanModel, planType, userType } from './doppler-legacy-client';
 
 export class DopplerPlanClient {
   private PlanList: PlanModel[] = [];
@@ -24,7 +24,7 @@ export class DopplerPlanClient {
     const featuredPlan = planList.find(
       (plan) =>
         currentPlan.subscribersByMonth === plan.subscribersByMonth &&
-        currentPlan.emailsByMonth === plan.emailsByMonth &&
+        currentPlan.emailsQty === plan.emailsQty &&
         plan.type === planType.PLUS,
     );
 
@@ -40,6 +40,24 @@ export class DopplerPlanClient {
     const result = planList.filter((plan) =>
       !!userType ? plan.type === planType && plan.userType === userType : plan.type === planType,
     );
+    return result;
+  }
+
+  async getPlans(): Promise<{ type: number; fee: number }[]> {
+    const planList = await this.getPlanData();
+    const filteredPlans = planList.sort((plan1, plan2) => Number(plan1.fee) - Number(plan2.fee));
+
+    const result = [
+      {
+        type: planType.STANDARD,
+        fee: filteredPlans.filter((plan) => plan.type === planType.STANDARD && plan.fee)[0].fee,
+      },
+      {
+        type: planType.PLUS,
+        fee: filteredPlans.filter((plan) => plan.type === planType.PLUS && plan.fee)[0].fee,
+      },
+    ];
+    console.log('Los planes filtrados son', result);
     return result;
   }
 }


### PR DESCRIPTION
### Get data from service

- Get data from service
- Show cards based on first plan from subscribers_monthly plans
- Hardcoded free and agencies plans
- Generate a temporal url for standard and plus cards. (We have to review what this card should redirect)

Link: https://cdn.fromdoppler.com/doppler-webapp/demo-build2619/#/plan-selection

![image](https://user-images.githubusercontent.com/10213170/91335352-a8c08c80-e7a6-11ea-8afd-e7ae9a8e0ae8.png)
