### PR TITLE
fix: link to partials-campaigns when sending now

### DIFF
--- a/src/components/Reports/SubscriberSentCampaigns/SubscriberSentCampaigns.js
+++ b/src/components/Reports/SubscriberSentCampaigns/SubscriberSentCampaigns.js
@@ -6,7 +6,7 @@ import queryString from 'query-string';
 import { extractParameter } from '../../../utils';
 import { Pagination } from '../../shared/Pagination/Pagination';
 import SafeRedirect from '../../SafeRedirect';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation, useRouteMatch, Link } from 'react-router-dom';
 
 const campaignsPerPage = 10;
 
@@ -117,42 +117,49 @@ const SubscriberSentCampaigns = ({
             <tbody>
               {stateSentCampaigns.sentCampaigns.length ? (
                 <>
-                  {stateSentCampaigns.sentCampaigns.map((campaign, index) => (
-                    <tr key={index}>
-                      <td>
-                        {campaign.urlImgPreview ? (
-                          <div className="dp-tooltip-container">
-                            <a
-                              href={`${reportsUrl}/Dashboard.aspx?idCampaign=${campaign.campaignId}`}
-                            >
-                              {campaign.campaignName}
-                              <div className="dp-tooltip-block">
-                                <img
-                                  src={campaign.urlImgPreview}
-                                  alt={_('subscriber_history.alt_image')}
-                                />
-                              </div>
-                            </a>
-                          </div>
-                        ) : (
-                          <a
-                            href={`${reportsUrl}/Dashboard.aspx?idCampaign=${campaign.campaignId}`}
-                          >
-                            {campaign.campaignName}
-                          </a>
-                        )}
-                      </td>
-                      <td>{campaign.campaignSubject}</td>
-                      <td>
-                        <span className={getDeliveryStatusCssClassName(campaign.deliveryStatus)}>
-                          <FormattedMessage
-                            id={'subscriber_history.delivery_status.' + campaign.deliveryStatus}
-                          />
-                        </span>
-                      </td>
-                      <td>{campaign.clicksCount}</td>
-                    </tr>
-                  ))}
+                  {stateSentCampaigns.sentCampaigns.map((campaign, index) => {
+                    const CampaignReportLink = ({ children }) => {
+                      return campaign.isSendingNow ? (
+                        <Link to={`/reports/partials-campaigns?campaignId=${campaign.campaignId}`}>
+                          {children}
+                        </Link>
+                      ) : (
+                        <a href={`${reportsUrl}/Dashboard.aspx?idCampaign=${campaign.campaignId}`}>
+                          {children}
+                        </a>
+                      );
+                    };
+                    return (
+                      <tr key={index}>
+                        <td>
+                          {campaign.urlImgPreview ? (
+                            <div className="dp-tooltip-container">
+                              <CampaignReportLink>
+                                {campaign.campaignName}
+                                <div className="dp-tooltip-block">
+                                  <img
+                                    src={campaign.urlImgPreview}
+                                    alt={_('subscriber_history.alt_image')}
+                                  />
+                                </div>
+                              </CampaignReportLink>
+                            </div>
+                          ) : (
+                            <CampaignReportLink>{campaign.campaignName}</CampaignReportLink>
+                          )}
+                        </td>
+                        <td>{campaign.campaignSubject}</td>
+                        <td>
+                          <span className={getDeliveryStatusCssClassName(campaign.deliveryStatus)}>
+                            <FormattedMessage
+                              id={'subscriber_history.delivery_status.' + campaign.deliveryStatus}
+                            />
+                          </span>
+                        </td>
+                        <td>{campaign.clicksCount}</td>
+                      </tr>
+                    );
+                  })}
                 </>
               ) : (
                 <tr>

--- a/src/services/doppler-api-client.double.ts
+++ b/src/services/doppler-api-client.double.ts
@@ -136,6 +136,7 @@ const campaignDeliveryItems = [...Array(100)].map((_, index) => {
     campaignSubject: '¿Como sacarle provecho a la primavera?',
     deliveryStatus: getDeliveryStatus(Math.round(Math.random() * (5 - 1) + 1)),
     clicksCount: Math.round(Math.random() * (100 - 1) + 1),
+    isSendingNow: index % 2 === 0,
     urlImgPreview:
       'http://dopplerfilesint.fromdoppler.net/Users/50018/Campaigns/33850437/33850437.png',
   };

--- a/src/services/doppler-api-client.test.ts
+++ b/src/services/doppler-api-client.test.ts
@@ -247,6 +247,7 @@ describe('HttpDopplerApiClient', () => {
               campaignSubject: '¿Como sacarle provecho a la primavera?',
               deliveryStatus: 'opened',
               clicksCount: 2,
+              isSendingNow: false,
               _links: [],
             },
             {
@@ -255,6 +256,7 @@ describe('HttpDopplerApiClient', () => {
               campaignSubject: 'El calendario estacional 2019 ya está aquí',
               deliveryStatus: 'opened',
               clicksCount: 23,
+              isSendingNow: false,
               _links: [],
             },
           ],

--- a/src/services/doppler-api-client.ts
+++ b/src/services/doppler-api-client.ts
@@ -50,6 +50,7 @@ interface CampaignDelivery {
   campaignSubject: string;
   clicksCount: number;
   deliveryStatus: string;
+  isSendingNow: boolean;
   urlImgPreview: string;
 }
 
@@ -163,6 +164,7 @@ export class HttpDopplerApiClient implements DopplerApiClient {
       campaignSubject: x.campaignSubject,
       clicksCount: x.clicksCount,
       deliveryStatus: x.deliveryStatus,
+      isSendingNow: x.isSendingNow,
       urlImgPreview: this.searchLinkByRel(x._links, '/docs/rels/get-campaign-preview'),
     }));
   }


### PR DESCRIPTION
Fix issue in subscriber sent campaigns report when the campaign is sending right now and the campaing don't have reports yet.
To fix this, when a user clicks in a campaign that it is sending now, it will be linked to partial-campaigns url. 