### PR TITLE
feat(invoices): refactor breadcrumb

### DIFF
--- a/src/components/InvoicesList/InvoicesList.js
+++ b/src/components/InvoicesList/InvoicesList.js
@@ -8,6 +8,7 @@ import { Pagination } from '../shared/Pagination/Pagination';
 import { useLocation, useRouteMatch } from 'react-router-dom';
 import queryString from 'query-string';
 import { extractParameter } from '../../utils';
+import { Breadcrumb, BreadcrumbItem } from '../shared/Breadcrumb/Breadcrumb';
 
 const InvoicesList = ({ dependencies: { dopplerBillingApiClient } }) => {
   const [stateInvoices, setStateInvoices] = useState({ loading: true });
@@ -56,21 +57,17 @@ const InvoicesList = ({ dependencies: { dopplerBillingApiClient } }) => {
       </Helmet>
       <HeaderSection>
         <div className="col-sm-12 col-md-12 col-lg-12">
-          <nav className="dp-breadcrumb">
-            <ul>
-              <li>
-                <a href={_('invoices_list.control_panel_account_preferences_url')}>
-                  {_('invoices_list.control_panel_section')}
-                </a>
-              </li>
-              <li>
-                <a href={_('invoices_list.control_panel_billing_information_url')}>
-                  {_('invoices_list.control_panel_billing_information_section')}
-                </a>
-              </li>
-              <li>{_('invoices_list.title')}</li>
-            </ul>
-          </nav>
+          <Breadcrumb>
+            <BreadcrumbItem
+              href={_('invoices_list.control_panel_account_preferences_url')}
+              text={_('invoices_list.control_panel_section')}
+            />
+            <BreadcrumbItem
+              href={_('invoices_list.control_panel_billing_information_url')}
+              text={_('invoices_list.control_panel_billing_information_section')}
+            />
+            <BreadcrumbItem text={_('invoices_list.title')} />
+          </Breadcrumb>
           <h2>
             <FormattedMessage id="invoices_list.title" />
           </h2>

--- a/src/components/shared/Breadcrumb/Breadcrumb.js
+++ b/src/components/shared/Breadcrumb/Breadcrumb.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const Breadcrumb = ({ children }) => {
+  return (
+    <nav className="dp-breadcrumb">
+      <ul>{children}</ul>
+    </nav>
+  );
+};
+
+const BreadcrumbItem = ({ href, text }) => {
+  return (
+    <>
+      {!!href ? (
+        <li>
+          <a href={href}>{text}</a>
+        </li>
+      ) : (
+        <li>{text}</li>
+      )}
+    </>
+  );
+};
+
+export { Breadcrumb, BreadcrumbItem };

--- a/src/components/shared/Breadcrumb/Breadcrumb.test.js
+++ b/src/components/shared/Breadcrumb/Breadcrumb.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { Breadcrumb, BreadcrumbItem } from './Breadcrumb';
+import { BrowserRouter } from 'react-router-dom';
+
+describe('Breadcrumb Component', () => {
+  afterEach(cleanup);
+
+  it('should show Breadcrumb', () => {
+    //Act
+    const { container } = render(
+      <BrowserRouter>
+        <Breadcrumb />
+      </BrowserRouter>,
+    );
+
+    // Asserts
+    expect(container.querySelector('.dp-breadcrumb')).toBeInTheDocument();
+  });
+
+  it('should show Breadcrumb without <li> item when the breadcrumb has no elements', () => {
+    //Act
+    const { container } = render(
+      <BrowserRouter>
+        <Breadcrumb></Breadcrumb>
+      </BrowserRouter>,
+    );
+
+    // Asserts
+    expect(container.querySelector('.dp-breadcrumb li')).not.toBeInTheDocument();
+  });
+
+  it('should show Breadcrumb with <a> item when new item contains href', () => {
+    //Act
+    const { container } = render(
+      <BrowserRouter>
+        <Breadcrumb>
+          <BreadcrumbItem href={'http://Test'} text={'Item Test'} />
+        </Breadcrumb>
+      </BrowserRouter>,
+    );
+
+    // Asserts
+    expect(container.querySelector('.dp-breadcrumb li a')).toBeInTheDocument();
+  });
+
+  it('should show Breadcrumb without <a> item when item not contains href', () => {
+    //Act
+    const { container } = render(
+      <BrowserRouter>
+        <Breadcrumb>
+          <BreadcrumbItem text={'Item Test'} />
+        </Breadcrumb>
+      </BrowserRouter>,
+    );
+
+    // Asserts
+    expect(container.querySelector('.dp-breadcrumb li a')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The breadcrumb was created as a component into the invoices list:

![image](https://user-images.githubusercontent.com/70591946/97610687-fb5f3480-19f3-11eb-94c1-31a19289ff6f.png)


**Task:** [DAT-176](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-176)