### PR TITLE
DW-963: fix(Notifications): allow more than one Notifications

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -69,7 +69,6 @@ const Header = ({
             <ul className="nav-right-main--list">
               <li>
                 <Notifications
-                  plan={user.plan}
                   notifications={notifications}
                   emptyNotificationText={emptyNotificationText}
                 />

--- a/src/components/Header/Notifications.js
+++ b/src/components/Header/Notifications.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-const Notifications = ({ plan, notifications, emptyNotificationText }) => {
-  // check if we're always going to show notifications
-  const showNotifications = plan.isFreeAccount && notifications.length;
+const Notifications = ({ notifications, emptyNotificationText }) => {
+  const showNotifications = notifications && notifications.length;
   const dataCountAttr = showNotifications ? { 'data-count': notifications.length } : {};
   return (
     <>
@@ -21,7 +20,19 @@ const Notifications = ({ plan, notifications, emptyNotificationText }) => {
               )}
             </i>
           ) : (
-            <div dangerouslySetInnerHTML={{ __html: notifications[0] }} />
+            notifications.map((notification, index, currentNotifications) => (
+              <div key={index + 'notification'}>
+                <div dangerouslySetInnerHTML={{ __html: notification }} />
+                {index < currentNotifications.length - 1 ? (
+                  <>
+                    <hr />
+                    <br />
+                  </>
+                ) : (
+                  <></>
+                )}
+              </div>
+            ))
           )}
         </div>
       </div>

--- a/src/components/Header/Notifications.test.js
+++ b/src/components/Header/Notifications.test.js
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react';
+import Notifications from './Notifications';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('Bell Notifications test', () => {
+  it('Shoud not break if notifications are undefined', () => {
+    // Arrange
+    const notifications = undefined;
+    const emptyNotificationText = 'empty';
+
+    // Act
+    const { getByText } = render(
+      <Notifications notifications={notifications} emptyNotificationText={emptyNotificationText} />,
+    );
+
+    // Assert
+    expect(getByText(emptyNotificationText)).toBeInTheDocument();
+  });
+
+  it('Shoud not break if notifications are null', () => {
+    // Arrange
+    const notifications = null;
+    const emptyNotificationText = 'empty';
+
+    // Act
+    const { getByText } = render(
+      <Notifications notifications={notifications} emptyNotificationText={emptyNotificationText} />,
+    );
+
+    // Assert
+    expect(getByText(emptyNotificationText)).toBeInTheDocument();
+  });
+
+  it('Shoud render no notifications text when there aren`t any', () => {
+    // Arrange
+    const notifications = [];
+    const emptyNotificationText = 'empty';
+
+    // Act
+    const { getByText } = render(
+      <Notifications notifications={notifications} emptyNotificationText={emptyNotificationText} />,
+    );
+
+    // Assert
+    expect(getByText(emptyNotificationText)).toBeInTheDocument();
+  });
+
+  it('Shoud be able to render many notifications', () => {
+    // Arrange
+    const notifications = ['one', 'two', 'three'];
+    const emptyNotificationText = 'empty';
+
+    // Act
+    const { getByText } = render(
+      <Notifications notifications={notifications} emptyNotificationText={emptyNotificationText} />,
+    );
+
+    // Assert
+    expect(getByText(notifications[0])).toBeInTheDocument();
+    expect(getByText(notifications[1])).toBeInTheDocument();
+    expect(getByText(notifications[2])).toBeInTheDocument();
+  });
+
+  it('Shoud render n-1 sperators for n notifications', () => {
+    // Arrange
+    const notifications = ['one', 'two', 'three'];
+    const emptyNotificationText = 'empty';
+
+    // Act
+    const { container } = render(
+      <Notifications notifications={notifications} emptyNotificationText={emptyNotificationText} />,
+    );
+
+    // Assert
+    expect(container.querySelector('hr')).not.toBeNull();
+    expect(container.querySelectorAll('hr').length).toBe(notifications.length - 1);
+  });
+});


### PR DESCRIPTION
### Fix notifications

For webapp notifications where only shown for free users. And only one notification per time.

Fixes:

- Fix issue with restricting notifications only for free user
- Allow having displayed more than one Notifications
- Add tests.