### PR TITLE
DW-973 fix(Promotions): get default image from be

### DIFF
--- a/src/components/shared/Promotions/Promotions.js
+++ b/src/components/shared/Promotions/Promotions.js
@@ -30,18 +30,14 @@ const Promotions = function ({ type, page, dependencies: { dopplerSitesClient } 
     const fetchData = async () => {
       setState({ loading: true });
       const bannerData = await dopplerSitesClient.getBannerData(intl.locale, type, page || '');
-      if (!bannerData.success) {
+      if (!bannerData || !bannerData.success) {
         setState({ loading: false, bannerData: getDefaultBannerData(intl) });
       } else {
         setState({ loading: false, bannerData: bannerData.value });
       }
     };
 
-    if (page) {
-      fetchData();
-    } else {
-      setState({ loading: false, bannerData: getDefaultBannerData(intl) });
-    }
+    fetchData();
   }, [dopplerSitesClient, page, intl, type]);
 
   return (

--- a/src/components/shared/Promotions/Promotions.test.js
+++ b/src/components/shared/Promotions/Promotions.test.js
@@ -59,4 +59,24 @@ describe('Promotions Component', () => {
     expect(container.querySelector('.loading-box')).toBeInTheDocument();
     await waitFor(() => expect(getByText(fullResponse.value.title)));
   });
+
+  it('should has full default data from service when dont have page in parameters', async () => {
+    const dopplerSitesClientDouble = {
+      getBannerData: async () => fullResponse,
+    };
+
+    const { container, getByText } = render(
+      <AppServicesProvider
+        forcedServices={{
+          dopplerSitesClient: dopplerSitesClientDouble,
+        }}
+      >
+        <DopplerIntlProvider locale="es">
+          <Promotions type="signup" />
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+    expect(container.querySelector('.loading-box')).toBeInTheDocument();
+    await waitFor(() => expect(getByText(fullResponse.value.title)));
+  });
 });


### PR DESCRIPTION
- Get the default image setting in be if has one, is not continue getting from local.

![image](https://user-images.githubusercontent.com/8861133/122603516-d71b9b00-d04a-11eb-8f4d-c10b0e62ba95.png)
