### PR TITLE
feat: add contact policy api double

### DIFF
--- a/src/services/doppler-contact-policy-api-client.double.ts
+++ b/src/services/doppler-contact-policy-api-client.double.ts
@@ -1,0 +1,49 @@
+import { ResultWithoutExpectedErrors } from '../doppler-types';
+import {
+  AccountSettings,
+  DopplerContactPolicyApiClient,
+  SubscriberList,
+} from './doppler-contact-policy-api-client';
+import { timeout } from '../utils';
+
+export class HardcodedDopplerContactPolicyApiClient implements DopplerContactPolicyApiClient {
+  private mapSubscriberList(data: any): SubscriberList[] {
+    return data.map((x: any) => ({
+      id: x.id,
+      name: x.name,
+    }));
+  }
+
+  async getAccountSettings(email: string): Promise<ResultWithoutExpectedErrors<AccountSettings>> {
+    console.log('getAccountSettings');
+    await timeout(1500);
+
+    const excludedSubscribersLists = [
+      {
+        id: 1,
+        name: 'List A',
+      },
+      {
+        id: 2,
+        name: 'List B',
+      },
+      {
+        id: 3,
+        name: 'List C',
+      },
+    ];
+
+    const settings = {
+      accountName: email,
+      active: true,
+      emailsAmountByInterval: 20,
+      intervalInDays: 7,
+      excludedSubscribersLists: this.mapSubscriberList(excludedSubscribersLists),
+    };
+
+    return {
+      success: true,
+      value: settings,
+    };
+  }
+}

--- a/src/services/doppler-contact-policy-api-client.test.ts
+++ b/src/services/doppler-contact-policy-api-client.test.ts
@@ -1,0 +1,15 @@
+import { cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('HttpDopplerContactPolicyApiClient', () => {
+  afterEach(cleanup);
+
+  //TODO: Implement real tests
+  it('dummy test', () => {
+    // Act
+    const n = null;
+
+    // Assert
+    expect(n).toBeNull();
+  });
+});

--- a/src/services/doppler-contact-policy-api-client.ts
+++ b/src/services/doppler-contact-policy-api-client.ts
@@ -1,0 +1,78 @@
+import { ResultWithoutExpectedErrors } from '../doppler-types';
+import { AxiosInstance, AxiosStatic } from 'axios';
+import { RefObject } from 'react';
+import { AppSession } from './app-session';
+
+export interface DopplerContactPolicyApiClient {
+  getAccountSettings(email: string): Promise<ResultWithoutExpectedErrors<AccountSettings>>;
+}
+
+export interface AccountSettings {
+  accountName: string;
+  active: boolean;
+  emailsAmountByInterval: number;
+  intervalInDays: number;
+  excludedSubscribersLists: SubscriberList[];
+}
+
+export interface SubscriberList {
+  id: number;
+  name: string;
+}
+
+export class HttpDopplerContactPolicyApiClient implements DopplerContactPolicyApiClient {
+  private readonly axios: AxiosInstance;
+  private readonly baseUrl: string;
+  private readonly connectionDataRef: RefObject<AppSession>;
+
+  constructor({
+    axiosStatic,
+    baseUrl,
+    connectionDataRef,
+  }: {
+    axiosStatic: AxiosStatic;
+    baseUrl: string;
+    connectionDataRef: RefObject<AppSession>;
+  }) {
+    this.baseUrl = baseUrl;
+    this.axios = axiosStatic.create({
+      baseURL: this.baseUrl,
+    });
+    this.connectionDataRef = connectionDataRef;
+  }
+
+  private mapSubscriberList(data: any): SubscriberList[] {
+    return data.map((x: any) => ({
+      id: x.id,
+      name: x.name,
+    }));
+  }
+
+  async getAccountSettings(email: string): Promise<ResultWithoutExpectedErrors<AccountSettings>> {
+    try {
+      const response = await this.axios.request({
+        method: 'GET',
+        url: `/accounts/${email}/settings`,
+      });
+
+      if (response.status === 200 && response.data) {
+        const settings = {
+          accountName: response.data.accountName,
+          active: response.data.active,
+          emailsAmountByInterval: response.data.emailsAmountByInterval,
+          intervalInDays: response.data.intervalInDays,
+          excludedSubscribersLists: this.mapSubscriberList(response.data.excludedSubscribersLists),
+        };
+
+        return {
+          success: true,
+          value: settings,
+        };
+      } else {
+        return { success: false, error: response };
+      }
+    } catch (error) {
+      return { success: false, error: error };
+    }
+  }
+}


### PR DESCRIPTION
Integrate contact-policy API (https://apis.fromdoppler.com/contact-policies/swagger/index.html) with double