### PR TITLE
chore: add husky into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 /.vscode
 /.eslintcache
 .idea
+/.husky/


### PR DESCRIPTION
### Add husky folder into gitignore

This is only for local use, so we should not upload anything from this folder. 
@jcamposmk is it ok this way? You are the expert in this 😄 

![image](https://user-images.githubusercontent.com/2439363/130137201-f2e18c0b-d40d-4ded-a682-7e0e317c4bd2.png)
