### PR TITLE
fix(PlanCalculator): select existed plan or first one

### DIFF
--- a/src/components/ChangePlan/PlanCalculator.js
+++ b/src/components/ChangePlan/PlanCalculator.js
@@ -189,7 +189,7 @@ const PlanCalculator = ({
         planList,
       );
       const planTypes = planService.getPlanTypes(currentPlan, pathType, planList);
-      const selectedPlanType = planType || planTypes[0];
+      const selectedPlanType = planTypes.includes(planType) ? planType : planTypes[0];
       const plansByType = planService.getPlans(
         currentPlan,
         pathType,


### PR DESCRIPTION
Fix issue when the user reach the top of subscribers plans. To avoid problems, the Plan Calculator screen will show the plan type passed by param or the first one in the list of available plan types if the one passed by param does not exist.  