### PR TITLE
fix: display an error message when a response error is received

### DIFF
--- a/src/components/Reports/GDPRPermissions/PermissionExpandableRow.js
+++ b/src/components/Reports/GDPRPermissions/PermissionExpandableRow.js
@@ -21,6 +21,7 @@ const PermissionValue = ({ value }) => {
 const PermissionExpandableRow = ({ field, email, dependencies: { dopplerApiClient } }) => {
   const [expanded, setExpanded] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [permissions, setPermissions] = useState([]);
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id }, values);
@@ -33,9 +34,11 @@ const PermissionExpandableRow = ({ field, email, dependencies: { dopplerApiClien
       fieldName,
     });
     if (success) {
+      setError(false);
       setPermissions(value.items);
     } else {
-      setPermissions([]);
+      setError(true);
+      setPermissions(undefined);
     }
     setLoading(false);
   };
@@ -85,7 +88,7 @@ const PermissionExpandableRow = ({ field, email, dependencies: { dopplerApiClien
             </td>
             <td />
           </>
-        ) : !permissions ? (
+        ) : error ? (
           <td className="dp-unexpected-error-table" colSpan={3}>
             <span>
               <span className="dp-icon-warning" />

--- a/src/components/Reports/GDPRPermissions/PermissionExpandableRow.test.js
+++ b/src/components/Reports/GDPRPermissions/PermissionExpandableRow.test.js
@@ -49,16 +49,23 @@ describe('PermissionExpandableRow component', () => {
   };
 
   const dopplerApiClientDouble = {
-    getUserFields: async () => {
-      return { success: true, value: subscriber.fields };
-    },
     getSubscriberPermissionHistory: async () => {
       return { success: true, value: { items: [] } };
     },
   };
 
+  const dopplerApiClientDoubleWithErrorInResponse = {
+    getSubscriberPermissionHistory: async () => {
+      return { success: false, error: new Error('Dummy error') };
+    },
+  };
+
   const dependencies = {
     dopplerApiClient: dopplerApiClientDouble,
+  };
+
+  const dependenciesWithErrorInResponse = {
+    dopplerApiClient: dopplerApiClientDoubleWithErrorInResponse,
   };
 
   afterEach(cleanup);
@@ -156,5 +163,29 @@ describe('PermissionExpandableRow component', () => {
 
     // Assert
     expect(container.querySelector('.dp-expanded-table').classList.contains('show')).toBe(true);
+  });
+
+  it('error message should be displayed when response error is received', async () => {
+    // Arrange
+    // Act
+    const { container } = render(
+      <AppServicesProvider forcedServices={dependenciesWithErrorInResponse}>
+        <IntlProvider>
+          <table>
+            <tbody>
+              <PermissionExpandableRow field={field} />
+            </tbody>
+          </table>
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    const arrowButton = container.querySelector('.dp-expand-results');
+    arrowButton.click();
+
+    // Assert
+    await waitFor(() => {
+      expect(container.querySelector('.dp-unexpected-error-table')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
If there was an error in the request, it was shown as if there was no history.

Before:
<img width="1254" alt="Screen Shot 2021-05-18 at 11 12 20" src="https://user-images.githubusercontent.com/46003860/118688663-4136eb00-b7d4-11eb-97d7-e260e7fc5214.png">

Now:
<img width="1250" alt="Screen Shot 2021-05-18 at 11 13 38" src="https://user-images.githubusercontent.com/46003860/118688719-4dbb4380-b7d4-11eb-89ea-e3204f80c6da.png">
