### PR TITLE
feat(login): add client manager disabled user message

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -203,6 +203,17 @@ const Login = ({ location, dependencies: { dopplerLegacyClient, sessionManager, 
         setErrors({
           _error: <LoginErrorBasedOnCustomerSupport messages={errorMessages.cancelatedAccount} />,
         });
+      } else if (result.expectedError && result.expectedError.blockedAccountCMDisabled) {
+        setErrors({
+          _error: (
+            <p>
+              <FormattedMessage
+                id={'validation_messages.error_account_is_blocked_disabled_by_cm'}
+              />
+              <strong>{result.expectedError.errorMessage}</strong>
+            </p>
+          ),
+        });
       } else if (
         result.expectedError &&
         (result.expectedError.blockedAccountInvalidPassword ||

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -502,6 +502,7 @@ deletion, security, cross-border data transfers and other issues.
   },
   validation_messages: {
     error_account_contact_zoho_chat: `<button>Chat with the Customer Support team</button> for help.`,
+    error_account_is_blocked_disabled_by_cm: `The Client Manager administrator blocked this account. Get in touch for more information: `,
     error_account_is_blocked_invalid_password: `Ouch! This account has been blocked due to failed access attempts.`,
     error_account_is_blocked_invalid_password_contact_support_MD: `Please [contact the Customer Support team](${mailtoAdmin + subjectBlockedAccountInvalidPassword}) for help.`,
     error_account_is_blocked_invalid_password_zoho_chat_msg: `¡Hola! ¿Me ayudas con mi cuenta bloqueada por intentos fallidos?`,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -503,6 +503,7 @@ eliminación, seguridad, transferencias transfronterizas y otros temas.
   },
   validation_messages: {
     error_account_contact_zoho_chat: `<button>Chatea con el equipo de Atención al Cliente</button> para solucionarlo.`,
+    error_account_is_blocked_disabled_by_cm: `Esta cuenta fue bloqueada por el administrador del Client Manager. Contáctate para más información: `,
     error_account_is_blocked_invalid_password: `¡Ouch! Esta cuenta ha sido bloqueada debido a intentos de acceso fallidos.`,
     error_account_is_blocked_invalid_password_contact_support_MD: `Por favor [contacta al equipo de Atención al Cliente](${mailtoAdmin + subjectBlockedAccountInvalidPassword}) para solucionarlo.`,
     error_account_is_blocked_invalid_password_zoho_chat_msg: `¡Hola! ¿Me ayudas con mi cuenta bloqueada por intentos fallidos?`,

--- a/src/services/doppler-legacy-client.doubles.ts
+++ b/src/services/doppler-legacy-client.doubles.ts
@@ -31,6 +31,7 @@ export class HardcodedDopplerLegacyClient implements DopplerLegacyClient {
     // return { expectedError: { invalidLogin: true } };
     // return { expectedError: { blockedAccountInvalidPassword: true } };
     // return { expectedError: { maxLoginAttempts: true } };
+    // return { expectedError: { blockedAccountCMDisabled: true, errorMessage: clientmanager - clientmanager@email.com } };
     // return { success: false, error: 'Error code' };
     // return {
     //   success: false,

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -67,6 +67,8 @@ export type LoginErrorResult =
       invalidLogin?: false;
       maxLoginAttempts?: false;
       wrongCaptcha?: false;
+      blockedAccountCMDisabled?: false;
+      errorMessage?: string;
     }
   | {
       accountNotValidated: true;
@@ -76,6 +78,8 @@ export type LoginErrorResult =
       invalidLogin?: false;
       maxLoginAttempts?: false;
       wrongCaptcha?: false;
+      blockedAccountCMDisabled?: false;
+      errorMessage?: string;
     }
   | {
       cancelatedAccount: true;
@@ -85,6 +89,8 @@ export type LoginErrorResult =
       invalidLogin?: false;
       maxLoginAttempts?: false;
       wrongCaptcha?: false;
+      blockedAccountCMDisabled?: false;
+      errorMessage?: string;
     }
   | {
       blockedAccountInvalidPassword: true;
@@ -94,6 +100,8 @@ export type LoginErrorResult =
       invalidLogin?: false;
       maxLoginAttempts?: false;
       wrongCaptcha?: false;
+      blockedAccountCMDisabled?: false;
+      errorMessage?: string;
     }
   | {
       invalidLogin: true;
@@ -103,6 +111,8 @@ export type LoginErrorResult =
       cancelatedAccount?: false;
       maxLoginAttempts?: false;
       wrongCaptcha?: false;
+      blockedAccountCMDisabled?: false;
+      errorMessage?: string;
     }
   | {
       blockedAccountInvalidPassword: true;
@@ -112,6 +122,8 @@ export type LoginErrorResult =
       invalidLogin?: false;
       maxLoginAttempts: true;
       wrongCaptcha?: false;
+      blockedAccountCMDisabled?: false;
+      errorMessage?: string;
     }
   | {
       blockedAccountInvalidPassword: true;
@@ -121,6 +133,19 @@ export type LoginErrorResult =
       invalidLogin?: false;
       maxLoginAttempts: true;
       wrongCaptcha?: true;
+      blockedAccountCMDisabled?: false;
+      errorMessage?: string;
+    }
+  | {
+      blockedAccountInvalidPassword?: false;
+      blockedAccountNotPayed?: false;
+      accountNotValidated?: false;
+      cancelatedAccount?: false;
+      invalidLogin?: false;
+      maxLoginAttempts?: false;
+      wrongCaptcha?: false;
+      blockedAccountCMDisabled: true;
+      errorMessage: string;
     };
 
 export type LoginResult = Result<{ redirectUrl?: string }, LoginErrorResult>;
@@ -128,6 +153,10 @@ export type LoginResult = Result<{ redirectUrl?: string }, LoginErrorResult>;
 export interface LoginModel extends PayloadWithCaptchaToken {
   username: string;
   password: string;
+}
+
+function removeErrorCodeFromExceptionMessage(errorCode: string, message: string) {
+  return message.search(errorCode) !== -1 ? message.substring(errorCode.length) : message;
 }
 
 /* #endregion */
@@ -551,6 +580,17 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
           }
           case 'MaxLoginAttempts': {
             return { expectedError: { maxLoginAttempts: true } };
+          }
+          case 'BlockedAccountCMDisabled': {
+            return {
+              expectedError: {
+                blockedAccountCMDisabled: true,
+                errorMessage: removeErrorCodeFromExceptionMessage(
+                  'BlockedAccountCMDisabled - ',
+                  response.data.message,
+                ),
+              },
+            };
           }
           case 'WrongCatpcha': {
             return {


### PR DESCRIPTION
### Client manager disabled user message in login
The client manager can have its users disabled, then if the user access into login, we were displaying a blocked account by invalid password. Now it shows the correct message and contact information for that client manager that disabled the user.

Tasks:
- Captured new error code for cm disabled user
- Captured exception message new field
- Separated exception code from message with client manager data

![image](https://user-images.githubusercontent.com/2439363/100382915-2b055a80-2ffb-11eb-9c35-6262f6d2ecfb.png)


Issue in jira: DW-515