### PR TITLE
chore: update GDPR history related API

### DIFF
--- a/src/services/doppler-api-client.double.ts
+++ b/src/services/doppler-api-client.double.ts
@@ -442,14 +442,14 @@ export class HardcodedDopplerApiClient implements DopplerApiClient {
     };
   }
 
-  public async getSubscriberFieldHistory({
+  public async getSubscriberPermissionHistory({
     email,
     fieldName,
   }: {
     email: string;
     fieldName: string;
   }): Promise<ResultWithoutExpectedErrors<FieldHistoryPage>> {
-    console.log('getSubscriberFieldHistory', email, fieldName);
+    console.log('getSubscriberPermissionHistory', email, fieldName);
     await timeout(1500);
     return {
       success: true,

--- a/src/services/doppler-api-client.test.ts
+++ b/src/services/doppler-api-client.test.ts
@@ -534,14 +534,14 @@ describe('HttpDopplerApiClient', () => {
     });
   });
 
-  describe('getSubscriberFieldHistory', () => {
+  describe('getSubscriberPermissionHistory', () => {
     it('should get an error when the response is not valid', async () => {
       // Arrange
       const request = jest.fn(async () => {}); // Invalid response
       const dopplerApiClient = createHttpDopplerApiClient({ request });
 
       // Act
-      const result = await dopplerApiClient.getSubscriberFieldHistory({
+      const result = await dopplerApiClient.getSubscriberPermissionHistory({
         subscriberEmail: 'a@a.com',
         fieldName: 'MiPermiso',
       });
@@ -597,7 +597,7 @@ describe('HttpDopplerApiClient', () => {
       const dopplerApiClient = createHttpDopplerApiClient({ request });
 
       // Act
-      const result = await dopplerApiClient.getSubscriberFieldHistory({
+      const result = await dopplerApiClient.getSubscriberPermissionHistory({
         subscriberEmail,
         fieldName,
       });
@@ -609,7 +609,7 @@ describe('HttpDopplerApiClient', () => {
           Authorization: `token ${jwtToken}`,
         },
         method: 'GET',
-        url: `/accounts/${accountEmail}/subscribers/${subscriberEmail}/fields/${fieldName}/history`,
+        url: `/accounts/${accountEmail}/subscribers/${subscriberEmail}/permissions-history/${fieldName}`,
       });
       expect(result).not.toBe(undefined);
       expect(result.success).toBe(true);

--- a/src/services/doppler-api-client.ts
+++ b/src/services/doppler-api-client.ts
@@ -498,7 +498,7 @@ export class HttpDopplerApiClient implements DopplerApiClient {
   // TODO: consider special characters in fieldName
   // TODO: test it with the real backend
   // TODO: add pagination (maybe it is not necessary for this stage, with the ten first items we are fine)
-  public async getSubscriberFieldHistory({
+  public async getSubscriberPermissionHistory({
     subscriberEmail,
     fieldName,
   }: {
@@ -510,7 +510,7 @@ export class HttpDopplerApiClient implements DopplerApiClient {
 
       const { data } = await this.axios.request({
         method: 'GET',
-        url: `/accounts/${userAccount}/subscribers/${subscriberEmail}/fields/${fieldName}/history`,
+        url: `/accounts/${userAccount}/subscribers/${subscriberEmail}/permissions-history/${fieldName}`,
         headers: { Authorization: `token ${jwtToken}` },
       });
 

--- a/src/services/doppler-api-client.ts
+++ b/src/services/doppler-api-client.ts
@@ -44,7 +44,7 @@ export interface Subscriber {
   score: number;
 }
 
-export interface FieldHistoryItem {
+export interface FieldUpdateEvent {
   subscriberEmail: string;
   fieldName: string;
   fieldType: string;
@@ -58,7 +58,7 @@ export interface FieldHistoryItem {
 }
 
 export interface FieldHistoryPage {
-  items: FieldHistoryItem[];
+  items: FieldUpdateEvent[];
   currentPage: number;
   itemsCount: number;
   pagesCount: number;
@@ -172,7 +172,7 @@ export class HttpDopplerApiClient implements DopplerApiClient {
     }));
   }
 
-  private mapFieldHistoryItem(item: any): FieldHistoryItem {
+  private mapFieldUpdateEvent(item: any): FieldUpdateEvent {
     return {
       subscriberEmail: item.subscriberEmail,
       fieldName: item.fieldName,
@@ -518,7 +518,7 @@ export class HttpDopplerApiClient implements DopplerApiClient {
       return {
         success: true,
         value: {
-          items: data.items.map(this.mapFieldHistoryItem),
+          items: data.items.map(this.mapFieldUpdateEvent),
           itemsCount: data.itemsCount,
           currentPage: data.currentPage,
           pagesCount: data.pagesCount,


### PR DESCRIPTION
As [we discussed with the team](https://makingsense.slack.com/archives/CGJ72QFQX/p1614107973070900), think that these URLs will match better our future scenarios:
* `GET /accounts/${userAccount}/subscribers/${subscriberEmail}/permissions-history` (for the complete history of all subscriber's permission fields, maybe with an option for CSV)
* `GET /accounts/${userAccount}/subscribers/${subscriberEmail}/permissions-history/${fieldName}` (for the history of a single permission field)