### PR TITLE
fix(Jenkinsfile): tag name was empty so now we use the function that …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,5 +135,5 @@ def boolean isVersionTag(String tag) {
 // https://stackoverflow.com/questions/56030364/buildingtag-always-returns-false
 // workaround https://issues.jenkins-ci.org/browse/JENKINS-55987
 def String readCurrentTag() {
-    return sh(returnStdout: true, script: "git describe --tags --match v?*.?*.?* --abbrev=0 --exact-match || echo ''").trim()
+    return sh(returnStdout: true, script: 'echo ${TAG_NAME}').trim()
 }


### PR DESCRIPTION
### Added the same approach as in hello microservice

Modified the function for tag detection like in [hello microservice](https://github.com/FromDoppler/hello-microservice/blob/c6151e852de2c1bd2600546339b5b0ab2d949a1a/Jenkinsfile#L105-L107). I will test this to see if it works. 

**Context**

This seems to be not working from a very long time, `${TAG_NAME}` variable is empty in jenkins file, It was like this in previous job webapp-next and now the issue is in the new job also.


![image](https://user-images.githubusercontent.com/2439363/124184193-96cb0c80-da8f-11eb-9189-8728c831d103.png)

![image](https://user-images.githubusercontent.com/2439363/124184251-ac403680-da8f-11eb-9420-c2a7d1974c71.png)

@ms-darianbenito @andresmoschini could you take a look?