### PR TITLE
DW-1134-fix-monthly-deliveries-plan-tabs

### DIFF
--- a/src/services/plan-service.test.js
+++ b/src/services/plan-service.test.js
@@ -260,7 +260,7 @@ describe('Doppler plan client', () => {
     var types = planService.getPlanTypes(currentPlan, 'standard', planList);
 
     // Assert
-    expect(types.length).toBe(2);
+    expect(types.length).toBe(1);
   });
 
   it('should get correct plans for free user - selected path plus, type subscribers', async () => {
@@ -334,7 +334,7 @@ describe('Doppler plan client', () => {
     expect(plans.length).toBeGreaterThan(0);
   });
 
-  it('should get higher subscriber plans when user type: monthly-deliveries', async () => {
+  it('should get no subscriber plans when user type: monthly-deliveries', async () => {
     // Arrange
     const currentPlan = {
       type: 'monthly-deliveries',
@@ -351,7 +351,7 @@ describe('Doppler plan client', () => {
     const plans = await planService.getPlans(currentPlan, 'standard', 'subscribers', planList);
 
     // Assert
-    expect(plans.length).toBe(2);
+    expect(plans.length).toBe(0);
   });
 
   it('should get plansfor subscriber user - selected path standard and type monthly', () => {

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -176,7 +176,6 @@ const getPotentialUpgrades = (userPlan: Plan, planList: Plan[]): Plan[] => {
           minFee: userPlan.fee,
           minEmailsByMonth: userPlan.emailsByMonth,
         }),
-        ...getUpgradeSubscribersPlans(planList),
       ];
       break;
 


### PR DESCRIPTION
## Modifications : https://makingsense.atlassian.net/browse/DW-1134
* fix(plan-service): Fix monthly deliveries tabs. Do not show Subscribers tab.

![image](https://user-images.githubusercontent.com/21247095/132583720-3146eb63-3227-40c2-8a86-f9ea31327a4b.png)
