### PR TITLE
DW-713: confirmation email sent error

### DIFF
--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -140,7 +140,10 @@ const Signup = function ({ location, dependencies: { dopplerLegacyClient, origin
     } else if (result.expectedError && result.expectedError.registerDenied) {
       setErrors({ _error: 'validation_messages.error_register_denied' });
       setSubmitting(false);
-    } else if (result.expectedError && result.expectedError.invalidDomain) {
+    } else if (
+      result.expectedError &&
+      (result.expectedError.invalidDomain || result.expectedError.confirmationSendFail)
+    ) {
       setErrors({ _error: 'validation_messages.error_invalid_domain' });
       setSubmitting(false);
     } else {

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -19,7 +19,7 @@ import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 import Promotions from '../shared/Promotions/Promotions';
 import queryString from 'query-string';
 import { Redirect } from 'react-router-dom';
-import { extractParameter, isWhitelisted } from './../../utils';
+import { extractParameter, isWhitelisted, addLogEntry } from './../../utils';
 import * as S from './Signup.styles';
 
 const fieldNames = {
@@ -140,12 +140,19 @@ const Signup = function ({ location, dependencies: { dopplerLegacyClient, origin
     } else if (result.expectedError && result.expectedError.registerDenied) {
       setErrors({ _error: 'validation_messages.error_register_denied' });
       setSubmitting(false);
-    } else if (
-      result.expectedError &&
-      (result.expectedError.invalidDomain || result.expectedError.confirmationSendFail)
-    ) {
+    } else if (result.expectedError && result.expectedError.invalidDomain) {
       setErrors({ _error: 'validation_messages.error_invalid_domain' });
       setSubmitting(false);
+    } else if (result.expectedError && result.expectedError.confirmationSendFail) {
+      setErrors({ _error: 'validation_messages.error_invalid_domain' });
+      setSubmitting(false);
+      addLogEntry({
+        account: values[fieldNames.email],
+        origin: window.location.origin,
+        section: 'Signup',
+        browser: window.navigator.userAgent,
+        message: 'Confirmation email send failed',
+      });
     } else {
       console.log('Unexpected error', result);
       setErrors({

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -183,24 +183,35 @@ type UserRegistrationErrorResult =
       blockedDomain?: false;
       registerDenied?: false;
       invalidDomain?: false;
+      confirmationSendFail?: false;
     }
   | {
       emailAlreadyExists?: false;
       blockedDomain: true;
       registerDenied?: false;
       invalidDomain?: false;
+      confirmationSendFail?: false;
     }
   | {
       emailAlreadyExists?: false;
       blockedDomain?: false;
       registerDenied: true;
       invalidDomain?: false;
+      confirmationSendFail?: false;
     }
   | {
       emailAlreadyExists?: false;
       blockedDomain?: false;
       registerDenied?: false;
       invalidDomain: true;
+      confirmationSendFail?: false;
+    }
+  | {
+      emailAlreadyExists?: false;
+      blockedDomain?: false;
+      registerDenied?: false;
+      invalidDomain?: false;
+      confirmationSendFail?: true;
     };
 
 export type UserRegistrationResult = EmptyResult<UserRegistrationErrorResult>;
@@ -692,6 +703,9 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
           }
           case 'RegisterDenied': {
             return { expectedError: { registerDenied: true } };
+          }
+          case 'General_DomainEmailIsInvalidToCreateAccount': {
+            return { expectedError: { confirmationSendFail: true } };
           }
           case 'InvalidDomain': {
             return { expectedError: { invalidDomain: true } };


### PR DESCRIPTION
### Add message for confirmation email sent error
In signup when confirmation email fails, the server returns anoter fail code that was not listed in webapp.
![image](https://user-images.githubusercontent.com/2439363/106767296-764e7180-6619-11eb-9d2b-a3d229ba679c.png)

https://github.com/MakingSense/Doppler/blob/9a9dba9dd2e5558599c6116f2acc7b6432974fbe/Doppler.Presentation.MVC/Controllers/WebAppPublicController.cs#L259

We show for now, invalid domain message for this case, and log an entry with email just in case.
```
{
   "account":"cbernat+testsending2@makingsense.com",
   "origin":"http://localhost:3000",
   "section":"Signup",
   "browser":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.104 Safari/537.36",
   "message":"Confirmation email send failed"
}
```

