### PR TITLE
feat(checkout): checkout summary page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ import { ContactPolicy } from './components/ContactPolicy/ContactPolicy';
 import { Promotional } from './components/Integrations/BigQuery/Promotional/Promotional';
 import { AuthorizationPage } from './components/Integrations/BigQuery/ControlPanel/AuthorizationPage';
 import Checkout from './components/ChangePlan/Checkout/Checkout';
+import { CheckoutSummary } from './components/ChangePlan/Checkout/CheckoutSummary';
 
 /**
  * @param { Object } props - props
@@ -144,6 +145,7 @@ const App = ({ locale, location, dependencies: { appSessionRef, sessionManager }
                 exact
                 component={AuthorizationPage}
               />
+              <PrivateRoute path={['/checkout-summary']} exact component={CheckoutSummary} />
               <PublicRouteWithLegacyFallback exact path="/login" />
               <PublicRouteWithLegacyFallback exact path="/signup" />
               <PublicRouteWithLegacyFallback exact path="/login/reset-password" />

--- a/src/components/ChangePlan/Checkout/CheckoutSummary.js
+++ b/src/components/ChangePlan/Checkout/CheckoutSummary.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { extractParameter } from '../../../utils';
+import queryString from 'query-string';
+import SafeRedirect from '../../SafeRedirect';
+
+export const CheckoutSummary = ({ location }) => {
+  const redirect = extractParameter(location, queryString.parse, 'redirect');
+  const legacy = extractParameter(location, queryString.parse, 'legacy');
+
+  if (legacy) {
+    if (redirect) {
+      return <SafeRedirect to={redirect} />;
+    }
+    return <SafeRedirect to="/Campaigns/Draft" />;
+  }
+
+  return 'Normal checkout flow for new plans should go here.';
+};


### PR DESCRIPTION
### Upgrade for old doppler

We need to track in google tag manager when the user upgrades from free to paid succesfully. To do this, we will track a redirection to a page. In Upgrade we will do a redirect to this page hidden and then redirect as usual. 
This page in the future will be the summary for checkout process for new plans. 
This page has two ways of operation:
- When legacy parameter is present it will redirect to old doppler with redirect parameter or by default to `Campaigns/Draft`
- When legacy parameter is not present it will remain in this page. 

Pending:

- [ ] Add tests 