### PR TITLE
fix: prepare reCaptcha for tests

### DIFF
--- a/src/components/DopplerPlus/AgenciesForm.test.js
+++ b/src/components/DopplerPlus/AgenciesForm.test.js
@@ -24,6 +24,16 @@ describe('AgenciesForm component', () => {
         return { success: true };
       },
     },
+    captchaUtilsService: {
+      useCaptcha: () => {
+        const Captcha = () => null;
+        const verifyCaptcha = async () => {
+          return { success: true, captchaResponseToken: 'hardcodedResponseToken' };
+        };
+        const recaptchaRef = null;
+        return [Captcha, verifyCaptcha, recaptchaRef];
+      },
+    },
   };
 
   const AgenciesFormElement = () => (

--- a/src/components/Login/LoginErrorAccountNotValidated.js
+++ b/src/components/Login/LoginErrorAccountNotValidated.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useCaptcha } from '../form-helpers/captcha-utils';
 import { useIntl } from 'react-intl';
 import { InjectAppServices } from '../../services/pure-di';
 import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
@@ -10,9 +9,9 @@ export const LoginErrorAccountNotValidated = InjectAppServices(
    * @param { string } props.email
    * @param { import('../../services/pure-di').AppServices } props.dependencies
    */
-  ({ email, dependencies: { dopplerLegacyClient } }) => {
+  ({ email, dependencies: { dopplerLegacyClient, captchaUtilsService } }) => {
     const [resentTimes, setResentTimes] = useState(0);
-    const [Captcha, verifyCaptcha] = useCaptcha();
+    const [Captcha, verifyCaptcha] = captchaUtilsService.useCaptcha();
     const intl = useIntl();
 
     const incrementAndResend = async () => {

--- a/src/components/Signup/SignupConfirmation.js
+++ b/src/components/Signup/SignupConfirmation.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useCaptcha } from '../form-helpers/captcha-utils';
 import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 import { Redirect } from 'react-router-dom';
 import * as S from './SignupConfirmation.styles';
@@ -11,11 +10,11 @@ import * as S from './SignupConfirmation.styles';
  * @param { import('react-intl').InjectedIntl } props.intl
  * @param { Function } props.resend - Function to resend registration email.
  */
-const SignupConfirmation = function ({ location }) {
+const SignupConfirmation = function ({ location, dependencies: { captchaUtilsService } }) {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
   const [resentTimes, setResentTimes] = useState(0);
-  const [Captcha, verifyCaptcha] = useCaptcha();
+  const [Captcha, verifyCaptcha] = captchaUtilsService.useCaptcha();
 
   if (!location.status || !location.status.resend) {
     return <Redirect to="/signup" />;

--- a/src/components/form-helpers/captcha-utils.tsx
+++ b/src/components/form-helpers/captcha-utils.tsx
@@ -26,74 +26,76 @@ type CaptchaVerificationResult = Readonly<
     }
 >;
 
-/** Returns a ReCAPTCHA component and a related validation function (as a hook)*/
-export function useCaptcha() {
-  const captchaUtilsRef = useRef<CaptchaUtils>();
-  if (!captchaUtilsRef.current) {
-    captchaUtilsRef.current = createCaptchaUtils();
+export class CaptchaUtilsService {
+  /** Returns a ReCAPTCHA component and a related validation function (as a hook)*/
+  public useCaptcha() {
+    const captchaUtilsRef = useRef<CaptchaUtils>();
+    if (!captchaUtilsRef.current) {
+      captchaUtilsRef.current = this.createCaptchaUtils();
+    }
+    return captchaUtilsRef.current;
   }
-  return captchaUtilsRef.current;
-}
 
-/** Returns a ReCAPTCHA component and a related validation function */
-function createCaptchaUtils(): CaptchaUtils {
-  /** Reference to re-captcha object */
-  const recaptchaRef = createRef<ReCAPTCHA>();
+  /** Returns a ReCAPTCHA component and a related validation function */
+  private createCaptchaUtils(): CaptchaUtils {
+    /** Reference to re-captcha object */
+    const recaptchaRef = createRef<ReCAPTCHA>();
 
-  /** Reference to what to do after captcha verification, I need override this function in order to resolve verifyCapcha promise */
-  let onCaptchaChangeMutable:
-    | ((captchaResponseToken: string | null, reason: 'change' | 'error') => Promise<void>)
-    | null = null;
+    /** Reference to what to do after captcha verification, I need override this function in order to resolve verifyCapcha promise */
+    let onCaptchaChangeMutable:
+      | ((captchaResponseToken: string | null, reason: 'change' | 'error') => Promise<void>)
+      | null = null;
 
-  /** To call current overrode implementation of onCaptchaChange */
-  const onCaptchaChange = (captchaResponseToken: string | null) =>
-    onCaptchaChangeMutable && onCaptchaChangeMutable(captchaResponseToken, 'change');
+    /** To call current overrode implementation of onCaptchaChange */
+    const onCaptchaChange = (captchaResponseToken: string | null) =>
+      onCaptchaChangeMutable && onCaptchaChangeMutable(captchaResponseToken, 'change');
 
-  /** To call current overrode implementation of onCaptchaChange */
-  const onCaptchaErrored = () => onCaptchaChangeMutable && onCaptchaChangeMutable(null, 'error');
+    /** To call current overrode implementation of onCaptchaChange */
+    const onCaptchaErrored = () => onCaptchaChangeMutable && onCaptchaChangeMutable(null, 'error');
 
-  /** Generates a promise that is resolved when captcha is resolved (successfully or not) */
-  const verifyCaptcha = () => {
-    return new Promise<CaptchaVerificationResult>(async (resolve) => {
-      onCaptchaChangeMutable = async (captchaResponseToken, resultType) => {
+    /** Generates a promise that is resolved when captcha is resolved (successfully or not) */
+    const verifyCaptcha = () => {
+      return new Promise<CaptchaVerificationResult>(async (resolve) => {
+        onCaptchaChangeMutable = async (captchaResponseToken, resultType) => {
+          try {
+            await (recaptchaRef.current && recaptchaRef.current.reset());
+          } catch (error) {
+            console.log('Error resetting captcha', error);
+          }
+
+          if (resultType === 'error') {
+            resolve({ captchaError: { errorCallback: true } });
+          } else if (!captchaResponseToken) {
+            resolve({ captchaError: { noToken: true } });
+          } else {
+            resolve({ success: true, captchaResponseToken: captchaResponseToken });
+          }
+        };
+
         try {
-          await (recaptchaRef.current && recaptchaRef.current.reset());
+          await (recaptchaRef.current && recaptchaRef.current.execute());
+          /* nothing to do if it is successful, only wait for onChange. */
         } catch (error) {
-          console.log('Error resetting captcha', error);
+          console.log('error on captcha execute', error);
+          resolve({ captchaError: { errorExecuting: true } });
         }
+        // If challenge window is closed, we do not have feedback, so, by the moment,
+        // See more details in https://stackoverflow.com/questions/43488605/detect-when-challenge-window-is-closed-for-google-recaptcha
+      });
+    };
 
-        if (resultType === 'error') {
-          resolve({ captchaError: { errorCallback: true } });
-        } else if (!captchaResponseToken) {
-          resolve({ captchaError: { noToken: true } });
-        } else {
-          resolve({ success: true, captchaResponseToken: captchaResponseToken });
-        }
-      };
+    const Captcha = InjectAppServices(
+      ({ dependencies: { appConfiguration } }: { dependencies: AppServices }) => (
+        <ReCAPTCHA
+          ref={recaptchaRef}
+          sitekey={appConfiguration.recaptchaPublicKey}
+          size="invisible"
+          onChange={onCaptchaChange}
+          onErrored={onCaptchaErrored}
+        />
+      ),
+    );
 
-      try {
-        await (recaptchaRef.current && recaptchaRef.current.execute());
-        /* nothing to do if it is successful, only wait for onChange. */
-      } catch (error) {
-        console.log('error on captcha execute', error);
-        resolve({ captchaError: { errorExecuting: true } });
-      }
-      // If challenge window is closed, we do not have feedback, so, by the moment,
-      // See more details in https://stackoverflow.com/questions/43488605/detect-when-challenge-window-is-closed-for-google-recaptcha
-    });
-  };
-
-  const Captcha = InjectAppServices(
-    ({ dependencies: { appConfiguration } }: { dependencies: AppServices }) => (
-      <ReCAPTCHA
-        ref={recaptchaRef}
-        sitekey={appConfiguration.recaptchaPublicKey}
-        size="invisible"
-        onChange={onCaptchaChange}
-        onErrored={onCaptchaErrored}
-      />
-    ),
-  );
-
-  return [Captcha, verifyCaptcha, recaptchaRef];
+    return [Captcha, verifyCaptcha, recaptchaRef];
+  }
 }

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -13,6 +13,7 @@ import { ExperimentalFeatures } from './experimental-features';
 import { PlanService } from './plan-service';
 
 import { DopplerBillingApiClient, HttpDopplerBillingApiClient } from './doppler-billing-api-client';
+import { CaptchaUtilsService } from '../components/form-helpers/captcha-utils';
 
 interface AppConfiguration {
   dopplerBillingApiUrl: string;
@@ -48,6 +49,7 @@ export interface AppServices {
   ipinfoClient: IpinfoClient;
   planService: PlanService;
   dopplerBillingApiClient: DopplerBillingApiClient;
+  captchaUtilsService: CaptchaUtilsService;
 }
 
 /**
@@ -220,6 +222,10 @@ export class AppCompositionRoot implements AppServices {
           connectionDataRef: this.appSessionRef,
         }),
     );
+  }
+
+  get captchaUtilsService() {
+    return this.singleton('captchaUtilsService', () => new CaptchaUtilsService());
   }
 }
 


### PR DESCRIPTION
Modify captcha utils to be used as a service that must be injected. This allows to harcode the service in tests. 

```
..............
..............
describe('AgenciesForm component', () => {
  afterEach(cleanup);

  const dependencies = {
    captchaUtilsService: {
      useCaptcha: () => {
        const Captcha = () => null;
        const verifyCaptcha = async () => {
          return { success: true, captchaResponseToken: 'hardcodedResponseToken' };
        };
        const recaptchaRef = null;
        return [Captcha, verifyCaptcha, recaptchaRef];
      },
    },
  };
..............
..............
```