### PR TITLE
DW-889: fix(utmCookies): add only one entrance for each navigation

### DIFF
--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -58,27 +58,6 @@ function getSource(location) {
   return utmSource;
 }
 
-const manageUtmCookies = (localStorage, utmSource, utmCampaign, utmMedium, utmTerm) => {
-  let utmCookies = JSON.parse(localStorage.getItem('UtmCookies'));
-
-  if (!utmCookies) {
-    utmCookies = [];
-  }
-
-  const newItem = {
-    date: new Date().toISOString(),
-    UTMSource: utmSource,
-    UTMCampaign: utmCampaign,
-    UTMMedium: utmMedium,
-    UTMTerm: utmTerm,
-  };
-  utmCookies.push(newItem);
-
-  localStorage.setItem('UtmCookies', JSON.stringify(utmCookies));
-
-  return utmCookies;
-};
-
 /** Prepare empty values for all fields
  * It is required because in another way, the fields are not marked as touched.
  */
@@ -96,7 +75,7 @@ const getFormInitialValues = () =>
  */
 const Signup = function ({
   location,
-  dependencies: { dopplerLegacyClient, originResolver, localStorage },
+  dependencies: { dopplerLegacyClient, originResolver, localStorage, utmCookiesManager },
 }) {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
@@ -110,7 +89,8 @@ const Signup = function ({
   const utmMedium = getParameter(location, 'utm_medium');
   const utmTerm = getParameter(location, 'utm_term');
 
-  const utmCookies = manageUtmCookies(localStorage, utmSource, utmCampaign, utmMedium, utmTerm);
+  utmCookiesManager.setCookieEntry(localStorage, utmSource, utmCampaign, utmMedium, utmTerm);
+  const utmCookies = utmCookiesManager.getUtmCookie(localStorage);
 
   const addExistentEmailAddress = (email) => {
     setAlreadyExistentAddresses((x) => [...x, email]);
@@ -172,7 +152,7 @@ const Signup = function ({
       utm_campaign: utmCampaign,
       utm_medium: utmMedium,
       utm_term: utmTerm,
-      utm_cookies: utmCookies.slice(-10),
+      utm_cookies: utmCookies,
     });
     if (result.success) {
       setRegisteredUser(values[fieldNames.email]);

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -15,6 +15,7 @@ import { HttpManualStatusClient, ManualStatusClient } from './manual-status-clie
 
 import { DopplerBillingApiClient, HttpDopplerBillingApiClient } from './doppler-billing-api-client';
 import { CaptchaUtilsService } from '../components/form-helpers/captcha-utils';
+import { UtmCookiesManager } from './utm-cookies-manager';
 
 interface AppConfiguration {
   dopplerBillingApiUrl: string;
@@ -52,6 +53,7 @@ export interface AppServices {
   dopplerBillingApiClient: DopplerBillingApiClient;
   captchaUtilsService: CaptchaUtilsService;
   manualStatusClient: ManualStatusClient;
+  utmCookiesManager: UtmCookiesManager;
 }
 
 /**
@@ -243,6 +245,10 @@ export class AppCompositionRoot implements AppServices {
           appStatusOverrideFileUrl: this.appConfiguration.appStatusOverrideFileUrl,
         }),
     );
+  }
+
+  get utmCookiesManager() {
+    return this.singleton('utmCookiesManager', () => new UtmCookiesManager());
   }
 }
 

--- a/src/services/utm-cookies-manager.js
+++ b/src/services/utm-cookies-manager.js
@@ -1,0 +1,28 @@
+export class UtmCookiesManager {
+  constructor() {
+    this.hasRegistered = false;
+  }
+
+  setCookieEntry(storage, utmSource, utmCampaign, utmMedium, utmTerm) {
+    if (!this.hasRegistered) {
+      let utmCookies = JSON.parse(localStorage.getItem('UtmCookies')) ?? [];
+
+      const newItem = {
+        date: new Date().toISOString(),
+        UTMSource: utmSource,
+        UTMCampaign: utmCampaign,
+        UTMMedium: utmMedium,
+        UTMTerm: utmTerm,
+      };
+      utmCookies.push(newItem);
+
+      storage.setItem('UtmCookies', JSON.stringify(utmCookies.slice(-10)));
+
+      this.hasRegistered = true;
+    }
+  }
+
+  getUtmCookie(storage) {
+    return JSON.parse(storage.getItem('UtmCookies'));
+  }
+}

--- a/src/services/utm-cookies-manager.test.js
+++ b/src/services/utm-cookies-manager.test.js
@@ -1,0 +1,28 @@
+import { UtmCookiesManager } from './utm-cookies-manager';
+import { FakeLocalStorage } from './test-utils/local-storage-double';
+
+describe('Utm cookies manager', () => {
+  it('should initialize add only an entry per instance', () => {
+    // Arrange
+    const utmCookiesManager = new UtmCookiesManager();
+    const storage = new FakeLocalStorage();
+    // Act
+    utmCookiesManager.setCookieEntry(storage, 'source', 'campaign', 'medium', 'term');
+    utmCookiesManager.setCookieEntry(storage, 'source', 'campaign', 'medium', 'term');
+    // Assert
+    expect(utmCookiesManager.getUtmCookie(storage).length).toBe(1);
+  });
+
+  it('should add utms into utmCookie', () => {
+    // Arrange
+    const utmCookiesManager = new UtmCookiesManager();
+    const storage = new FakeLocalStorage();
+    // Act
+    utmCookiesManager.setCookieEntry(storage, 'source', 'campaign', 'medium', 'term');
+    // Assert
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMSource).toBe('source');
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMCampaign).toBe('campaign');
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMMedium).toBe('medium');
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMTerm).toBe('term');
+  });
+});


### PR DESCRIPTION
### Fix utmCookies record

Each time the signup component was rendered, a new entrances was added to this field utmCookies. To fix this I've added that this addition be done only dependent on the first render.

Besides it should only be registered one navigation each time the user access from outside in Signup. 
Example:
**Scenario 1**
- The user navigates to  `/signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm`
_One entrance is registered in UtmCookie and the registered flag is set to true_
- The user then navigates to `/login`
- Then he returns to `/signup` 
_No new entrance is registered_

**Scenario 2**
- The user navigates to  `/signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm`
_One entrance is registered in UtmCookie and the registered flag is set to true_
- The user closes the tab
- The user opens a new tab and types directy the url `/signup`
_Another entrance is registered in UtmCookie with the source direct and the registered flag is set to true_
