### PR TITLE
fix(ForgotPassword): add dependency doppler sites client

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.test.js
+++ b/src/components/ForgotPassword/ForgotPassword.test.js
@@ -5,10 +5,18 @@ import DopplerIntlProvider from '../../i18n/DopplerIntlProvider';
 import { MemoryRouter as Router } from 'react-router-dom';
 import { AppServicesProvider } from '../../services/pure-di';
 import '@testing-library/jest-dom/extend-expect';
+import { timeout } from '../../utils';
+
+const emptyResponse = { success: false, error: new Error('Dummy error') };
 
 const defaultDependencies = {
   dopplerLegacyClient: {
     sendResetPasswordEmail: () => ({ success: true }),
+  },
+  dopplerSitesClient: {
+    getBannerData: async () => {
+      return emptyResponse;
+    },
   },
   captchaUtilsService: {
     useCaptcha: () => {

--- a/src/components/Signup/Signup.test.js
+++ b/src/components/Signup/Signup.test.js
@@ -14,7 +14,6 @@ const emptyResponse = { success: false, error: new Error('Dummy error') };
 const defaultDependencies = {
   dopplerSitesClient: {
     getBannerData: async () => {
-      await timeout(0);
       return emptyResponse;
     },
   },


### PR DESCRIPTION
fix tests in forgot password adding the dependency of doppler sites client to get the default banner.

