### PR TITLE
feat(CI): add warning as errors in build

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,4 @@ REACT_APP_DOPPLER_UI_LIBRARY_VERSION = v3.101.7
 REACT_APP_DATA_HUB_URL= https://hub.fromdoppler.com
 REACT_APP_MANUAL_STATUS_ENABLED=false
 REACT_APP_MANUAL_STATUS_FILE_URL = https://cdn.fromdoppler.com/webapp-status.json
+CI=true

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -1,6 +1,7 @@
-// eslint-disable-next-line
+/* eslint-disable */
 const emailRegex =
   /^\s*((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\s*$/i;
+/* eslint-enable */
 const nameRegex = /^[\u00C0-\u1FFF\u2C00-\uD7FF\w][\u00C0-\u1FFF\u2C00-\uD7FF\w'`\-. ]+$/i;
 const accentRegex = /[\u00C0-\u00FF]/i;
 


### PR DESCRIPTION
### Treat warnings as errors
We have a lot of people commiting in this proyect, and they are not checking the warnings so I think this is a good solution.
For command `yarn build` only, warnings will be treated as errors. 

![image](https://user-images.githubusercontent.com/2439363/130076307-37d3df31-275f-4a57-bdc5-e94cf8a1952a.png)

https://create-react-app.dev/docs/advanced-configuration/

![image](https://user-images.githubusercontent.com/2439363/130076651-9756271a-ab5d-40d5-bd1f-2fe8efeb01e6.png)
