### PR TITLE
fix: add release tag generation in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,14 @@ pipeline {
                     .'''
             }
         }
+        stage('Release') {
+            when { 
+                branch 'master'
+            }
+            steps {
+                sh 'sh generate-release-w-docker.sh'
+            }
+        }
         stage('Build final version images') {
             when {
                 expression {

--- a/generate-release-w-docker.sh
+++ b/generate-release-w-docker.sh
@@ -7,7 +7,7 @@ set -u
 
 # Lines added to get the script running in the script path shell context
 # reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 # To avoid issues with MINGW y Git Bash, see:
 # https://github.com/docker/toolbox/issues/673
@@ -16,15 +16,13 @@ export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
 # build production package and generate version number
-
-#docker build --tag webapp_sources:current --target test -f Dockerfile.swarm .
-#docker run --rm \
-#    -e GH_TOKEN \
-#    -e "NPM_TOKEN=00000000-0000-0000-0000-000000000000" \
-#    -v `pwd`/.git:/app/.git \
-#    webapp_sources:current \
-#    /bin/sh -c "\
-#        yarn semantic-release \
-#    "
-
-echo "Moved to jenkinsfile ..."
+tag_name="webapp_sources$(date +%y%m%d%H%M%S)"
+docker build --tag "${tag_name}":current --target test -f Dockerfile.swarm .
+docker run --rm \
+    -e GH_TOKEN \
+    -e "NPM_TOKEN=00000000-0000-0000-0000-000000000000" \
+    -v "$(pwd)"/.git:/app/.git \
+    "${tag_name}":current \
+    /bin/sh -c "\
+        yarn semantic-release || true \
+    "


### PR DESCRIPTION
In an effort to move to the new process for deployment I've added semantic release tag generation in jenkinsfile.

Tasks:
- Disable old tag generation
- Copy into a new file
- Call this file from jenkins pipeline
