### PR TITLE
refactor: add tag cloud component to big query

### DIFF
--- a/src/components/Integrations/BigQuery/ControlPanel/AuthorizationForm.js
+++ b/src/components/Integrations/BigQuery/ControlPanel/AuthorizationForm.js
@@ -1,117 +1,60 @@
-import React, { useState } from 'react';
-import { Formik, Field, Form, FieldArray } from 'formik';
+import React from 'react';
+import { Formik, Form } from 'formik';
 import { useIntl } from 'react-intl';
 import { validateEmail } from '../../../../validations';
+import { CloudTagField } from '../../../form-helpers/CloudTagField';
+import { FormattedMessage } from 'react-intl';
+import { SubmitButton } from '../../../form-helpers/form-helpers';
 
-export const AuthorizationForm = ({ emails }) => {
-  const [errorMessage, setErrorMessage] = useState('');
+const fieldNames = {
+  emails: 'emails',
+};
+
+export const AuthorizationForm = ({ emails, onSubmit }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
-  const initialValues = [...emails, ''];
 
-  const emailValidation = (value) => {
-    const validateEmailMessage = validateEmail(value);
-    // error message is set manually because formik's original error function doesn't with
-    // doppler error component
-    if (!value) {
-      setErrorMessage(_('big_query.plus_error_message_empty'));
-      return true;
-    }
-
-    if (validateEmailMessage) {
-      setErrorMessage(_(validateEmailMessage));
-      return true;
-    }
-
-    setErrorMessage('');
-    return false;
+  const _validateEmail = (value) => {
+    const errorKey = validateEmail(value);
+    return errorKey ? <FormattedMessage id={errorKey} /> : null;
   };
 
-  const addEmail = async (validateField, fieldName, callback, values) => {
-    const errors = await validateField(fieldName);
-    const tags = [...values.emails];
-    const tagToAdd = tags.pop();
+  const handleSubmit = async (values) => {
+    onSubmit(values);
+  };
 
-    if (!errors && callback) {
-      if (!tags.includes(tagToAdd)) {
-        setErrorMessage('');
-        callback();
-      } else {
-        setErrorMessage(_('big_query.plus_error_message_email_exists'));
-      }
-    }
+  const formikConfig = {
+    enableReinitialize: true,
+    initialValues: { [fieldNames.emails]: emails },
+    validateOnChange: false,
+    validateOnBlur: false,
+    onSubmit: handleSubmit,
   };
 
   return (
-    <Formik
-      enableReinitialize={true}
-      initialValues={{ emails: initialValues }}
-      validateOnChange={false}
-      validateOnBlur={false}
-    >
-      {({ values, validateField }) => (
-        <Form aria-label="form">
-          <ul className="field-group">
-            <FieldArray
-              name="emails"
-              render={(arrayHelpers) => {
-                const lastIndex = Math.max(0, values.emails.length - 1);
-                const fieldName = `emails.${lastIndex}`;
-                const isEmailEmpty = !values.emails[lastIndex];
-                return (
-                  <div>
-                    <li
-                      className={errorMessage !== '' ? 'field-item dp-error error' : 'field-item'}
-                    >
-                      {/* email input field and add button */}
-                      <div className="dp-rowflex p-b-32">
-                        <div className="col-md-8">
-                          <Field
-                            type="email"
-                            name={fieldName}
-                            // TODO: add items on enter event
-                            validate={!isEmailEmpty ? emailValidation : null}
-                          />
-                          <div className="wrapper-errors dp-message dp-error-form">
-                            <p>{errorMessage}</p>
-                          </div>
-                        </div>
-                        <div className="col-md-4">
-                          <button
-                            disabled={isEmailEmpty}
-                            type="button"
-                            onClick={() =>
-                              addEmail(
-                                validateField,
-                                fieldName,
-                                () => arrayHelpers.push(''),
-                                values,
-                              )
-                            }
-                            className="dp-button button-medium secondary-green"
-                          >
-                            {_('big_query.plus_button_add')}
-                          </button>
-                        </div>
-                      </div>
-                    </li>
-                    {values.emails?.length > 1 &&
-                      values.emails.slice(0, values.emails.length - 1).map((email, index) => (
-                        <div key={index} className="p-b-6 p-t-6">
-                          <span className="p-r-36">{email}</span>
-                          <button type="button" onClick={() => arrayHelpers.remove(index)}>
-                            {_('big_query.plus_button_remove')}
-                          </button>
-                        </div>
-                      ))}
-                    <div className="p-t-54 p-l-54 m-l-54"></div>
-                  </div>
-                );
-              }}
-            />
-          </ul>
-        </Form>
-      )}
+    <Formik {...formikConfig}>
+      <Form className="dp-add-tags" aria-label="form" noValidate>
+        <fieldset>
+          <legend>{_('big_query.add_permission_google_account')}</legend>
+          <CloudTagField
+            fieldName={fieldNames.emails}
+            validateTag={_validateEmail}
+            render={({ value, onChange, onKeyDown }) => (
+              <input
+                type="email"
+                placeholder={_('big_query.add_google_account')}
+                value={value}
+                onChange={onChange}
+                onKeyDown={onKeyDown}
+                className="dp--dashed"
+              />
+            )}
+          />
+        </fieldset>
+        <SubmitButton className="dp-button button-medium primary-green m-t-30">
+          {_('common.save')}
+        </SubmitButton>
+      </Form>
     </Formik>
   );
 };

--- a/src/components/Integrations/BigQuery/ControlPanel/AuthorizationPage.js
+++ b/src/components/Integrations/BigQuery/ControlPanel/AuthorizationPage.js
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { Loading } from '../../../Loading/Loading';
 import { AuthorizationForm } from './AuthorizationForm';
 import { InjectAppServices } from '../../../../services/pure-di';
+import useTimeout from '../../../../hooks/useTimeout';
 
 const AuthorizationLayout = ({ dependencies: { bigQueryClient } }) => {
-  const [data, setData] = useState(['']);
+  const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const createTimeout = useTimeout();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -19,14 +21,25 @@ const AuthorizationLayout = ({ dependencies: { bigQueryClient } }) => {
     fetchData();
   }, [bigQueryClient]);
 
+  const onSubmit = async (values) => {
+    // TODO: integrate actual implementation to save
+    await new Promise((resolve) => {
+      createTimeout(() => {
+        resolve(true);
+        alert('Sent: ' + JSON.stringify([...values.emails]));
+      }, 100);
+    });
+  };
+
   if (loading) {
-    return <Loading page></Loading>;
+    return <Loading page />;
   }
+
   return (
     <div className="dp-container">
       <div className="dp-rowflex p-t-48">
         <div className="col-lg-5">
-          <AuthorizationForm emails={data}></AuthorizationForm>
+          <AuthorizationForm emails={data} onSubmit={onSubmit} />
         </div>
       </div>
     </div>

--- a/src/components/form-helpers/CloudTagField/index.js
+++ b/src/components/form-helpers/CloudTagField/index.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { FieldArray, useFormikContext } from 'formik';
-import { combineValidations } from '../../../validations';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { CloudTags } from '../../CloudTags';

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -58,6 +58,8 @@ const messages_en = {
     volume_do_not_know: `I don't know`,
   },
   big_query: {
+    add_google_account: `Add google account`,
+    add_permission_google_account: `Add permission for Google accounts.`,
     free_alt_image: `big query`,
     free_btn_redirect: `Get to know our Plus plan`,
     free_text_data_studio_MD: `Learn to configure our dashboard [Data Studio in a few steps](https://datastudio.google.com/overview),

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -58,6 +58,8 @@ const messages_es = {
     volume_do_not_know: 'No lo sé',
   },
   big_query: {
+    add_google_account: `Agregar cuenta de Google`,
+    add_permission_google_account: `Agregar permiso para cuentas de Google.`,
     free_alt_image: `big query`,
     free_btn_redirect: `Conoce nuestro plan Plus`,
     free_text_data_studio_MD: `Aprende a configurar nuestro tablero de [Data Studio en unos pocos pasos](https://datastudio.google.com/overview),

--- a/src/services/big-query-client.double.ts
+++ b/src/services/big-query-client.double.ts
@@ -3,7 +3,13 @@ import { BigQueryClient, EmailList } from './big-query-client';
 import { timeout } from '../utils';
 
 const result = {
-  emails: ['email1@gmail.com', 'email2@gmail.com', 'email3@gmail.com'],
+  emails: [
+    'allanwatts@gmail.com',
+    'mdirago@gmail.com',
+    'casco@gmail.com',
+    'carlos-sampedro@gmail.com',
+    'jose_luis_alvarez_arguelles@gmail.com',
+  ],
 };
 
 export class HardcodedBigQueryClient implements BigQueryClient {


### PR DESCRIPTION
### **Add tag cloud component to big query**

**scenario:** 

- the user navigate to /integrations/big-query/plus
- the user can see the authorization form for google account
- the user adds tag with enter event or click to the + button
- when the user add invalid tag (no email) shown error message
- when the user add tag valid but the tag already exist, shown error message
- when the user submit form, shown alert with sent data

![image](https://user-images.githubusercontent.com/84402180/126811985-d9dc735d-d665-4d63-909c-24013fc81987.png)

tests: 
![image](https://user-images.githubusercontent.com/84402180/126812027-1775e9e3-1d31-436f-863c-f4978999effd.png)
