### PR TITLE
feat: add after remove callback (optional)

### DIFF
--- a/src/components/CloudTags/index.js
+++ b/src/components/CloudTags/index.js
@@ -13,30 +13,37 @@ RemoveButton.propTypes = {
 };
 
 // CloudTags component
-export const CloudTags = ({ tags, remove, disabled, render }) => (
-  <ul
-    className={classNames({
-      'dp-cloud-tags': true,
-      'dp-overlay': disabled,
-    })}
-    aria-label="cloud tags"
-  >
-    {tags.map((tag, index) => (
-      <li key={`tag-${index}`}>
-        <span
-          className={classNames({
-            'dp-tag': true,
-            'dp-recently-add': index + 1 === tags.length,
-          })}
-        >
-          {tag}
-          <RemoveButton removeTag={() => remove(index)} />
-        </span>
-      </li>
-    ))}
-    {render && <li>{render()}</li>}
-  </ul>
-);
+export const CloudTags = ({ tags, remove, afterRemove, disabled, render }) => {
+  const removeTag = (index) => {
+    remove(index);
+    afterRemove && afterRemove(index);
+  };
+
+  return (
+    <ul
+      className={classNames({
+        'dp-cloud-tags': true,
+        'dp-overlay': disabled,
+      })}
+      aria-label="cloud tags"
+    >
+      {tags.map((tag, index) => (
+        <li key={`tag-${index}`}>
+          <span
+            className={classNames({
+              'dp-tag': true,
+              'dp-recently-add': index + 1 === tags.length,
+            })}
+          >
+            {tag}
+            <RemoveButton removeTag={() => removeTag(index)} />
+          </span>
+        </li>
+      ))}
+      {render && <li>{render()}</li>}
+    </ul>
+  );
+};
 CloudTags.propTypes = {
   tags: PropTypes.array.isRequired,
   remove: PropTypes.func.isRequired,

--- a/src/components/form-helpers/CloudTagCompoundField/index.js
+++ b/src/components/form-helpers/CloudTagCompoundField/index.js
@@ -13,6 +13,7 @@ export const CloudTagCompoundField = ({
   disabled,
   messageKeys,
   render,
+  afterRemove,
 }) => {
   const { getAllTags, validateTagToAdd, addTag } = useCloudTags(
     fieldName,
@@ -34,6 +35,7 @@ export const CloudTagCompoundField = ({
           <CloudTags
             tags={tags}
             remove={remove}
+            afterRemove={afterRemove}
             disabled={disabled}
             render={() => render(_addTag)}
           />
@@ -47,6 +49,7 @@ CloudTagCompoundField.propTypes = {
   labelKey: PropTypes.string.isRequired,
   max: PropTypes.number,
   disabled: PropTypes.bool,
+  afterRemove: PropTypes.func,
   messageKeys: PropTypes.shape({
     tagAlreadyExist: PropTypes.string,
     tag_limit_exceeded: PropTypes.string,

--- a/src/components/form-helpers/CloudTagCompoundField/index.test.js
+++ b/src/components/form-helpers/CloudTagCompoundField/index.test.js
@@ -22,14 +22,16 @@ describe('CloudTagCompoundField component', () => {
   it('should add a tag when the add button is clicked and show error if it already exists', async () => {
     // Arrange
     const labelKey = 'name';
+    const index = 1;
     const fieldName = 'subscribers';
     const tagToAdd = { id: 1, [labelKey]: 'subscriber_x' };
-    const initialValues = [
+    let initialValues = [
       { id: 1, [labelKey]: 'subscriber_1' },
       { id: 2, [labelKey]: 'subscriber_2' },
     ];
     const max = 4;
     const buttonText = 'add list';
+    const afterRemove = jest.fn((removedTag) => removedTag);
     const onSubmit = jest.fn();
 
     const WrapperComponent = ({ handleSubmit }) => {
@@ -47,6 +49,7 @@ describe('CloudTagCompoundField component', () => {
                 <CloudTagCompoundField
                   fieldName={fieldName}
                   labelKey={labelKey}
+                  afterRemove={afterRemove}
                   max={max}
                   render={(addTag) => (
                     <button
@@ -95,6 +98,13 @@ describe('CloudTagCompoundField component', () => {
     // the tag was not added. The number of tags is maintained
     expect(addedTags.length - 1).toBe(initialValues.length + 1);
 
+    // simulate remove tag
+    const removeButton = addedTags[index].querySelector('button.dp-remove-tag');
+    await fireEvent.click(removeButton);
+    expect(screen.getByRole('list')).not.toHaveTextContent(initialValues[index][labelKey]);
+    expect(afterRemove).toHaveBeenCalledTimes(1);
+    expect(afterRemove).toHaveBeenCalledWith(index);
+
     // simulate submit form
     const submitButton = screen.getByRole('button', { name: 'Save' });
     await fireEvent.click(submitButton);
@@ -102,6 +112,7 @@ describe('CloudTagCompoundField component', () => {
     await waitForElementToBeRemoved(screen.getByRole('alert'));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
+    initialValues.splice(index, 1); // because the element at the 'index' position was removed
     expect(onSubmit).toHaveBeenCalledWith({
       [fieldName]: [...initialValues, tagToAdd], // because only one tag was added
     });


### PR DESCRIPTION
### **Add callback to CloudTag component**
task: https://makingsense.atlassian.net/browse/DW-1094

**Description**
When `CloudTagCompoundField` component is used, can be passed as prop a callback afterRemove function. 