### PR TITLE
fix(security): disable nginx emmiting version

### DIFF
--- a/conf/site-swarm.conf
+++ b/conf/site-swarm.conf
@@ -1,6 +1,7 @@
 server {
         listen                  80 default_server;
         server_name             localhost;
+        server_tokens           off;
 
         gzip                    on;
         gzip_disable            "msie6";


### PR DESCRIPTION
Disables emitting nginx version on error pages and in the “Server” response header field.

Actually:
![image](https://user-images.githubusercontent.com/8170372/108262423-acc0dc00-7143-11eb-9018-ebc9fa2b705a.png)

http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens

