### PR TITLE
fix(security): prevent clickjacking header

### DIFF
--- a/conf/site-local.conf
+++ b/conf/site-local.conf
@@ -28,6 +28,7 @@ server {
                 index   index.html index.html;
                 expires off;
                 add_header Cache-Control "no-store";
+                add_header X-Frame-Options "DENY";
         }
 
         location / {
@@ -36,6 +37,7 @@ server {
                 try_files $uri $uri/ /index.html;
                 expires off;
                 add_header Cache-Control "no-store";
+                add_header X-Frame-Options "DENY";
         }
 
 

--- a/conf/site-swarm.conf
+++ b/conf/site-swarm.conf
@@ -22,6 +22,7 @@ server {
                 index   index.html index.html;
                 expires off;
                 add_header Cache-Control "no-store";
+                add_header X-Frame-Options "DENY";
         }
         location / {
                 root    /usr/share/nginx/html;
@@ -29,5 +30,6 @@ server {
                 try_files $uri $uri/ /index.html;
                 expires off;
                 add_header Cache-Control "no-store";
+                add_header X-Frame-Options "DENY";
         }
 }

--- a/request-testing.http
+++ b/request-testing.http
@@ -6,3 +6,5 @@ http://localhost:8080/login
 # It should cache aggressively al content in /static/
 http://localhost:8080/static/js/main.ed1f8fc4.chunk.js
 
+###
+https://app.fromdoppler.com/login


### PR DESCRIPTION
### Add X-frame-options header
To prevent that webapp could be rendered inside an iframe, added x-frame-options header in deny option. 

![image](https://user-images.githubusercontent.com/2439363/95993752-dd93ac00-0e05-11eb-99f4-98d0a68ee772.png)

![image](https://user-images.githubusercontent.com/2439363/95994221-67437980-0e06-11eb-9ccc-ec8a0e875d74.png)
