### PR TITLE
fix: improve tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
     "comment": "Resolution to avoid test warning: [...] Please update the following components: SideEffect(NullComponent)"
   },
   "devDependencies": {
+    "@testing-library/dom": "^8.1.0",
+    "@testing-library/user-event": "^13.2.0",
     "@types/styled-components": "^5.1.11",
     "jest-environment-jsdom-sixteen": "^1.0.3"
   }

--- a/src/components/ContactPolicy/ContactPolicy.js
+++ b/src/components/ContactPolicy/ContactPolicy.js
@@ -183,7 +183,7 @@ export const ContactPolicy = InjectAppServices(
                 {({ values, errors, isSubmitting, isValid, dirty }) => (
                   <>
                     <Prompt when={dirty} message={_('common.unsaved_changes_message')} />
-                    <Form className="dp-contact-policy-form">
+                    <Form className="dp-contact-policy-form" aria-label="settings">
                       <fieldset>
                         <legend>{_('contact_policy.title')}</legend>
                         <FieldGroup>
@@ -204,6 +204,7 @@ export const ContactPolicy = InjectAppServices(
                                   id="contact-policy-input-amount"
                                   disabled={!values[fieldNames.active]}
                                   required
+                                  aria-label={_('common.emails')}
                                 />
                                 <span className="m-r-6">{_('common.emails')}</span>
                               </div>
@@ -215,6 +216,7 @@ export const ContactPolicy = InjectAppServices(
                                   id="contact-policy-input-interval"
                                   disabled={!values[fieldNames.active]}
                                   required
+                                  aria-label={_('contact_policy.interval_unit')}
                                 />
                                 <span>{_('contact_policy.interval_unit')}</span>
                               </div>

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -3,10 +3,10 @@ import React from 'react';
 export const Loading = ({ page }) => {
   if (page) {
     return (
-      <div className="wrapper-loading">
+      <div data-testid="wrapper-loading" className="wrapper-loading">
         <div className="loading-page" />
       </div>
     );
   }
-  return <div className="loading-box" />;
+  return <div data-testid="loading-box" className="loading-box" />;
 };

--- a/src/components/shared/ShowLikeFlash/ShowLikeFlash.test.js
+++ b/src/components/shared/ShowLikeFlash/ShowLikeFlash.test.js
@@ -7,19 +7,18 @@ import { successMessageDelay } from '../../../utils';
 
 describe('ShowLikeFlash component', () => {
   const children = <p data-testid="child">A child element</p>;
-  jest.useFakeTimers();
 
   it('should hide children elements after delay', () => {
     // Act
     render(<ShowLikeFlash delay={successMessageDelay}>{children}</ShowLikeFlash>);
     // Assert
     expect(screen.getByTestId('child')).toBeInTheDocument();
-    jest.advanceTimersByTime(successMessageDelay);
     waitForElementToBeRemoved(screen.getByTestId('child'));
   });
 
   it("shouldn't hide children elements if delay is not set", async () => {
     // Act
+    jest.useFakeTimers();
     render(<ShowLikeFlash>{children}</ShowLikeFlash>);
     // Assert
     expect(screen.getByTestId('child')).toBeInTheDocument();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,6 +2573,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.0.6":
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.6.tgz#9a992bc517e0c49f035938b8549719c2de40706b"
+  integrity sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@kunukn/react-collapse@^2.2.9":
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/@kunukn/react-collapse/-/react-collapse-2.2.9.tgz#89787666b25145d179b65c55fcd335af7fa8fb6d"
@@ -2948,6 +2959,20 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/dom@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.1.0.tgz#f8358b1883844ea569ba76b7e94582168df5370d"
+  integrity sha512-kmW9alndr19qd6DABzQ978zKQ+J65gU2Rzkl8hriIetPnwpesRaK4//jEQyYh8fEALmGhomD/LBQqt+o+DL95Q==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.6"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^5.14.1":
   version "5.14.1"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz#8501e16f1e55a55d675fe73eecee32cdaddb9766"
@@ -2981,6 +3006,13 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
+
+"@testing-library/user-event@^13.2.0":
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.2.0.tgz#8d63aaae1f5ec1d683d3afe57acd5f175f819f0f"
+  integrity sha512-wDEuKkkChNfA02Fpd9A39AXmdmxkvRcHyt/cK3WWiPAQTyMhcKFNM51aQgpEDJUcdj7uPsOaDEESoW/L1b2kZA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -3376,6 +3408,13 @@
   version "15.0.2"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.2.tgz#0bf292a0369493cee030e2e4f4ff84f5982b028d"
   integrity sha512-hFkuAp58M2xOc1QgJhkFrLMnqa8KWTFRTnzrI1zlEcOfg3DZ0eH3aPAo/N6QlVVu8E4KS4xD1jtEG3rdQYFmIg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3949,6 +3988,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
@@ -13991,6 +14035,16 @@ pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2:
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.6.tgz#ab770c47b2c6f893a21aefc57b75da63ef49a11f"
+  integrity sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==
+  dependencies:
+    "@jest/types" "^27.0.6"
+    ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 private@^0.1.8:


### PR DESCRIPTION
With the help of @jcamposmk, consulting the documentation of the [react testing library](https://testing-library.com) and analyzing some articles about the [author](https://kentcdodds.com/blog) of the library, we found some recommendations on tests, which may be useful. We would like to know your opinions on this.


- There is no need to call the [cleanup](https://testing-library.com/docs/react-testing-library/api/#cleanup) function as it is called automatically for Jest and other test frameworks.

- The use of [screen](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen) is recommended:
The benefit of using [screen](https://testing-library.com/docs/queries/about/#screen) is you no longer need to keep the render call destructure up-to-date as you add/remove the [queries](https://testing-library.com/docs/queries/about/#using-queries) you need. You only need to type screen. and let your editor's magic autocomplete take care of the rest.

   *_It seems like the returned object from the render function could be framework specific but the screen object will be framework agnostic, making your tests more resilient and consistent across projects._ 

- Wrapping things in [`act` unnecessarily](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#wrapping-things-in-act-unnecessarily). Some queries and functions are already wrapped in `act`

- Use [`*byRole`](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-byrole-most-of-the-time) most of the time: 
There's not much you can't get with this (if you can't, it's possible your UI is inaccessible).
[Queries priority](https://testing-library.com/docs/queries/about/#priority)

- Do not use `waitFor` to wait for items that can be queried with [`find*`](https://testing-library.com/docs/dom-testing-library/api-async#findby-queries)
   (`find*` queries use `waitFor` under the hood)

- Do not put [multiple assertions](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#having-multiple-assertions-in-a-single-waitfor-callback) in a single `waitFor` callback
By putting a single assertion, we can wait for the UI to settle to the state we want to assert on, and also fail faster if one of the assertions do end up failing.

- Use [@testing-library/user-event](https://testing-library.com/docs/ecosystem-user-event)
Is a [package](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-testing-libraryuser-event) that's built on top of `fireEvent`, but it provides several methods that resemble the user interactions more closely. It provides more advanced simulation of browser interactions than the built-in `fireEvent` method.

[Common mistakes](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)
[Cheatsheet](https://testing-library.com/docs/react-testing-library/cheatsheet)

Other changes:
- The [`data-testid`](https://testing-library.com/docs/queries/bytestid) attribute was added to the `Loading` component to [obtain the component](https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change#whats-with-the-data-testid-query) by this attribute and not by the name of the class. This way we make sure that the test keeps working no matter if the class name changes.
   **_In production_**: You can compile this attribute away with `babel-plugin-react-remove-properties`.

- The [aria-label](https://www.aditus.io/aria/aria-label) attribute was added to the form and the inputs fields to differentiate them by their role and [accessibility name](https://es.reactjs.org/docs/accessibility.html) 

[Using aria-label attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute)