### PR TITLE
DW-957-remove-duplicate-zoho-css

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -104,6 +104,5 @@
       src="https://cdn.fromdoppler.com/doppler-ui-library/%REACT_APP_DOPPLER_UI_LIBRARY_VERSION%/js/app.js"
     ></script>
     <script type="text/javascript" src="zoho-chat.js"></script>
-    <link rel="stylesheet" type="text/css" href="zoho-chat.css" />
   </body>
 </html>


### PR DESCRIPTION
## Modifications:
Remove duplicate stylesheet link from **index.html**, it was in header and before  closing body tag. ( This last one was removed).

@cbernat @andresmoschini @GusBaamonde @lucianaDilizio 