### PR TITLE
Loggly log cleaning

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -235,6 +235,7 @@ const Login = ({ location, dependencies: { dopplerLegacyClient, sessionManager, 
           origin: window.location.origin,
           section: 'Login',
           browser: window.navigator.userAgent,
+          message: 'WrongCaptcha',
           error: result,
         });
         console.log('invalid captcha', result);

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -82,16 +82,19 @@ export class OnlineSessionManager implements SessionManager {
       );
     } catch (error) {
       if (error.code === 'ECONNABORTED') {
-        addLogEntry({
-          account:
-            this.appSessionRef.current?.status === 'authenticated'
-              ? this.appSessionRef.current.userData.user.email
-              : 'none',
-          origin: window.location.origin,
-          section: 'Login/GetUserData',
-          browser: window.navigator.userAgent,
-          message: 'Connection timed out',
-        });
+        const account =
+          this.appSessionRef.current?.status === 'authenticated'
+            ? this.appSessionRef.current.userData.user.email
+            : 'none';
+        if (account !== 'none') {
+          addLogEntry({
+            account: account,
+            origin: window.location.origin,
+            section: 'Login/GetUserData',
+            browser: window.navigator.userAgent,
+            message: 'Connection timed out',
+          });
+        }
       }
       if (this.appStatusOverrideEnabled) {
         const manualStatusData = await this.manualStatusClient.getStatusData();

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -417,7 +417,7 @@ describe('utils', () => {
       // Assert
       expect(logEntry.origin).not.toBe(undefined);
       expect(logEntry.account).not.toBe(undefined);
-      expect(logEntry.errorMessage).not.toBe(undefined);
+      expect(logEntry.message).not.toBe(undefined);
     });
 
     it('should log error correctly for login', () => {
@@ -445,7 +445,7 @@ describe('utils', () => {
 
       // Assert
       expect(logEntry.account).not.toBe(undefined);
-      expect(logEntry.errorMessage).not.toBe(undefined);
+      expect(logEntry.message).not.toBe(undefined);
     });
 
     it('should not break if parameters are missing', () => {
@@ -472,7 +472,7 @@ describe('utils', () => {
 
       // Assert
       expect(logEntry.account).toBe(undefined);
-      expect(logEntry.errorMessage).not.toBe(undefined);
+      expect(logEntry.message).not.toBe(undefined);
     });
 
     it('should not break if error is empty', () => {
@@ -494,7 +494,7 @@ describe('utils', () => {
 
       // Assert
       expect(logEntry.account).toBe(undefined);
-      expect(logEntry.errorMessage).not.toBe(undefined);
+      expect(logEntry.message).not.toBe(undefined);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,7 +105,7 @@ export function logAxiosRetryError(error: any, logger: any, window: any) {
       signupOrigin: data?.Origin,
       postUrl: error?.config?.url,
       browser: window.navigator.userAgent,
-      errorMessage: error?.message,
+      message: error?.message,
     });
   } catch {
     logger({
@@ -113,7 +113,7 @@ export function logAxiosRetryError(error: any, logger: any, window: any) {
       section: 'Axios Retry Catch',
       postUrl: error?.config?.url,
       browser: window.navigator.userAgent,
-      errorMessage: error?.message,
+      message: error?.message,
       data: error?.config?.data,
     });
   }


### PR DESCRIPTION
### Loggly log cleaning

- Stop login timeout error for accounts not registered (this can happen in login and does not affect anyone)
- Set all error message description as message, to avoid having all sorts of confusing fields in log
