### PR TITLE
DW-992-allow-plan-upgrade

### DIFF
--- a/src/components/ChangePlan/ChangePlan.js
+++ b/src/components/ChangePlan/ChangePlan.js
@@ -178,7 +178,7 @@ export const CardWithPrice = ({ path, showFeatures, currentPlanType, promoCode }
       <CardPrice doNotShowSince={path.current} currency="US$">
         {thousandSeparatorNumber(intl.defaultLocale, path.minimumFee)}
       </CardPrice>
-      {path.current && !path.deadEnd ? (
+      {path.current ? (
         <>
           {/* TODO: it's not necessary. Can be used 'search' and add promoCode
           https://reactrouter.com/web/api/Link */}
@@ -190,11 +190,6 @@ export const CardWithPrice = ({ path, showFeatures, currentPlanType, promoCode }
           >
             {_(`change_plan.increase_action_${currentPlanType.replace('-', '_')}`)}
           </Link>
-          <span className="dp-what-plan">{_('change_plan.current_plan')}</span>
-        </>
-      ) : path.current && path.deadEnd ? (
-        <>
-          <span className="dp-maximum">{_('change_plan.card_generic_maximum_reached')}</span>
           <span className="dp-what-plan">{_('change_plan.current_plan')}</span>
         </>
       ) : (

--- a/src/components/ChangePlan/ChangePlan.test.js
+++ b/src/components/ChangePlan/ChangePlan.test.js
@@ -145,7 +145,7 @@ describe('CardWithPrice component', () => {
   const currentPlanType = 'prepaid';
   const showFeatures = false;
 
-  it('should render CardWithPrice when path type is plus and has not deadEnd', async () => {
+  it('should render CardWithPrice when path type is plus', async () => {
     // Arrange
     const path = {
       type: 'plus',
@@ -182,7 +182,7 @@ describe('CardWithPrice component', () => {
     expect(getByText(`change_plan.features_HTML_${path.type}`)).toBeInTheDocument();
   });
 
-  it('should render CardWithPrice when path type is standard and deadEnd', async () => {
+  it('should render CardWithPrice when path type is standard', async () => {
     // Arrange
     const path = {
       type: 'standard',
@@ -217,12 +217,11 @@ describe('CardWithPrice component', () => {
     );
   });
 
-  it('should render CardWithPrice when has not promotion code and path has current and deadEnd', async () => {
+  it('should render CardWithPrice when has not promotion code and path has current', async () => {
     // Arrange
     const path = {
       type: 'standard',
       current: 'fake current',
-      deadEnd: 'fake deadEnd',
     };
 
     // Act
@@ -240,7 +239,6 @@ describe('CardWithPrice component', () => {
 
     // Assert
     expect(container.querySelector('.dp-highlighthed')).not.toBeInTheDocument();
-    expect(getByText('change_plan.card_generic_maximum_reached')).toBeInTheDocument();
   });
 
   it('should render CardWithPrice showing CardPrice', async () => {
@@ -249,7 +247,6 @@ describe('CardWithPrice component', () => {
       type: 'standard',
       current: 'fake current',
       minimumFee: 1000,
-      deadEnd: 'fake deadEnd',
     };
 
     // Act
@@ -347,7 +344,6 @@ describe('ChangePlan component', () => {
     };
     const complementariesPaths = Object.keys(pricePlansByType).map((path) => ({
       current: false,
-      deadEnd: false,
       minimumFee: pricePlansByType[path],
       type: path,
     }));
@@ -355,7 +351,6 @@ describe('ChangePlan component', () => {
       {
         type: 'free',
         current: true,
-        deadEnd: true,
       },
       ...complementariesPaths,
     ];

--- a/src/doppler-types.ts
+++ b/src/doppler-types.ts
@@ -87,7 +87,6 @@ export interface AgencyPlan {
 export interface FreePath {
   type: 'free';
   current: boolean;
-  deadEnd: boolean;
 }
 
 export type Plan =
@@ -103,20 +102,17 @@ export interface StandardPath {
   type: 'standard';
   current: boolean;
   minimumFee: number;
-  deadEnd: boolean;
 }
 
 export interface PlusPath {
   type: 'plus';
   current: boolean;
   minimumFee: number;
-  deadEnd: boolean;
 }
 
 export interface AgenciesPath {
   type: 'agencies';
   current: boolean;
-  deadEnd: boolean;
 }
 
 export interface AppStatus {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -80,7 +80,6 @@ const messages_en = {
     card_agencies_title: 'Agencies',
     card_free_description: 'Try a FREE Doppler account with no contracts or credit cards. Until 500 Contacts.',
     card_free_title: 'FREE',
-    card_generic_maximum_reached: 'MAXIMUM REACHED',
     card_plus_description: 'Advanced features for professionals with custom needs.',
     card_plus_title: 'Plus',
     card_standard_description: 'Try our plans that best fit to your needs, monthly or prepaids.',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -80,7 +80,6 @@ const messages_es = {
     card_agencies_title: 'Agencias',
     card_free_description: 'Prueba Doppler GRATIS sin contratos ni tarjetas de crédito. Hasta 500 Contactos.',
     card_free_title: 'GRATUITO',
-    card_generic_maximum_reached: 'MÁXIMO ALCANZADO',
     card_plus_description: 'Funciones avanzadas para profesionales que necesitan mas personalización.',
     card_plus_title: 'Plus',
     card_standard_description: 'Prueba nuestros planes que se ajusten mas a tus necesidades: mensuales o prepagos.',

--- a/src/services/plan-service.test.js
+++ b/src/services/plan-service.test.js
@@ -106,7 +106,6 @@ describe('Doppler plan client', () => {
     // Assert
     expect(paths.length).toBe(4);
     expect(paths[0].current).toBe(true);
-    expect(paths[0].deadEnd).toBe(true);
     expect(paths.filter((plan) => plan.current).length > 0);
   });
 
@@ -127,7 +126,6 @@ describe('Doppler plan client', () => {
     // Assert
     expect(paths.length).toBe(3);
     expect(paths[0].current).toBe(true);
-    expect(paths[0].deadEnd).toBe(false);
   });
 
   it('should get correct path for a current subscriber standard user', async () => {
@@ -150,7 +148,6 @@ describe('Doppler plan client', () => {
     // Assert
     expect(paths.length).toBe(3);
     expect(paths[0].current).toBe(true);
-    expect(paths[0].deadEnd).toBe(false);
   });
 
   it('should get correct path for a current subscriber plus user', async () => {
@@ -174,7 +171,6 @@ describe('Doppler plan client', () => {
     // Assert
     expect(paths.length).toBe(2);
     expect(paths[0].current).toBe(true);
-    expect(paths[0].deadEnd).toBe(false);
     expect(paths[0].minimumFee).toBe(currentPlan.fee);
   });
 

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -98,7 +98,6 @@ const getFreePathOrEmpty = (userPlan: Plan, planList: Plan[]): [] | [FreePath] =
     {
       type: 'free',
       current: userPlan.featureSet === 'free',
-      deadEnd: plans.length === 1 && userPlan === cheapestPlan,
     },
   ];
 };
@@ -116,7 +115,6 @@ const getAgencyPathOrEmpty = (userPlan: Plan, planList: Plan[]): [] | [AgenciesP
     {
       type: 'agencies',
       current: userPlan.featureSet === 'agency',
-      deadEnd: plans.length === 1 && userPlan === cheapestPlan,
     },
   ];
 };
@@ -134,7 +132,6 @@ const getStandardPathOrEmpty = (userPlan: Plan, planList: Plan[]): [] | [Standar
       type: 'standard',
       current: userPlan.featureSet === 'standard',
       minimumFee: getPlanFee(cheapestPlan),
-      deadEnd: plans.length === 1 && cheapestPlan === userPlan,
     },
   ];
 };
@@ -153,7 +150,6 @@ const getPlusPathOrEmpty = (userPlan: Plan, planList: Plan[]): PlusPath[] => {
       type: 'plus',
       current: userPlan.featureSet === 'plus',
       minimumFee: cheapestPlan.fee,
-      deadEnd: plans.length === 1 && cheapestPlan === userPlan,
     },
   ];
 };


### PR DESCRIPTION
## Modifications:

- fix(change-plan): Always show button to upgrade current plan. _( Also when current plan is the highest plan)_

- fix(plan-service): Remove unused `deadEnd `property from plan-service, tests and code.

![image](https://user-images.githubusercontent.com/21247095/124031749-142e4880-d9ce-11eb-9f36-efe1b171c5cf.png)
