### PR TITLE
feat(invoices): add two fixed decimals to the Amount, Paid and Balance columns

### DIFF
--- a/src/components/InvoicesList/InvoicesList.js
+++ b/src/components/InvoicesList/InvoicesList.js
@@ -17,6 +17,12 @@ const InvoicesList = ({ dependencies: { dopplerBillingApiClient } }) => {
   const { url } = useRouteMatch();
   const invoicesPerPage = 10;
 
+  const numberFormatOptions = {
+    style: 'decimal',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  };
+
   useEffect(() => {
     const fetchData = async () => {
       const currentPage = extractParameter(location, queryString.parse, 'page') || 1;
@@ -132,13 +138,13 @@ const InvoicesList = ({ dependencies: { dopplerBillingApiClient } }) => {
                           </td>
                           <td>{invoice.currency}</td>
                           <td>
-                            <FormattedNumber value={invoice.amount} />
+                            <FormattedNumber value={invoice.amount} {...numberFormatOptions} />
                           </td>
                           <td>
-                            <FormattedNumber value={invoice.paidToDate} />
+                            <FormattedNumber value={invoice.paidToDate} {...numberFormatOptions} />
                           </td>
                           <td>
-                            <FormattedNumber value={invoice.balance} />
+                            <FormattedNumber value={invoice.balance} {...numberFormatOptions} />
                           </td>
                           <td>
                             {!!invoice.downloadInvoiceUrl ? (


### PR DESCRIPTION
Added two fixed decimals to the number columns:

![image](https://user-images.githubusercontent.com/70591946/97482902-875e5700-1935-11eb-9dd0-b2b2b52065b5.png)

**Changes:**

- Added two fixed decimals for the column: **Amount**, **Paid** and **Balance**

**Task:** [DAT-169](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-169)