### PR TITLE
fix(retry): DW-616 space a bit more between retries

### DIFF
--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -536,7 +536,7 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
         if (retryCount === configRetryCount) {
           logAxiosRetryError(error, addLogEntry);
         }
-        return retryCount * 200;
+        return retryCount * 700;
       },
     });
   }


### PR DESCRIPTION
### Increate time between retries for login and signup
After post to login or signup we have a retry policy, but all attempts were made within the same second, spacing seems to be a good idea.

Before we had 200 ms fixed in retry, so for each retry:
1st retry: wait 200ms
2nd retry: wait 400ms
3rd retry: wait 600ms 

With this change:
1st: 700ms
2nd: 1.4s
3rd: 2.1s

@andresmoschini how do you feel this?