### PR TITLE
fix: replace version for ui library js script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -77,7 +77,7 @@
     -->
     <script
       type="text/javascript"
-      src="https://cdn.fromdoppler.com/doppler-ui-library/v3.38.0/js/app.js"
+      src="https://cdn.fromdoppler.com/doppler-ui-library/%REACT_APP_DOPPLER_UI_LIBRARY_VERSION%/js/app.js"
     ></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
     <script


### PR DESCRIPTION
Added versioning for js file in ui library for webapp

Replaced old v3.38.0 for current version.

![image](https://user-images.githubusercontent.com/2439363/93887843-952d1680-fcbd-11ea-88ad-18aa7a0841f9.png)

