### PR TITLE
fix(ChangePlan): do not show "since" always when current plan

### DIFF
--- a/src/components/ChangePlan/ChangePlan.js
+++ b/src/components/ChangePlan/ChangePlan.js
@@ -171,7 +171,7 @@ const CardWithPrice = ({ path, showFeatures, currentPlanType, promoCode }) => {
         <p>{_(`change_plan.card_${path.type}_description`)}</p>
       </div>
 
-      <CardPrice doNotShowSince={path.current && path.deadEnd} currency="US$">
+      <CardPrice doNotShowSince={path.current} currency="US$">
         {path.minimumFee}
       </CardPrice>
       {path.current && !path.deadEnd ? (


### PR DESCRIPTION
If the card is showing current plan, it has not to show the legend "since".

![image](https://user-images.githubusercontent.com/10213170/96494845-47a0bc80-121d-11eb-9ab6-512dc9a88905.png)
