### PR TITLE
feat(plans): add currentSubscription filtering

### DIFF
--- a/src/components/ChangePlan/ChangePlan.js
+++ b/src/components/ChangePlan/ChangePlan.js
@@ -244,6 +244,7 @@ const ChangePlan = ({ location, dependencies: { planService, appSessionRef } }) 
       const currentPlan = planService.mapCurrentPlanFromTypeOrId(
         sessionPlan.planType,
         sessionPlan.idPlan,
+        sessionPlan.planSubscription,
         planList,
       );
       const pathList = await planService.getPaths(currentPlan, planList);

--- a/src/components/ChangePlan/PlanCalculator/PlanCalculator.js
+++ b/src/components/ChangePlan/PlanCalculator/PlanCalculator.js
@@ -81,6 +81,7 @@ const PlanCalculator = ({ location, dependencies: { planService, appSessionRef }
       const currentPlan = planService.mapCurrentPlanFromTypeOrId(
         sessionPlan.planType,
         sessionPlan.idPlan,
+        sessionPlan.planSubscription,
         planList,
       );
       const planTypes = planService.getPlanTypes(currentPlan, pathType, planList);

--- a/src/components/ChangePlan/PlanCalculator/PlanCalculator.test.js
+++ b/src/components/ChangePlan/PlanCalculator/PlanCalculator.test.js
@@ -15,7 +15,7 @@ describe('PlanCalculator component', () => {
       current: {
         userData: {
           user: {
-            plan: {},
+            plan: { planSubscription: 1 },
           },
         },
       },

--- a/src/doppler-types.ts
+++ b/src/doppler-types.ts
@@ -50,6 +50,7 @@ export interface SubscribersLimitedPlan {
   featureSet: 'standard' | 'plus';
   featureList: Features[];
   billingCycleDetails: AdvancePayOptions[];
+  currentSubscription: number;
 }
 
 export interface MonthlyRenewalDeliveriesPlan {

--- a/src/services/plan-service.test.js
+++ b/src/services/plan-service.test.js
@@ -234,6 +234,7 @@ describe('Doppler plan client', () => {
       fee: 32,
       featureSet: 'standard',
       featureList: [],
+      currentSubscription: 1,
     };
 
     // Act
@@ -241,6 +242,26 @@ describe('Doppler plan client', () => {
 
     // Assert
     expect(types.length).toBe(2);
+  });
+
+  it('should get correct types for subscriber user - standard subscription > 1 month', () => {
+    // Arrange
+    const currentPlan = {
+      type: 'subscribers',
+      id: 20,
+      name: '2500-SUBSCRIBERS-STANDARD',
+      subscriberLimit: 2500,
+      fee: 32,
+      featureSet: 'standard',
+      featureList: [],
+      currentSubscription: 3,
+    };
+
+    // Act
+    var types = planService.getPlanTypes(currentPlan, 'standard', planList);
+
+    // Assert
+    expect(types.length).toBe(1);
   });
 
   it('should get correct types for monthly user - selected path standard', () => {
@@ -354,7 +375,7 @@ describe('Doppler plan client', () => {
     expect(plans.length).toBe(0);
   });
 
-  it('should get plansfor subscriber user - selected path standard and type monthly', () => {
+  it('should get plans for subscriber user - selected path standard and type monthly', () => {
     // Arrange
     const currentPlan = {
       type: 'subscribers',
@@ -364,6 +385,7 @@ describe('Doppler plan client', () => {
       fee: 32,
       featureSet: 'standard',
       featureList: [],
+      currentSubscription: 1,
     };
 
     // Act

--- a/src/services/plan-service.test.js
+++ b/src/services/plan-service.test.js
@@ -101,7 +101,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var paths = await planService.getPaths(currentPlan, planList);
+    const paths = await planService.getPaths(currentPlan, planList);
 
     // Assert
     expect(paths.length).toBe(4);
@@ -121,7 +121,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var paths = await planService.getPaths(currentPlan, planList);
+    const paths = await planService.getPaths(currentPlan, planList);
 
     // Assert
     expect(paths.length).toBe(3);
@@ -144,7 +144,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var paths = await planService.getPaths(currentPlan, planList);
+    const paths = await planService.getPaths(currentPlan, planList);
     // Assert
     expect(paths.length).toBe(3);
     expect(paths[0].current).toBe(true);
@@ -166,7 +166,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var paths = await planService.getPaths(currentPlan, planList);
+    const paths = await planService.getPaths(currentPlan, planList);
 
     // Assert
     expect(paths.length).toBe(2);
@@ -185,7 +185,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var types = await planService.getPlanTypes(currentPlan, 'standard', planList);
+    const types = await planService.getPlanTypes(currentPlan, 'standard', planList);
 
     // Assert
     expect(types.length).toBe(3);
@@ -200,7 +200,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var types = await planService.getPlanTypes(currentPlan, 'plus', planList);
+    const types = await planService.getPlanTypes(currentPlan, 'plus', planList);
 
     // Assert
     expect(types.length).toBe(2);
@@ -218,7 +218,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var types = await planService.getPlanTypes(currentPlan, 'standard', planList);
+    const types = await planService.getPlanTypes(currentPlan, 'standard', planList);
 
     // Assert
     expect(types.length).toBe(3);
@@ -238,7 +238,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var types = planService.getPlanTypes(currentPlan, 'standard', planList);
+    const types = planService.getPlanTypes(currentPlan, 'standard', planList);
 
     // Assert
     expect(types.length).toBe(2);
@@ -258,7 +258,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var types = planService.getPlanTypes(currentPlan, 'standard', planList);
+    const types = planService.getPlanTypes(currentPlan, 'standard', planList);
 
     // Assert
     expect(types.length).toBe(1);
@@ -278,7 +278,7 @@ describe('Doppler plan client', () => {
     };
 
     // Act
-    var types = planService.getPlanTypes(currentPlan, 'standard', planList);
+    const types = planService.getPlanTypes(currentPlan, 'standard', planList);
 
     // Assert
     expect(types.length).toBe(1);


### PR DESCRIPTION
### Contact plans with a subscription greater than 1 month

These planes are not allowed to buy an email plan. 

Contact plan with a monthly subscription will see in plan calculator: Contact and Email tabs

Contact plan with a tree months subscription will see in plan calculator: Contact tab only. 

DW-1138