### PR TITLE
fix(offline-page): add timeout 30 sec to resolve no server response…

### DIFF
--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -566,7 +566,7 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
   }
 
   public async getUserData() {
-    const response = await this.axios.get('/WebApp/GetUserData');
+    const response = await this.axios.get('/WebApp/GetUserData', { timeout: 30000 });
     if (!response || !response.data) {
       throw new Error('Empty Doppler response');
     }

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -2,6 +2,7 @@ import { DopplerLegacyClient } from './doppler-legacy-client';
 import { AppSession } from './app-session';
 import { MutableRefObject } from 'react';
 import { ManualStatusClient } from './manual-status-client';
+import { addLogEntry } from '../utils';
 
 const noop = () => {};
 
@@ -80,6 +81,15 @@ export class OnlineSessionManager implements SessionManager {
         } as AppSession, // Cast required because TS cannot resolve datahubCustomerId complexity
       );
     } catch (error) {
+      if (error.code === 'ECONNABORTED') {
+        addLogEntry({
+          account: 'none',
+          origin: window.location.origin,
+          section: 'Login/GetUserData',
+          browser: window.navigator.userAgent,
+          message: 'Connection timed out',
+        });
+      }
       if (this.appStatusOverrideEnabled) {
         const manualStatusData = await this.manualStatusClient.getStatusData();
         if (manualStatusData.offline) {


### PR DESCRIPTION
### Offline page: Add timeout 1 minute to resolve no server response in deploy
Analizing the logs from production during deploy: 
When we try to establish if the user is connected or not in `session-manager`, and mvc is offline, the server does not respond to `getUserData` request. I suspect that the code freezes in await, that's why we do not see the offline page. 

![image](https://user-images.githubusercontent.com/2439363/106500285-62cbcb00-64a0-11eb-80f3-1331387d7440.png)

### Fix
To test this I've added a timeout of 30 seconds to `getUserData` call only, with a log entry for this case, to monitorize (just in case).

Production log shows this:
![image](https://user-images.githubusercontent.com/2439363/106500455-9d356800-64a0-11eb-9855-c0b80bc72e29.png)

![image](https://user-images.githubusercontent.com/2439363/106500006-141e3100-64a0-11eb-9df3-b20a806985ca.png)
