### PR TITLE
fix: [DAT-516] Fix button text of upgrade popup

### DIFF
--- a/src/components/UpgradePlanForm/UpgradePlanForm.js
+++ b/src/components/UpgradePlanForm/UpgradePlanForm.js
@@ -21,8 +21,8 @@ const getAvailablePlans = (userPlan, availablePlans) =>
 
 const getAmmountSubscribers = (availablePlans, selectedPlanId, isSubscriber) =>
   isSubscriber
-    ? availablePlans.find((p) => p.IdUserTypePlan == selectedPlanId).SubscribersQty
-    : availablePlans.find((p) => p.IdUserTypePlan == selectedPlanId).EmailQty;
+    ? availablePlans.find((p) => p.IdUserTypePlan === selectedPlanId).SubscribersQty
+    : availablePlans.find((p) => p.IdUserTypePlan === selectedPlanId).EmailQty;
 
 /** @type { import('../../services/doppler-legacy-client').DopplerLegacyClient } */
 const UpgradePlanForm = ({
@@ -70,7 +70,7 @@ const UpgradePlanForm = ({
       setAmountSubscribers(
         getAmmountSubscribers(
           state.availablePlans,
-          values[fieldNames.selectedPlanId],
+          parseInt(values[fieldNames.selectedPlanId]),
           isSubscriber,
         ),
       );
@@ -171,7 +171,7 @@ const UpgradePlanForm = ({
                   <FormattedMessage id="common.cancel" />
                 </button>
                 <SubmitButton>
-                  <FormattedMessage id="common.send" />
+                  <FormattedMessage id="upgradePlanForm.update" />
                 </SubmitButton>
               </div>
             ) : (

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -629,6 +629,7 @@ deletion, security, cross-border data transfers and other issues.
     message_placeholder: `Your message`,
     plan_select: `Select Plan`,
     title: `Request an update of your Plan`,
+    update: `Update Plan`,
   },
   upgrade_suggestion_form: {
     breadcrumb: 'Plans',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -630,6 +630,7 @@ eliminación, seguridad, transferencias transfronterizas y otros temas.
     message_placeholder: `Tu mensaje`,
     plan_select: `Selecciona el Plan`,
     title: `Solicita una actualización de tu Plan`,
+    update: `Actualizar Plan`,
   },
   upgrade_suggestion_form: {
     breadcrumb: 'Planes',


### PR DESCRIPTION
# Background

- Change of text button "Send" by "Update Plan" in Spanish "Enviar" by "Actualizar Plan",
- Additionally, I parsed string by int in PlanTypeId when the users Update the plan
Example:
![image](https://user-images.githubusercontent.com/6796523/127327191-6c308aa1-823a-4c25-b5b2-5091ab32e89c.png)
