### PR TITLE
fix: exclude the 'consent' field in the permission list

### DIFF
--- a/src/components/Reports/GDPRPermissions/SubscriberGdprPermissions.js
+++ b/src/components/Reports/GDPRPermissions/SubscriberGdprPermissions.js
@@ -24,10 +24,10 @@ const SubscriberGdprPermissions = ({
 
       if (allFields.success) {
         const allPermissionFields = allFields.value.filter(
-          (customField) => customField.type === 'permission' || customField.type === 'consent',
+          (customField) => customField.type === 'permission',
         );
         const subscriberPermissionFields = subscriber.fields.filter(
-          (customField) => customField.type === 'permission' || customField.type === 'consent',
+          (customField) => customField.type === 'permission',
         );
 
         const fields = allPermissionFields.map((field) => {


### PR DESCRIPTION

![image-20210421-122751](https://user-images.githubusercontent.com/46003860/117010989-5fbcc280-acbb-11eb-84ba-1a50e585b8c3.png)

The 'consent' field is a legacy field, which behaves differently than permission-type fields, and even has no permission history.