### PR TITLE
fix(HeaderUserMenu): fix upgrade link when the user has a prepaid plan

### DIFF
--- a/src/components/Header/HeaderUserMenu/HeaderUserMenu.js
+++ b/src/components/Header/HeaderUserMenu/HeaderUserMenu.js
@@ -48,7 +48,14 @@ const HeaderUserMenu = ({ user }) => {
                 )}
               </>
             ) : !user.hasClientManager ? (
-              <p className="user-plan--monthly-text">{_('header.plan_prepaid')}</p>
+              <>
+                <p className="user-plan--monthly-text">{_('header.plan_prepaid')}</p>
+                {user.plan.buttonUrl && !user.plan.pendingFreeUpgrade && (
+                  <a className="user-plan" href={user.plan.buttonUrl}>
+                    {user.plan.buttonText}
+                  </a>
+                )}
+              </>
             ) : (
               ''
             )}

--- a/src/components/Header/HeaderUserMenu/HeaderUserMenu.test.js
+++ b/src/components/Header/HeaderUserMenu/HeaderUserMenu.test.js
@@ -74,6 +74,32 @@ describe('Header user menu', () => {
     expect(getByText('upgrade')).toBeInTheDocument();
   });
 
+  it('should render a button if the plan has buttonText and buttonUrl properties', () => {
+    // Arrange
+    userData = {
+      ...userData,
+      plan: {
+        remainingCredits: 200000,
+        description: 'Remaining Credits',
+        buttonText: 'upgrade',
+        buttonUrl: 'https://link-to-upgrade.com',
+      },
+    };
+
+    // Act
+    const { getByText } = render(
+      <IntlProvider>
+        <HeaderUserMenu user={userData} />
+      </IntlProvider>,
+    );
+
+    // Assert
+    const upgradeLink = getByText('upgrade');
+    expect(getByText(userData.plan.description)).toBeInTheDocument();
+    expect(upgradeLink).toBeInTheDocument();
+    expect(upgradeLink).toHaveAttribute('href', userData.plan.buttonUrl);
+  });
+
   it('user is clienManager', () => {
     // Arrange
     userData = {


### PR DESCRIPTION
### Fix upgrade link visibility when the user has a prepaid plan
task: https://makingsense.atlassian.net/browse/DW-1145

**scenario:** 

- the user has a prepaid plan
- the user opens the user dropdown 
- the user sees the text "Prepaid Plan" together with the upgrade link

**Before:** 

![image](https://user-images.githubusercontent.com/84402180/132547745-91dc5dc4-7f34-404f-b1de-68f4a1ca41f2.png)

**After:**

![image](https://user-images.githubusercontent.com/84402180/132547823-bd1a2d47-0abf-4bfa-9148-ffe7161a4810.png)
