### PR TITLE
DW-926 add gclid parameter

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -691,7 +691,7 @@ describe('App component', () => {
           <AppServicesProvider forcedServices={dependencies}>
             <Router
               initialEntries={[
-                '/signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm',
+                '/signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm&gclid=testgclid',
               ]}
             >
               <App locale="en" />
@@ -708,6 +708,7 @@ describe('App component', () => {
         expect(utmCookiesObject[0].UTMTerm).toEqual('testterm');
         expect(utmCookiesObject[0].UTMCampaign).toEqual('testcampaign');
         expect(utmCookiesObject[0].UTMMedium).toEqual('testmedium');
+        expect(utmCookiesObject[0].gclid).toEqual('testgclid');
         expect(utmCookiesObject[0].UTMSource).toEqual('test');
       });
     });
@@ -726,6 +727,7 @@ describe('App component', () => {
         UTMCampaign: 'utmcampaign1',
         UTMMedium: 'utmmedium1',
         UTMTerm: 'utmterm1',
+        gclid: 'gclid1',
       };
       dependencies.localStorage.setItem('UtmCookies', JSON.stringify(utmCookie));
       createJsonParse(utmCookie);
@@ -735,7 +737,7 @@ describe('App component', () => {
           <AppServicesProvider forcedServices={dependencies}>
             <Router
               initialEntries={[
-                '/signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm',
+                '/signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm&gclid=testgclid',
               ]}
             >
               <App locale="en" />
@@ -753,10 +755,12 @@ describe('App component', () => {
         expect(utmCookiesObject[0].UTMCampaign).toEqual('utmcampaign1');
         expect(utmCookiesObject[0].UTMMedium).toEqual('utmmedium1');
         expect(utmCookiesObject[0].UTMSource).toEqual('utmsource1');
+        expect(utmCookiesObject[0].gclid).toEqual('gclid1');
         expect(utmCookiesObject[1].UTMTerm).toEqual('testterm');
         expect(utmCookiesObject[1].UTMCampaign).toEqual('testcampaign');
         expect(utmCookiesObject[1].UTMMedium).toEqual('testmedium');
         expect(utmCookiesObject[1].UTMSource).toEqual('test');
+        expect(utmCookiesObject[1].gclid).toEqual('testgclid');
         expect(utmCookiesObject.length).toBeGreaterThan(1);
       });
     });

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -88,8 +88,16 @@ const Signup = function ({
   const utmCampaign = getParameter(location, 'utm_campaign');
   const utmMedium = getParameter(location, 'utm_medium');
   const utmTerm = getParameter(location, 'utm_term');
+  const gclid = getParameter(location, 'gclid');
 
-  utmCookiesManager.setCookieEntry(localStorage, utmSource, utmCampaign, utmMedium, utmTerm);
+  utmCookiesManager.setCookieEntry({
+    storage: localStorage,
+    UTMSource: utmSource,
+    UTMCampaign: utmCampaign,
+    UTMMedium: utmMedium,
+    UTMTerm: utmTerm,
+    gclid,
+  });
   const utmCookies = utmCookiesManager.getUtmCookie(localStorage);
 
   const addExistentEmailAddress = (email) => {
@@ -142,6 +150,7 @@ const Signup = function ({
 
   const onSubmit = async (values, { setSubmitting, setErrors, validateForm }) => {
     var redirectUrl = extractRedirect(location);
+
     const result = await dopplerLegacyClient.registerUser({
       ...values,
       language: intl.locale,
@@ -153,6 +162,7 @@ const Signup = function ({
       utm_medium: utmMedium,
       utm_term: utmTerm,
       utm_cookies: utmCookies,
+      gclid,
     });
     if (result.success) {
       setRegisteredUser(values[fieldNames.email]);

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -243,6 +243,7 @@ export interface UserRegistrationModel extends PayloadWithCaptchaToken {
   utm_medium: string;
   utm_campaign: string;
   utm_cookies: UTMCookie[];
+  gclid: string;
 }
 
 export interface ResendRegistrationModel extends PayloadWithCaptchaToken {
@@ -711,6 +712,7 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
         UTMCampaign: model.utm_campaign,
         UTMTerm: model.utm_term,
         UTMCookies: model.utm_cookies,
+        gclid: model.gclid,
       });
 
       if (!response.data.success) {

--- a/src/services/utm-cookies-manager.js
+++ b/src/services/utm-cookies-manager.js
@@ -3,16 +3,13 @@ export class UtmCookiesManager {
     this.hasRegistered = false;
   }
 
-  setCookieEntry(storage, utmSource, utmCampaign, utmMedium, utmTerm) {
+  setCookieEntry({ storage, ...utmParams }) {
     if (!this.hasRegistered) {
       let utmCookies = JSON.parse(localStorage.getItem('UtmCookies')) ?? [];
 
       const newItem = {
         date: new Date().toISOString(),
-        UTMSource: utmSource,
-        UTMCampaign: utmCampaign,
-        UTMMedium: utmMedium,
-        UTMTerm: utmTerm,
+        ...utmParams,
       };
       utmCookies.push(newItem);
 

--- a/src/services/utm-cookies-manager.test.js
+++ b/src/services/utm-cookies-manager.test.js
@@ -1,15 +1,7 @@
 import { UtmCookiesManager } from './utm-cookies-manager';
 import { FakeLocalStorage } from './test-utils/local-storage-double';
 
-const saveMockDataInStorage = (utmCookiesManager, storage) =>
-  utmCookiesManager.setCookieEntry({
-    storage,
-    UTMSource: 'source',
-    UTMCampaign: 'campaign',
-    UTMMedium: 'medium',
-    UTMTerm: 'term',
-    gclid: 'gclid',
-  });
+const utmsParameterName = ['UTMSource', 'UTMCampaign', 'UTMMedium', 'UTMTerm', 'gclid'];
 
 describe('Utm cookies manager', () => {
   let utmCookiesManager;
@@ -22,17 +14,35 @@ describe('Utm cookies manager', () => {
   });
 
   it('should initialize add only an entry per instance', () => {
+    // Arrange
+    const utmParams = {
+      UTMSource: 'source',
+      UTMCampaign: 'campaign',
+      UTMMedium: 'medium',
+      UTMTerm: 'term',
+      gclid: 'gclid',
+    };
+
     // Act
-    saveMockDataInStorage(utmCookiesManager, storage);
-    saveMockDataInStorage(utmCookiesManager, storage);
+    utmCookiesManager.setCookieEntry({ storage, ...utmParams });
+    utmCookiesManager.setCookieEntry({ storage, ...utmParams });
 
     // Assert
     expect(utmCookiesManager.getUtmCookie(storage).length).toBe(1);
   });
 
   it('should add utms into utmCookie', () => {
+    // Arrange
+    const utmParams = {
+      UTMSource: 'source',
+      UTMCampaign: 'campaign',
+      UTMMedium: 'medium',
+      UTMTerm: 'term',
+      gclid: 'gclid',
+    };
+
     // Act
-    saveMockDataInStorage(utmCookiesManager, storage);
+    utmCookiesManager.setCookieEntry({ storage, ...utmParams });
 
     // Assert
     expect(utmCookiesManager.getUtmCookie(storage)[0].UTMSource).toBe('source');
@@ -40,5 +50,80 @@ describe('Utm cookies manager', () => {
     expect(utmCookiesManager.getUtmCookie(storage)[0].UTMMedium).toBe('medium');
     expect(utmCookiesManager.getUtmCookie(storage)[0].UTMTerm).toBe('term');
     expect(utmCookiesManager.getUtmCookie(storage)[0].gclid).toBe('gclid');
+  });
+
+  it('should add UTMSource parameter into utmCookie', () => {
+    const utmExclude = utmsParameterName.filter((item) => item !== 'UTMSource');
+
+    // Act
+    utmCookiesManager.setCookieEntry({ storage, UTMSource: 'a-value' });
+
+    // Assert
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMSource).toBe('a-value');
+    utmExclude.map((utmKey) =>
+      expect(utmCookiesManager.getUtmCookie(storage)[0][utmKey]).toBeUndefined(),
+    );
+  });
+
+  it('should add UTMCampaign parameter into utmCookie', () => {
+    const utmExclude = utmsParameterName.filter((item) => item !== 'UTMCampaign');
+
+    // Act
+    utmCookiesManager.setCookieEntry({ storage, UTMCampaign: 'a-value' });
+
+    // Assert
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMCampaign).toBe('a-value');
+    utmExclude.map((utmKey) =>
+      expect(utmCookiesManager.getUtmCookie(storage)[0][utmKey]).toBeUndefined(),
+    );
+  });
+
+  it('should add UTMMedium parameter into utmCookie', () => {
+    const utmExclude = utmsParameterName.filter((item) => item !== 'UTMMedium');
+
+    // Act
+    utmCookiesManager.setCookieEntry({ storage, UTMMedium: 'a-value' });
+
+    // Assert
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMMedium).toBe('a-value');
+    utmExclude.map((utmKey) =>
+      expect(utmCookiesManager.getUtmCookie(storage)[0][utmKey]).toBeUndefined(),
+    );
+  });
+
+  it('should add UTMTerm parameter into utmCookie', () => {
+    const utmExclude = utmsParameterName.filter((item) => item !== 'UTMTerm');
+
+    // Act
+    utmCookiesManager.setCookieEntry({ storage, UTMTerm: 'a-value' });
+
+    // Assert
+    expect(utmCookiesManager.getUtmCookie(storage)[0].UTMTerm).toBe('a-value');
+    utmExclude.map((utmKey) =>
+      expect(utmCookiesManager.getUtmCookie(storage)[0][utmKey]).toBeUndefined(),
+    );
+  });
+
+  it('should add gclid parameter into utmCookie', () => {
+    const utmExclude = utmsParameterName.filter((item) => item !== 'gclid');
+
+    // Act
+    utmCookiesManager.setCookieEntry({ storage, gclid: 'a-value' });
+
+    // Assert
+    expect(utmCookiesManager.getUtmCookie(storage)[0].gclid).toBe('a-value');
+    utmExclude.map((utmKey) =>
+      expect(utmCookiesManager.getUtmCookie(storage)[0][utmKey]).toBeUndefined(),
+    );
+  });
+
+  it('the utms parameters should not be stored into utmCookie', () => {
+    // Act
+    utmCookiesManager.setCookieEntry({ storage });
+
+    // Assert
+    utmsParameterName.map((utmKey) =>
+      expect(utmCookiesManager.getUtmCookie(storage)[0][utmKey]).toBeUndefined(),
+    );
   });
 });

--- a/src/services/utm-cookies-manager.test.js
+++ b/src/services/utm-cookies-manager.test.js
@@ -1,28 +1,44 @@
 import { UtmCookiesManager } from './utm-cookies-manager';
 import { FakeLocalStorage } from './test-utils/local-storage-double';
 
+const saveMockDataInStorage = (utmCookiesManager, storage) =>
+  utmCookiesManager.setCookieEntry({
+    storage,
+    UTMSource: 'source',
+    UTMCampaign: 'campaign',
+    UTMMedium: 'medium',
+    UTMTerm: 'term',
+    gclid: 'gclid',
+  });
+
 describe('Utm cookies manager', () => {
-  it('should initialize add only an entry per instance', () => {
+  let utmCookiesManager;
+  let storage;
+
+  beforeEach(() => {
     // Arrange
-    const utmCookiesManager = new UtmCookiesManager();
-    const storage = new FakeLocalStorage();
+    utmCookiesManager = new UtmCookiesManager();
+    storage = new FakeLocalStorage();
+  });
+
+  it('should initialize add only an entry per instance', () => {
     // Act
-    utmCookiesManager.setCookieEntry(storage, 'source', 'campaign', 'medium', 'term');
-    utmCookiesManager.setCookieEntry(storage, 'source', 'campaign', 'medium', 'term');
+    saveMockDataInStorage(utmCookiesManager, storage);
+    saveMockDataInStorage(utmCookiesManager, storage);
+
     // Assert
     expect(utmCookiesManager.getUtmCookie(storage).length).toBe(1);
   });
 
   it('should add utms into utmCookie', () => {
-    // Arrange
-    const utmCookiesManager = new UtmCookiesManager();
-    const storage = new FakeLocalStorage();
     // Act
-    utmCookiesManager.setCookieEntry(storage, 'source', 'campaign', 'medium', 'term');
+    saveMockDataInStorage(utmCookiesManager, storage);
+
     // Assert
     expect(utmCookiesManager.getUtmCookie(storage)[0].UTMSource).toBe('source');
     expect(utmCookiesManager.getUtmCookie(storage)[0].UTMCampaign).toBe('campaign');
     expect(utmCookiesManager.getUtmCookie(storage)[0].UTMMedium).toBe('medium');
     expect(utmCookiesManager.getUtmCookie(storage)[0].UTMTerm).toBe('term');
+    expect(utmCookiesManager.getUtmCookie(storage)[0].gclid).toBe('gclid');
   });
 });


### PR DESCRIPTION
**Add gclid parameter** 

**Scenario**

- The user navigates to /signup?origin=testOrigin&utm_source=test&utm_campaign=testcampaign&utm_medium=testmedium&utm_term=testterm&gclid=testgclid
- The url parameter called gclid is registered in utm_cookies
- The user submits the signup form
- It is sent together with the information, the gclid parameter