### PR TITLE
fix(PlanCalculator): fix order of plans

### DIFF
--- a/src/components/ChangePlan/PlanCalculator.test.js
+++ b/src/components/ChangePlan/PlanCalculator.test.js
@@ -5,6 +5,7 @@ import PlanCalculator from './PlanCalculator';
 import IntlProvider from '../../i18n/DopplerIntlProvider.double-with-ids-as-values';
 import { AppServicesProvider } from '../../services/pure-di';
 import { MemoryRouter, Route } from 'react-router-dom';
+import { orderPlanTypes } from '../../utils';
 
 describe('PlanCalculator component', () => {
   afterEach(cleanup);
@@ -21,10 +22,11 @@ describe('PlanCalculator component', () => {
     },
   };
 
+  const planTypes = orderPlanTypes(['prepaid', 'subscribers', 'monthly-deliveries']);
   const planServiceDoubleBase = {
     getPlanList: () => [],
     mapCurrentPlanFromTypeOrId: () => {},
-    getPlanTypes: () => ['prepaid', 'subscribers', 'monthly-deliveries'],
+    getPlanTypes: () => planTypes,
     getBuyUrl: () => '',
   };
 
@@ -67,6 +69,14 @@ describe('PlanCalculator component', () => {
       expect(getByText('plan_calculator.plan_type_prepaid')).toBeInTheDocument();
       expect(getByText('plan_calculator.plan_type_subscribers')).toBeInTheDocument();
       expect(getByText('plan_calculator.plan_type_monthly_deliveries')).toBeInTheDocument();
+
+      // check the order of the plan types
+      const navigatorTabs = container.querySelector('.tabs-nav');
+      let tab = navigatorTabs.firstChild;
+      planTypes.forEach((planType) => {
+        expect(tab).toHaveTextContent(`plan_calculator.plan_type_${planType.replace('-', '_')}`);
+        tab = tab.nextSibling;
+      });
     });
   });
 

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -14,7 +14,7 @@ import {
   FreePlan,
   AgencyPlan,
 } from '../doppler-types';
-import { getPlanFee } from '../utils';
+import { getPlanFee, orderPlanTypes } from '../utils';
 
 export interface PlanHierarchy {
   getPaths(userPlan: Plan, planList: Plan[]): Path[];
@@ -252,7 +252,7 @@ export class PlanService implements PlanHierarchy {
       (n, i) => typesAllowed.indexOf(n) === i,
     );
 
-    return distinctTypesAllowed;
+    return orderPlanTypes(distinctTypesAllowed);
   }
 
   getPlans(userPlan: Plan, pathType: PathType, planType: PlanType, planList: Plan[]): Plan[] {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -8,14 +8,79 @@ import {
   isWhitelisted,
   searchLinkByRel,
   logAxiosRetryError,
-  addLogEntry,
   thousandSeparatorNumber,
   compactNumber,
+  orderPlanTypes,
 } from './utils';
 import { renderHook } from '@testing-library/react-hooks';
 import queryString from 'query-string';
 
 describe('utils', () => {
+  describe('orderPlanTypes', () => {
+    it('should sort plan types when all first plans are', () => {
+      // Arrange
+      const planTypes = ['demo', 'prepaid', 'free', 'monthly-deliveries', 'subscribers'];
+      const expectedPlans = ['subscribers', 'monthly-deliveries', 'prepaid', 'demo', 'free'];
+
+      // Act
+      const orderedPlans = orderPlanTypes(planTypes);
+
+      // Assert
+      expect(orderedPlans).toEqual(expectedPlans);
+    });
+
+    it('should sort plan types when there are only first 2 plans', () => {
+      // Arrange
+      const planTypes = ['demo', 'prepaid', 'free', 'monthly-deliveries'];
+      const expectedPlans = ['monthly-deliveries', 'prepaid', 'demo', 'free'];
+
+      // Act
+      const orderedPlans = orderPlanTypes(planTypes);
+
+      // Assert
+      expect(orderedPlans).toEqual(expectedPlans);
+    });
+
+    it('should return original list when there are no plans to sort', () => {
+      // Arrange
+      const planTypes = ['demo', 'agencies', 'free'];
+      const expectedPlans = ['demo', 'agencies', 'free'];
+
+      // Act
+      const orderedPlans = orderPlanTypes(planTypes);
+
+      // Assert
+      expect(orderedPlans).toEqual(expectedPlans);
+    });
+
+    it('should return original list when there are no plans to sort', () => {
+      // Arrange
+      const planTypes = [
+        'demo',
+        'free',
+        'agencies',
+        'monthly-deliveries',
+        'prepaid',
+        'subscribers',
+      ];
+      const expectedPlans = [
+        'agencies',
+        'prepaid',
+        'free',
+        'demo',
+        'monthly-deliveries',
+        'subscribers',
+      ];
+      const firstPlans = ['agencies', 'prepaid', 'free'];
+
+      // Act
+      const orderedPlans = orderPlanTypes(planTypes, firstPlans);
+
+      // Assert
+      expect(orderedPlans).toEqual(expectedPlans);
+    });
+  });
+
   describe('getDataHubParams', () => {
     it('should parse url with no params and no hash correctly', () => {
       //Arrange

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import urlParse from 'url-parse';
 import { useEffect, useRef } from 'react';
-import { Plan, PrepaidPack, FeaturedPlan } from './doppler-types';
+import { Plan, PrepaidPack, FeaturedPlan, PlanType } from './doppler-types';
 
 declare global {
   interface Window {
@@ -248,6 +248,26 @@ export function openZohoChatWithMessage(message: string) {
 
 export function getPlanFee(plan: Plan): number {
   return plan.type === 'prepaid' ? (plan as PrepaidPack).price : (plan as FeaturedPlan).fee;
+}
+
+const firstPlansDefaultOrder: PlanType[] = ['subscribers', 'monthly-deliveries', 'prepaid'];
+
+export function orderPlanTypes(
+  planTypes: PlanType[],
+  firstPlans: PlanType[] = firstPlansDefaultOrder,
+): PlanType[] {
+  const firstPlansIncluded: PlanType[] = firstPlans.filter((planType: PlanType) =>
+    planTypes.includes(planType),
+  );
+
+  if (firstPlansIncluded.length === 0) {
+    return planTypes;
+  }
+
+  const complementaryPlans = planTypes.filter(
+    (plantType: PlanType) => !firstPlansIncluded.includes(plantType),
+  );
+  return [...firstPlansIncluded, ...complementaryPlans];
 }
 
 interface Link {


### PR DESCRIPTION
### **Fix order of plans**
task link: https://makingsense.atlassian.net/browse/DW-545

- The user navigates to /plan-selection/standard
- Plans are displayed in the order: by contacts, by sending and by credits

Results: 

![image](https://user-images.githubusercontent.com/84402180/122803251-f81efe80-d28b-11eb-8dff-f97e8ffa17d0.png)
