### PR TITLE
[DW-540] show decimals fix rounding

### DIFF
--- a/src/components/ChangePlan/PlanCalculator.js
+++ b/src/components/ChangePlan/PlanCalculator.js
@@ -140,12 +140,14 @@ const BannerUpgrade = ({ currentPlan, currentPlanList }) => {
 };
 
 const PlanPriceWithoutDiscounts = ({ planData }) => {
+  const intl = useIntl();
+  const formatedFee = thousandSeparatorNumber(intl.defaultLocale, getPlanFee(planData.plan));
   return (
     <>
       {planData.discount?.discountPercentage ? (
         <span className="dp-price-old">
           <span className="dp-price-old-money">US$</span>
-          <span className="dp-price-old-amount">{getPlanFee(planData.plan)}</span>
+          <span className="dp-price-old-amount">{formatedFee}</span>
         </span>
       ) : (
         <></>
@@ -157,21 +159,18 @@ const PlanPriceWithoutDiscounts = ({ planData }) => {
 const PlanPricePerMonth = ({ planData }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const discountPercentage = planData.discount?.discountPercentage;
+  const planFee = getPlanFee(planData.plan);
+  const planFeeWithDiscount = thousandSeparatorNumber(
+    intl.defaultLocale,
+    discountPercentage ? planFee * (1 - discountPercentage / 100) : planFee,
+  );
 
   return (
     <>
       <h2 className="dp-price-large">
         <span className="dp-price-large-money">US$</span>
-        <span className="dp-price-large-amount">
-          {thousandSeparatorNumber(
-            intl.defaultLocale,
-            planData.discount?.discountPercentage
-              ? Math.round(
-                  getPlanFee(planData.plan) * (1 - planData.discount?.discountPercentage / 100),
-                )
-              : getPlanFee(planData.plan),
-          )}
-        </span>
+        <span className="dp-price-large-amount">{planFeeWithDiscount}</span>
       </h2>
       <span className="dp-for-time">{_('plan_calculator.per_month')}</span>
     </>
@@ -181,6 +180,13 @@ const PlanPricePerMonth = ({ planData }) => {
 const PlanAgreement = ({ planData }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const discountPercentage = planData.discount?.discountPercentage;
+  const monthsAmmount = planData?.discount?.monthsAmmount;
+  const planFee = Math.round(getPlanFee(planData.plan));
+  const planFeeWithDiscount = thousandSeparatorNumber(
+    intl.defaultLocale,
+    planFee * (1 - discountPercentage / 100) * monthsAmmount,
+  );
 
   const getAgreementDescription = (discountDescription) => {
     switch (discountDescription) {
@@ -195,25 +201,16 @@ const PlanAgreement = ({ planData }) => {
 
   return (
     <div className="dp-agreement">
-      {planData.discount?.discountPercentage ? (
+      {discountPercentage ? (
         <p>
           {getAgreementDescription(planData.discount.description)}
           <strong>
             {' '}
             US$
-            {thousandSeparatorNumber(
-              intl.defaultLocale,
-              Math.round(
-                getPlanFee(planData.plan) *
-                  (1 - planData.discount.discountPercentage / 100) *
-                  planData.discount.monthsAmmount,
-              ),
-            )}
+            {planFeeWithDiscount}
           </strong>
         </p>
-      ) : (
-        <></>
-      )}
+      ) : null}
       <p>{_('plan_calculator.discount_clarification')}</p>
     </div>
   );

--- a/src/components/ChangePlan/PlanCalculator.test.js
+++ b/src/components/ChangePlan/PlanCalculator.test.js
@@ -309,8 +309,8 @@ describe('PlanCalculator component', () => {
 
     // Assert
     await waitFor(() => {
-      expect(getByText('US$1,739')).toBeInTheDocument();
-      expect(getByText('580')).toBeInTheDocument();
+      expect(getByText('US$1,738.50')).toBeInTheDocument();
+      expect(getByText('579.50')).toBeInTheDocument();
       expect(getByText('610')).toBeInTheDocument();
     });
   });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -565,28 +565,36 @@ describe('utils', () => {
     });
   });
 
-  describe('thousandSeparatorNumber function', () => {
-    it('should return correct intl format for numbers in ESP', () => {
-      // Assert
-      expect(thousandSeparatorNumber('es', 100)).toBe('100');
-      expect(thousandSeparatorNumber('es', 1000)).toBe('1.000');
-      expect(thousandSeparatorNumber('es', 10000)).toBe('10.000');
-    });
+  describe.each`
+    rawNumber | expectedFormatted | language
+    ${100}    | ${'100'}          | ${'en'}
+    ${1000}   | ${'1,000'}        | ${'en'}
+    ${10000}  | ${'10,000'}       | ${'en'}
+    ${100}    | ${'100'}          | ${'es'}
+    ${1000}   | ${'1.000'}        | ${'es'}
+    ${10000}  | ${'10.000'}       | ${'es'}
+  `('thousandSeparatorNumber function', ({ rawNumber, expectedFormatted, language }) => {
+    it(`should return ${expectedFormatted} when the number is ${rawNumber} and language is ${language}`, () => {
+      // Act
+      const result = thousandSeparatorNumber(language, rawNumber);
 
-    it('should return correct intl format for numbers in ENG', () => {
       // Assert
-      expect(thousandSeparatorNumber('en', 100)).toBe('100');
-      expect(thousandSeparatorNumber('en', 1000)).toBe('1,000');
-      expect(thousandSeparatorNumber('en', 10000)).toBe('10,000');
+      expect(result).toBe(expectedFormatted);
     });
   });
 
-  describe('compactNumber function', () => {
-    it('should return correct compact format for numbers (no matter what language)', () => {
+  describe.each`
+    rawNumber | expectedFormatted
+    ${100}    | ${'100'}
+    ${1000}   | ${'1K'}
+    ${10000}  | ${'10K'}
+  `('compactNumber function', ({ rawNumber, expectedFormatted }) => {
+    it(`should return ${expectedFormatted} when the number is ${rawNumber} (no matter what language)`, () => {
+      // Act
+      const result = compactNumber(rawNumber);
+
       // Assert
-      expect(compactNumber(100)).toBe('100');
-      expect(compactNumber(1000)).toBe('1K');
-      expect(compactNumber(10000)).toBe('10K');
+      expect(result).toBe(expectedFormatted);
     });
   });
 });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -566,15 +566,19 @@ describe('utils', () => {
   });
 
   describe.each`
-    rawNumber | expectedFormatted | language
-    ${100}    | ${'100'}          | ${'en'}
-    ${1000}   | ${'1,000'}        | ${'en'}
-    ${10000}  | ${'10,000'}       | ${'en'}
-    ${100}    | ${'100'}          | ${'es'}
-    ${1000}   | ${'1.000'}        | ${'es'}
-    ${10000}  | ${'10.000'}       | ${'es'}
+    rawNumber  | expectedFormatted | language
+    ${100}     | ${'100'}          | ${'en'}
+    ${1000}    | ${'1,000'}        | ${'en'}
+    ${10000}   | ${'10,000'}       | ${'en'}
+    ${1000.35} | ${'1,000.35'}     | ${'en'}
+    ${1000.5}  | ${'1,000.50'}     | ${'en'}
+    ${100}     | ${'100'}          | ${'es'}
+    ${1000}    | ${'1.000'}        | ${'es'}
+    ${10000}   | ${'10.000'}       | ${'es'}
+    ${1000.35} | ${'1.000,35'}     | ${'es'}
+    ${1000.5}  | ${'1.000,50'}     | ${'es'}
   `('thousandSeparatorNumber function', ({ rawNumber, expectedFormatted, language }) => {
-    it(`should return ${expectedFormatted} when the number is ${rawNumber} and language is ${language}`, () => {
+    it(`should return ${expectedFormatted} when the number is ${rawNumber} and language is "${language}"`, () => {
       // Act
       const result = thousandSeparatorNumber(language, rawNumber);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,7 +290,9 @@ export function searchLinkByRel(links: Link[], rel: string): Link[] {
 // Due to it seems to be that RAE defines that numbers has to be grouped when has more than 4 digits,
 // (so 1000 it shouldn't to be 1.000), it was decided to use German language when Spanish.
 export const thousandSeparatorNumber = (lang: string, value: number) =>
-  new Intl.NumberFormat(lang === 'es' ? 'de' : lang).format(value);
+  new Intl.NumberFormat(lang === 'es' ? 'de' : lang, {
+    minimumFractionDigits: value % 1 ? 2 : 0,
+  }).format(value);
 
 export const compactNumber = new Intl.NumberFormat('en', {
   //@ts-ignore


### PR DESCRIPTION
### Show decimals, fix rounding
- Modify `thousandSeparatorNumber` function to show decimals if applies (if amount doesn't have decimals it will show it without them)
- If discount is applied, it will show total without rounding.
- A refactor was also made to make code more readable.
- A refactor was made in utils.test.
- Some new tests were added. 

![image](https://user-images.githubusercontent.com/10213170/123149796-0742af80-d438-11eb-9b1d-beee6ec25fbe.png)

