### PR TITLE
Dw 544 format numbers in plan calculator

### DIFF
--- a/src/components/ChangePlan/ChangePlan.js
+++ b/src/components/ChangePlan/ChangePlan.js
@@ -3,7 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { Helmet } from 'react-helmet';
 import { Card, CardPrice, CardAction, Ribbon, CardFeatures } from './Card';
 import queryString from 'query-string';
-import { extractParameter } from '../../utils';
+import { extractParameter, thousandSeparatorNumber } from '../../utils';
 import { InjectAppServices } from '../../services/pure-di';
 import { Loading } from '../Loading/Loading';
 import { Link } from 'react-router-dom';
@@ -173,7 +173,7 @@ const CardWithPrice = ({ path, showFeatures, currentPlanType, promoCode }) => {
       </div>
 
       <CardPrice doNotShowSince={path.current} currency="US$">
-        {path.minimumFee}
+        {thousandSeparatorNumber(intl.defaultLocale, path.minimumFee)}
       </CardPrice>
       {path.current && !path.deadEnd ? (
         <>

--- a/src/components/ChangePlan/PlanCalculator.js
+++ b/src/components/ChangePlan/PlanCalculator.js
@@ -4,7 +4,7 @@ import { InjectAppServices } from '../../services/pure-di';
 import { Loading } from '../Loading/Loading';
 import { FormattedMessage, useIntl } from 'react-intl';
 import queryString from 'query-string';
-import { extractParameter, getPlanFee } from '../../utils';
+import { extractParameter, getPlanFee, thousandSeparatorNumber } from '../../utils';
 import { useRouteMatch, Link } from 'react-router-dom';
 
 const NavigatorTabs = ({ tabs, pathType, selectedPlanType }) => {
@@ -157,16 +157,20 @@ const PlanPriceWithoutDiscounts = ({ planData }) => {
 const PlanPricePerMonth = ({ planData }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
   return (
     <>
       <h2 className="dp-price-large">
         <span className="dp-price-large-money">US$</span>
         <span className="dp-price-large-amount">
-          {planData.discount?.discountPercentage
-            ? Math.round(
-                getPlanFee(planData.plan) * (1 - planData.discount?.discountPercentage / 100),
-              )
-            : getPlanFee(planData.plan)}
+          {thousandSeparatorNumber(
+            intl.defaultLocale,
+            planData.discount?.discountPercentage
+              ? Math.round(
+                  getPlanFee(planData.plan) * (1 - planData.discount?.discountPercentage / 100),
+                )
+              : getPlanFee(planData.plan),
+          )}
         </span>
       </h2>
       <span className="dp-for-time">{_('plan_calculator.per_month')}</span>
@@ -197,10 +201,13 @@ const PlanAgreement = ({ planData }) => {
           <strong>
             {' '}
             US$
-            {Math.round(
-              getPlanFee(planData.plan) *
-                (1 - planData.discount.discountPercentage / 100) *
-                planData.discount.monthsAmmount,
+            {thousandSeparatorNumber(
+              intl.defaultLocale,
+              Math.round(
+                getPlanFee(planData.plan) *
+                  (1 - planData.discount.discountPercentage / 100) *
+                  planData.discount.monthsAmmount,
+              ),
             )}
           </strong>
         </p>

--- a/src/components/ChangePlan/PlanCalculator.test.js
+++ b/src/components/ChangePlan/PlanCalculator.test.js
@@ -299,7 +299,7 @@ describe('PlanCalculator component', () => {
 
     // Assert
     await waitFor(() => {
-      expect(getByText('US$1739')).toBeInTheDocument();
+      expect(getByText('US$1,739')).toBeInTheDocument();
       expect(getByText('580')).toBeInTheDocument();
       expect(getByText('610')).toBeInTheDocument();
     });

--- a/src/components/shared/Slider/Slider.js
+++ b/src/components/shared/Slider/Slider.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
+import { compactNumber, thousandSeparatorNumber } from '../../../utils';
 
 export const Slider = ({ planDescriptions, defaultValue, handleChange }) => {
   const [selectedPlanIndex, setSelectedPlanIndex] = useState(defaultValue);
@@ -9,7 +10,9 @@ export const Slider = ({ planDescriptions, defaultValue, handleChange }) => {
   return (
     <>
       <div className="dp-calc-quantity">
-        <h3>{planDescriptions[selectedPlanIndex].amount}</h3>
+        <h3>
+          {thousandSeparatorNumber(intl.defaultLocale, planDescriptions[selectedPlanIndex].amount)}
+        </h3>
         <h4>{_(planDescriptions[selectedPlanIndex].descriptionId)}</h4>
       </div>
       <div className="dp-calc-slider progress-bar">
@@ -48,13 +51,13 @@ export const Slider = ({ planDescriptions, defaultValue, handleChange }) => {
         <div className="dp-indicator">
           {planDescriptions.length > 1 ? (
             <span>
-              <strong>{planDescriptions[0].amount}</strong>
+              <strong>{compactNumber(planDescriptions[0].amount)}</strong>
             </span>
           ) : (
             <span></span>
           )}
           <span>
-            <strong>{planDescriptions[planDescriptions.length - 1].amount}</strong>
+            <strong>{compactNumber(planDescriptions[planDescriptions.length - 1].amount)}</strong>
           </span>
         </div>
       </div>

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -9,6 +9,8 @@ import {
   searchLinkByRel,
   logAxiosRetryError,
   addLogEntry,
+  thousandSeparatorNumber,
+  compactNumber,
 } from './utils';
 import { renderHook } from '@testing-library/react-hooks';
 import queryString from 'query-string';
@@ -495,6 +497,31 @@ describe('utils', () => {
       // Assert
       expect(logEntry.account).toBe(undefined);
       expect(logEntry.message).not.toBe(undefined);
+    });
+  });
+
+  describe('thousandSeparatorNumber function', () => {
+    it('should return correct intl format for numbers in ESP', () => {
+      // Assert
+      expect(thousandSeparatorNumber('es', 100)).toBe('100');
+      expect(thousandSeparatorNumber('es', 1000)).toBe('1.000');
+      expect(thousandSeparatorNumber('es', 10000)).toBe('10.000');
+    });
+
+    it('should return correct intl format for numbers in ENG', () => {
+      // Assert
+      expect(thousandSeparatorNumber('en', 100)).toBe('100');
+      expect(thousandSeparatorNumber('en', 1000)).toBe('1,000');
+      expect(thousandSeparatorNumber('en', 10000)).toBe('10,000');
+    });
+  });
+
+  describe('compactNumber function', () => {
+    it('should return correct compact format for numbers (no matter what language)', () => {
+      // Assert
+      expect(compactNumber(100)).toBe('100');
+      expect(compactNumber(1000)).toBe('1K');
+      expect(compactNumber(10000)).toBe('10K');
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -266,3 +266,15 @@ export function searchLinkByRel(links: Link[], rel: string): Link[] {
   var regularExpression = new RegExp('\\b' + escapeRegExp(rel) + '\\b');
   return links.filter((l) => regularExpression.test(l.rel));
 }
+
+// Due to it seems to be that RAE defines that numbers has to be grouped when has more than 4 digits,
+// (so 1000 it shouldn't to be 1.000), it was decided to use German language when Spanish.
+export const thousandSeparatorNumber = (lang: string, value: number) =>
+  new Intl.NumberFormat(lang === 'es' ? 'de' : lang).format(value);
+
+export const compactNumber = new Intl.NumberFormat('en', {
+  //@ts-ignore
+  notation: 'compact',
+  //@ts-ignore
+  compactDisplay: 'short',
+}).format;


### PR DESCRIPTION
### Plan Calculator: Numbers format
- Add a new function to allow format number based on configured language.
- Function also allows define between a simple intl format or compact one. 

ESP
![image](https://user-images.githubusercontent.com/10213170/122453011-44aec500-cf80-11eb-8c72-a2d51efb3d9e.png)

ENG
![image](https://user-images.githubusercontent.com/10213170/122453079-56906800-cf80-11eb-835a-dfb10d4c1b75.png)
