### PR TITLE
[DAT-498] -Remove warning in the ContactInformation component

### DIFF
--- a/src/components/ChangePlan/Checkout/ContactInformation/ContactInformation.js
+++ b/src/components/ChangePlan/Checkout/ContactInformation/ContactInformation.js
@@ -51,7 +51,7 @@ export const ContactInformation = InjectAppServices(
         });
       };
       fetchData();
-    }, [dopplerUserApiClient]);
+    }, [dopplerUserApiClient, onComplete]);
 
     const _ = (id, values) => intl.formatMessage({ id: id }, values);
     const defaultOption = { key: '', value: _('checkoutProcessForm.empty_option_select') };


### PR DESCRIPTION
Remove warning in the ContactInformation component.

The warning was:
```
src\components\ChangePlan\Checkout\ContactInformation\ContactInformation.js
  Line 54:8:  React Hook useEffect has a missing dependency: 'onComplete'. Either include it or remove the dependency array. If 'onComplete' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps
```

**Task:** [DAT-498](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-498)