### PR TITLE
feat(Signup): add utms

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -57,6 +57,8 @@ const dopplerSitesClientDouble = {
   getBannerData: jest.fn(async () => rejectedPromise),
 };
 
+const parse = JSON.parse;
+
 const createJsonParse = (item) => {
   JSON.parse = jest.fn().mockImplementationOnce(() => {
     if (item) {
@@ -700,16 +702,13 @@ describe('App component', () => {
 
       // Assert
       const localStorageItems = dependencies.localStorage.getAllItems();
+      const utmCookiesObject = parse(localStorageItems['UtmCookies']);
       await waitFor(() => {
         expect(localStorageItems['UtmCookies']).toBeDefined();
-        expect(localStorageItems['UtmCookies']).toMatch('UTMSource');
-        expect(localStorageItems['UtmCookies']).toMatch('test');
-        expect(localStorageItems['UtmCookies']).toMatch('UTMCampaign');
-        expect(localStorageItems['UtmCookies']).toMatch('testcampaign');
-        expect(localStorageItems['UtmCookies']).toMatch('UTMMedium');
-        expect(localStorageItems['UtmCookies']).toMatch('testmedium');
-        expect(localStorageItems['UtmCookies']).toMatch('UTMTerm');
-        expect(localStorageItems['UtmCookies']).toMatch('testterm');
+        expect(utmCookiesObject[0].UTMTerm).toEqual('testterm');
+        expect(utmCookiesObject[0].UTMCampaign).toEqual('testcampaign');
+        expect(utmCookiesObject[0].UTMMedium).toEqual('testmedium');
+        expect(utmCookiesObject[0].UTMSource).toEqual('test');
       });
     });
 
@@ -747,20 +746,18 @@ describe('App component', () => {
 
       // Assert
       const localStorageItems = dependencies.localStorage.getAllItems();
+      const utmCookiesObject = parse(localStorageItems['UtmCookies']);
       await waitFor(() => {
         expect(localStorageItems['UtmCookies']).toBeDefined();
-        expect(localStorageItems['UtmCookies']).toMatch('UTMSource');
-        expect(localStorageItems['UtmCookies']).toMatch('test');
-        expect(localStorageItems['UtmCookies']).toMatch('UTMCampaign');
-        expect(localStorageItems['UtmCookies']).toMatch('testcampaign');
-        expect(localStorageItems['UtmCookies']).toMatch('UTMMedium');
-        expect(localStorageItems['UtmCookies']).toMatch('testmedium');
-        expect(localStorageItems['UtmCookies']).toMatch('UTMTerm');
-        expect(localStorageItems['UtmCookies']).toMatch('testterm');
-        expect(localStorageItems['UtmCookies']).toMatch('utmsource1');
-        expect(localStorageItems['UtmCookies']).toMatch('utmcampaign1');
-        expect(localStorageItems['UtmCookies']).toMatch('utmmedium1');
-        expect(localStorageItems['UtmCookies']).toMatch('utmterm1');
+        expect(utmCookiesObject[0].UTMTerm).toEqual('utmterm1');
+        expect(utmCookiesObject[0].UTMCampaign).toEqual('utmcampaign1');
+        expect(utmCookiesObject[0].UTMMedium).toEqual('utmmedium1');
+        expect(utmCookiesObject[0].UTMSource).toEqual('utmsource1');
+        expect(utmCookiesObject[1].UTMTerm).toEqual('testterm');
+        expect(utmCookiesObject[1].UTMCampaign).toEqual('testcampaign');
+        expect(utmCookiesObject[1].UTMMedium).toEqual('testmedium');
+        expect(utmCookiesObject[1].UTMSource).toEqual('test');
+        expect(utmCookiesObject.length).toBeGreaterThan(1);
       });
     });
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -668,6 +668,46 @@ describe('App component', () => {
       });
     });
 
+    it('check utm parameters', async () => {
+      // Arrange
+      const dependencies = {
+        sessionManager: createDoubleSessionManager(),
+        localStorage: createLocalStorageDouble(),
+        dopplerSitesClient: dopplerSitesClientDouble,
+      };
+
+      createJsonParse();
+
+      // Act
+      act(() => {
+        render(
+          <AppServicesProvider forcedServices={dependencies}>
+            <Router
+              initialEntries={[
+                '/signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm',
+              ]}
+            >
+              <App locale="en" />
+            </Router>
+          </AppServicesProvider>,
+        );
+      });
+
+      // Assert
+      const localStorageItems = dependencies.localStorage.getAllItems();
+      await waitFor(() => {
+        expect(localStorageItems['UtmCookies']).toBeDefined();
+        expect(localStorageItems['UtmCookies']).toMatch('utm_source');
+        expect(localStorageItems['UtmCookies']).toMatch('test');
+        expect(localStorageItems['UtmCookies']).toMatch('utm_campaign');
+        expect(localStorageItems['UtmCookies']).toMatch('testcampaign');
+        expect(localStorageItems['UtmCookies']).toMatch('utm_medium');
+        expect(localStorageItems['UtmCookies']).toMatch('testmedium');
+        expect(localStorageItems['UtmCookies']).toMatch('utm_term');
+        expect(localStorageItems['UtmCookies']).toMatch('testterm');
+      });
+    });
+
     // TODO: fix this tests console warning
     it('should not be replaced in local storage if it already exists', async () => {
       // Arrange

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -57,6 +57,12 @@ const dopplerSitesClientDouble = {
   getBannerData: jest.fn(async () => rejectedPromise),
 };
 
+const createJsonParse = () => {
+  JSON.parse = jest.fn().mockImplementationOnce(() => {
+    return [];
+  });
+};
+
 const defaultDependencies = {
   sessionManager: createDoubleSessionManager(),
   dopplerSitesClient: dopplerSitesClientDouble,
@@ -636,6 +642,8 @@ describe('App component', () => {
         dopplerSitesClient: dopplerSitesClientDouble,
       };
 
+      createJsonParse();
+
       // Act
       act(() => {
         render(
@@ -653,6 +661,7 @@ describe('App component', () => {
         expect(localStorageItems['dopplerFirstOrigin.value']).toBeDefined();
         expect(localStorageItems['dopplerFirstOrigin.value']).toEqual('testOrigin');
         expect(localStorageItems['dopplerFirstOrigin.date']).toBeDefined();
+        expect(localStorageItems['UtmCookies']).toBeDefined();
         const dopplerOriginDate = new Date(localStorageItems['dopplerFirstOrigin.date']);
         expect(dopplerOriginDate).toBeDefined();
         expect(dopplerOriginDate.getFullYear()).toBeGreaterThan(2018);

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -66,11 +66,11 @@ const manageUtmCookies = (localStorage, utmSource, utmCampaign, utmMedium, utmTe
   }
 
   const newItem = {
-    date: new Date().toUTCString(),
-    utm_source: utmSource,
-    utm_campaign: utmCampaign,
-    utm_medium: utmMedium,
-    utm_term: utmTerm,
+    date: new Date().toISOString(),
+    UTMSource: utmSource,
+    UTMCampaign: utmCampaign,
+    UTMMedium: utmMedium,
+    UTMTerm: utmTerm,
   };
   utmCookies.push(newItem);
 

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -46,6 +46,39 @@ function extractRedirect(location) {
   return extractParameter(location, queryString.parse, 'redirect');
 }
 
+function getParameter(location, parameter) {
+  return extractParameter(location, queryString.parse, parameter);
+}
+
+function getSource(location) {
+  let utmSource = getParameter(location, 'utm_source');
+  if (!utmSource) {
+    utmSource = document.referrer || 'direct';
+  }
+  return utmSource;
+}
+
+const manageUtmCookies = (localStorage, utmSource, utmCampaign, utmMedium, utmTerm) => {
+  let utmCookies = JSON.parse(localStorage.getItem('UtmCookies'));
+
+  if (!utmCookies) {
+    utmCookies = [];
+  }
+
+  const newItem = {
+    date: new Date().toUTCString(),
+    utm_source: utmSource,
+    utm_campaign: utmCampaign,
+    utm_medium: utmMedium,
+    utm_term: utmTerm,
+  };
+  utmCookies.push(newItem);
+
+  localStorage.setItem('UtmCookies', JSON.stringify(utmCookies));
+
+  return utmCookies;
+};
+
 /** Prepare empty values for all fields
  * It is required because in another way, the fields are not marked as touched.
  */
@@ -61,13 +94,23 @@ const getFormInitialValues = () =>
  * @param { import('react-intl').InjectedIntl } props.intl
  * @param { import('../../services/pure-di').AppServices } props.dependencies
  */
-const Signup = function ({ location, dependencies: { dopplerLegacyClient, originResolver } }) {
+const Signup = function ({
+  location,
+  dependencies: { dopplerLegacyClient, originResolver, localStorage },
+}) {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
   const [registeredUser, setRegisteredUser] = useState(null);
   const [alreadyExistentAddresses, setAlreadyExistentAddresses] = useState([]);
   const [blockedDomains, setBlockedDomains] = useState([]);
+
+  const utmSource = getSource(location);
+  const utmCampaign = getParameter(location, 'utm_campaign');
+  const utmMedium = getParameter(location, 'utm_medium');
+  const utmTerm = getParameter(location, 'utm_term');
+
+  const utmCookies = manageUtmCookies(localStorage, utmSource, utmCampaign, utmMedium, utmTerm);
 
   const addExistentEmailAddress = (email) => {
     setAlreadyExistentAddresses((x) => [...x, email]);
@@ -125,6 +168,11 @@ const Signup = function ({ location, dependencies: { dopplerLegacyClient, origin
       firstOrigin: originResolver.getFirstOrigin(),
       origin: originResolver.getCurrentOrigin(),
       redirect: !!redirectUrl && isWhitelisted(redirectUrl) ? redirectUrl : '',
+      utm_source: utmSource,
+      utm_campaign: utmCampaign,
+      utm_medium: utmMedium,
+      utm_term: utmTerm,
+      utm_cookies: utmCookies,
     });
     if (result.success) {
       setRegisteredUser(values[fieldNames.email]);

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -218,6 +218,14 @@ type UserRegistrationErrorResult =
 
 export type UserRegistrationResult = EmptyResult<UserRegistrationErrorResult>;
 
+interface UTMCookie {
+  date: string;
+  utm_source: string;
+  utm_campaign: string;
+  utm_medium: string;
+  utm_term: string;
+}
+
 export interface UserRegistrationModel extends PayloadWithCaptchaToken {
   firstname: string;
   lastname: string;
@@ -230,6 +238,11 @@ export interface UserRegistrationModel extends PayloadWithCaptchaToken {
   origin: string;
   language: string;
   redirect?: string;
+  utm_source: string;
+  utm_term: string;
+  utm_medium: string;
+  utm_campaign: string;
+  utm_cookies: UTMCookie[];
 }
 
 export interface ResendRegistrationModel extends PayloadWithCaptchaToken {
@@ -693,6 +706,11 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
         Language: model.language || 'es',
         RecaptchaUserCode: model.captchaResponseToken,
         Redirect: model.redirect,
+        UTMSource: model.utm_source,
+        UTMMedium: model.utm_medium,
+        UTMCampaign: model.utm_campaign,
+        UTMTerm: model.utm_term,
+        UTMCookies: model.utm_cookies,
       });
 
       if (!response.data.success) {


### PR DESCRIPTION
- get utms from url and save in local storage the history in UtmCokies.
- add utm_source, utm_campaign, utm_medium and utm_term in the model when the user create the account.

![image](https://user-images.githubusercontent.com/8861133/115390446-a0ddae80-a1b4-11eb-8f1a-d65fa22cd583.png)
