### PR TITLE
refactor: fix spinner on reports page

### DIFF
--- a/src/components/Reports/Reports.js
+++ b/src/components/Reports/Reports.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Helmet } from 'react-helmet';
 import { InjectAppServices } from '../../services/pure-di';
-import { Loading } from '../Loading/Loading';
 import { BoxMessage } from '../styles/messages';
 import { addDays, getStartOfDate } from '../../utils';
 import ReportsFilters from './ReportsFilters/ReportsFilters';
@@ -35,7 +34,7 @@ const Reports = ({ dependencies: { datahubClient } }) => {
     dailyView: periodSelectedDaysDefault === 1,
   });
 
-  const [totalVisits, setTotalVisits] = useState({});
+  const [totalVisits, setTotalVisits] = useState({ loading: true });
 
   const changeDomain = async (name) => {
     const domainFound = state.domains.find((item) => item.name === name);
@@ -113,11 +112,9 @@ const Reports = ({ dependencies: { datahubClient } }) => {
             changePeriod={changePeriod}
             isEnableWeeks
           />
-          {state.loading ? (
-            <Loading />
-          ) : state.domains ? (
+          {state.loading || (!state.loading && state.domains) ? (
             <section className="dp-container">
-              {!state.domainSelected.verified_date ? (
+              {state.domainSelected && !state.domainSelected.verified_date ? (
                 <BoxMessage className="dp-msj-error bounceIn" spaceTopBottom>
                   <span>
                     <FormattedMessageMarkdown id="reports_filters.domain_not_verified_MD" />
@@ -132,7 +129,7 @@ const Reports = ({ dependencies: { datahubClient } }) => {
                     today={state.dailyView}
                     emailFilter={'without_email'}
                     visits={totalVisits.withoutEmail}
-                    loading={totalVisits.loading}
+                    loading={state.loading || totalVisits.loading}
                   />
                 </div>
                 <div className="col-lg-6 col-md-6 col-sm-12 m-b-24">
@@ -142,13 +139,13 @@ const Reports = ({ dependencies: { datahubClient } }) => {
                     today={state.dailyView}
                     emailFilter={'with_email'}
                     visits={totalVisits.withEmail}
-                    loading={totalVisits.loading}
+                    loading={state.loading || totalVisits.loading}
                   />
                 </div>
                 {!state.dailyView ? (
                   <div className="col-sm-12 m-b-24">
                     <ReportsDailyVisits
-                      domainName={state.domainSelected.name}
+                      domainName={state.domainSelected?.name}
                       dateFrom={state.dateFrom}
                       dateTo={state.dateTo}
                     />
@@ -156,7 +153,7 @@ const Reports = ({ dependencies: { datahubClient } }) => {
                 ) : null}
                 <div className="col-sm-12 m-b-24">
                   <ReportsTrafficSources
-                    domainName={state.domainSelected.name}
+                    domainName={state.domainSelected?.name}
                     dateFrom={state.dateFrom}
                     dateTo={state.dateTo}
                   />
@@ -164,7 +161,7 @@ const Reports = ({ dependencies: { datahubClient } }) => {
                 {!state.dailyView ? (
                   <div className="col-sm-12 m-b-24">
                     <ReportsHoursVisits
-                      domainName={state.domainSelected.name}
+                      domainName={state.domainSelected?.name}
                       dateTo={state.dateTo}
                       dateFrom={state.dateFrom}
                     />
@@ -172,7 +169,7 @@ const Reports = ({ dependencies: { datahubClient } }) => {
                 ) : null}
                 <div className="col-sm-12 m-b-24">
                   <ReportsPageRanking
-                    domainName={state.domainSelected.name}
+                    domainName={state.domainSelected?.name}
                     dateTo={state.dateTo}
                     dateFrom={state.dateFrom}
                   />

--- a/src/components/Reports/Reports.test.js
+++ b/src/components/Reports/Reports.test.js
@@ -12,17 +12,25 @@ describe('Reports page', () => {
     // Arrange
     const datahubClientDouble = {
       getAccountDomains: async () => [],
+      getTotalVisitsOfPeriod: async () => 0,
+      getTrafficSourcesByPeriod: async () => [],
+      getVisitsQuantitySummarizedByDay: async () => [],
+      getVisitsQuantitySummarizedByWeekdayAndHour: async () => [],
+      getPagesRankingByPeriod: async () => [],
     };
+
     // Act
     const { getByText } = render(
-      <DopplerIntlProvider>
-        <Reports
-          dependencies={{
-            datahubClient: datahubClientDouble,
-            appConfiguration: { dopplerLegacyUrl: 'http://test.localhost' },
-          }}
-        />
-      </DopplerIntlProvider>,
+      <AppServicesProvider
+        forcedServices={{
+          datahubClient: datahubClientDouble,
+        }}
+      >
+        <DopplerIntlProvider>
+          <Reports />
+        </DopplerIntlProvider>
+        ,
+      </AppServicesProvider>,
     );
 
     // Assert
@@ -35,17 +43,23 @@ describe('Reports page', () => {
       getAccountDomains: async () => {
         return { success: false };
       },
+      getTotalVisitsOfPeriod: async () => 0,
+      getTrafficSourcesByPeriod: async () => [],
+      getVisitsQuantitySummarizedByDay: async () => [],
+      getVisitsQuantitySummarizedByWeekdayAndHour: async () => [],
+      getPagesRankingByPeriod: async () => [],
     };
     // Act
     const { getByText } = render(
-      <DopplerIntlProvider>
-        <Reports
-          dependencies={{
-            datahubClient: datahubClientDouble,
-            appConfiguration: { dopplerLegacyUrl: 'http://test.localhost' },
-          }}
-        />
-      </DopplerIntlProvider>,
+      <AppServicesProvider
+        forcedServices={{
+          datahubClient: datahubClientDouble,
+        }}
+      >
+        <DopplerIntlProvider>
+          <Reports />
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
     );
 
     // Assert
@@ -73,7 +87,7 @@ describe('Reports page', () => {
     };
 
     // Act
-    const { getByText, container } = render(
+    const { queryByText } = render(
       <AppServicesProvider
         forcedServices={{
           datahubClient: datahubClientDouble,
@@ -87,8 +101,7 @@ describe('Reports page', () => {
     );
 
     // Assert
-    expect(container.querySelectorAll('.loading-box')).toHaveLength(1);
-    await waitFor(() => expect(getByText('reports_filters.domain_not_verified_MD')));
+    await waitFor(() => expect(queryByText('reports_filters.domain_not_verified_MD')));
   });
 
   it('should show "no domains" message when the domain list is empty', async () => {
@@ -99,10 +112,13 @@ describe('Reports page', () => {
       },
       getTotalVisitsOfPeriod: async () => 0,
       getTrafficSourcesByPeriod: async () => [],
+      getVisitsQuantitySummarizedByDay: async () => [],
+      getVisitsQuantitySummarizedByWeekdayAndHour: async () => [],
+      getPagesRankingByPeriod: async () => [],
     };
 
     // Act
-    const { container, getByText } = render(
+    const { container, findByText } = render(
       <AppServicesProvider
         forcedServices={{
           datahubClient: datahubClientDouble,
@@ -114,10 +130,9 @@ describe('Reports page', () => {
         </DopplerIntlProvider>
       </AppServicesProvider>,
     );
-    expect(container.querySelectorAll('.loading-box')).toHaveLength(1);
 
     // Assert
     await waitFor(() => expect(container.querySelectorAll('.loading-box')).toHaveLength(0));
-    getByText('reports.no_domains_MD');
+    expect(await findByText('reports.no_domains_MD')).toBeInTheDocument();
   });
 });

--- a/src/components/Reports/ReportsBox/ReportsBox.js
+++ b/src/components/Reports/ReportsBox/ReportsBox.js
@@ -8,38 +8,31 @@ import { Loading } from '../../Loading/Loading';
  * @param { import('../../../services/pure-di').AppServices } props.dependencies
  */
 const ReportsBox = ({ dateFrom, dateTo, emailFilter, today, visits, loading }) => {
+  const withEmail = 'with_email' === emailFilter;
+  const totalVisits = visits ?? 0;
+  const descriptionKey = withEmail
+    ? 'reports_box.visits_description_with_email'
+    : 'reports_box.visits_description_without_emails';
+  const titleKey = withEmail
+    ? 'reports_box.visits_with_email'
+    : 'reports_box.visits_without_emails';
+
   return (
     <div className={visits === 0 ? 'dp-box-shadow warning--kpi' : 'dp-box-shadow'}>
-      {loading ? (
-        <Loading />
-      ) : emailFilter === 'with_email' ? (
+      {loading && <Loading />}
+      {['with_email', 'without_email'].includes(emailFilter) ? (
         <>
           <div className="box-border--bottom">
-            <h3 className="number-kpi">{visits}</h3>
+            <h3 className="number-kpi">{totalVisits}</h3>
             <h6>
-              <FormattedMessage id="reports_box.visits_with_email" />
+              <FormattedMessage id={titleKey} />
             </h6>
             <small className="date-range">
               <FormattedDateRangeText dateFrom={dateFrom} dateTo={dateTo} today={today} />
             </small>
           </div>
           <p className="text-kpi">
-            <FormattedMessage id="reports_box.visits_description_with_email" />
-          </p>
-        </>
-      ) : emailFilter === 'without_email' ? (
-        <>
-          <div className="box-border--bottom">
-            <h3 className="number-kpi">{visits}</h3>
-            <h6>
-              <FormattedMessage id="reports_box.visits_without_emails" />
-            </h6>
-            <small className="date-range">
-              <FormattedDateRangeText dateFrom={dateFrom} dateTo={dateTo} today={today} />
-            </small>
-          </div>
-          <p className="text-kpi">
-            <FormattedMessage id="reports_box.visits_description_without_emails" />
+            <FormattedMessage id={descriptionKey} />
           </p>
         </>
       ) : (

--- a/src/components/Reports/ReportsBox/ReportsBox.test.js
+++ b/src/components/Reports/ReportsBox/ReportsBox.test.js
@@ -17,7 +17,7 @@ describe('ReportsBox component', () => {
     const loading = true;
 
     // Act
-    const { container } = render(
+    const { container, getByText, getByRole } = render(
       <DopplerIntlProvider>
         <ReportsBox
           dateFrom={dateFrom}
@@ -32,6 +32,8 @@ describe('ReportsBox component', () => {
 
     // Assert
     expect(container.querySelector('.loading-box')).toBeInTheDocument();
+    expect(getByText('reports_box.visits_with_email')).toBeInTheDocument();
+    expect(getByRole('heading', { name: 0 })).toBeInTheDocument();
   });
 
   it('should show visits 0 and warning when dont have visits', () => {

--- a/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
+++ b/src/components/Reports/ReportsDailyVisits/ReportsDailyVisits.js
@@ -90,34 +90,36 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dateTo, dependencies: { data
   });
 
   useEffect(() => {
-    const fetchData = async () => {
-      setState({ loading: true });
-      const dailyVisitsData = await datahubClient.getVisitsQuantitySummarizedByDay({
-        domainName: domainName,
-        dateFrom: dateFrom,
-        dateTo: dateTo,
-      });
-      if (!dailyVisitsData.success) {
-        setState({ loading: false });
-      } else {
-        setState({
-          loading: false,
-          chartData: {
-            json: dailyVisitsData.value,
-            keys: {
-              x: 'from',
-              value: ['qVisitors', 'qVisitorsWithEmail', 'qVisitorsWithOutEmail'],
-            },
-            classes: {
-              qVisitorsWithEmail: 'hide-graph',
-              qVisitorsWithOutEmail: 'hide-graph',
-            },
-          },
+    if (domainName) {
+      const fetchData = async () => {
+        setState({ loading: true });
+        const dailyVisitsData = await datahubClient.getVisitsQuantitySummarizedByDay({
+          domainName: domainName,
+          dateFrom: dateFrom,
+          dateTo: dateTo,
         });
-      }
-    };
+        if (!dailyVisitsData.success) {
+          setState({ loading: false });
+        } else {
+          setState({
+            loading: false,
+            chartData: {
+              json: dailyVisitsData.value,
+              keys: {
+                x: 'from',
+                value: ['qVisitors', 'qVisitorsWithEmail', 'qVisitorsWithOutEmail'],
+              },
+              classes: {
+                qVisitorsWithEmail: 'hide-graph',
+                qVisitorsWithOutEmail: 'hide-graph',
+              },
+            },
+          });
+        }
+      };
 
-    fetchData();
+      fetchData();
+    }
   }, [datahubClient, dateFrom, dateTo, domainName]);
 
   return (
@@ -127,9 +129,8 @@ const ReportsDailyVisits = ({ domainName, dateFrom, dateTo, dependencies: { data
           <FormattedMessage id="reports_daily_visits.title" />
         </h6>
       </div>
-      {state.loading ? (
-        <Loading />
-      ) : !state.chartData ? (
+      {state.loading && <Loading />}
+      {!state.loading && !state.chartData ? (
         <p className="dp-boxshadow--error bounceIn">
           <FormattedMessage id="common.unexpected_error" />
         </p>

--- a/src/components/Reports/ReportsFilters/ReportsFilters.js
+++ b/src/components/Reports/ReportsFilters/ReportsFilters.js
@@ -4,6 +4,8 @@ import * as S from './ReportsFilters.styles';
 import { FormattedMessageMarkdown } from '../../../i18n/FormattedMessageMarkdown';
 import HeaderSection from '../../shared/HeaderSection/HeaderSection';
 
+export const placeholderDate = '--/--/----';
+
 const ReportsFilters = ({
   domains,
   domainSelected,
@@ -41,18 +43,24 @@ const ReportsFilters = ({
                     </option>
                   ))}
               </select>
-              {domainSelected ? (
-                <S.DropdownLegend>
-                  {domainSelected.verified_date ? (
-                    <>
-                      <FormattedMessage id="reports_filters.verified_domain" />{' '}
-                      <span>
+              <S.DropdownLegend>
+                <span>
+                  {domainSelected ? (
+                    domainSelected.verified_date ? (
+                      <>
+                        <FormattedMessage id="reports_filters.verified_domain" />{' '}
                         <FormattedDate value={domainSelected.verified_date} />
-                      </span>
+                      </>
+                    ) : (
+                      <FormattedMessage id="reports_filters.no_information" />
+                    )
+                  ) : (
+                    <>
+                      <FormattedMessage id="reports_filters.verified_domain" /> {placeholderDate}
                     </>
-                  ) : null}
-                </S.DropdownLegend>
-              ) : null}
+                  )}
+                </span>
+              </S.DropdownLegend>
             </fieldset>
           </div>
           <div className="col-sm-12 col-md-4 col-lg-4 m-b-12">

--- a/src/components/Reports/ReportsFilters/ReportsFilters.test.js
+++ b/src/components/Reports/ReportsFilters/ReportsFilters.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import DopplerIntlProvider from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
 import ReportsFilters from './ReportsFilters';
 
 describe('ReportsFilters component', () => {
-  afterEach(cleanup);
-
   it('should show verification date', async () => {
     // Arrange
     const domain = {
@@ -31,8 +29,31 @@ describe('ReportsFilters component', () => {
     );
 
     // Assert
-    getByText('reports_filters.verified_domain');
-    getByText('5/30/2018');
+    getByText(/reports_filters.verified_domain/i);
+    getByText(/5\/30\/2018/i);
+  });
+
+  it('should show placeholder date when has not domain selected', async () => {
+    // Arrange
+
+    // Act
+    const { getByText, queryByText } = render(
+      <DopplerIntlProvider>
+        <ReportsFilters
+          changeDomain={() => {}}
+          pages={[]}
+          pageSelected={null}
+          changePage={() => {}}
+          periodSelectedDays={7}
+          changePeriod={() => {}}
+        />
+      </DopplerIntlProvider>,
+    );
+
+    // Assert
+    expect(queryByText(/reports_filters.no_information/i)).not.toBeInTheDocument();
+    expect(getByText(/reports_filters.verified_domain/i)).toBeInTheDocument();
+    expect(getByText(/--\/--\/----/i)).toBeInTheDocument();
   });
 
   it('should work when there is not verification date', async () => {
@@ -43,7 +64,7 @@ describe('ReportsFilters component', () => {
     };
 
     // Act
-    const { container } = render(
+    const { container, getByText } = render(
       <DopplerIntlProvider>
         <ReportsFilters
           changeDomain={() => {}}
@@ -59,7 +80,7 @@ describe('ReportsFilters component', () => {
     );
 
     // Assert
-    expect(container).not.toContainHTML('reports_filters.verified_domain');
+    expect(getByText('reports_filters.no_information')).toBeInTheDocument();
   });
 
   it('should show 2 and 3 weeks when isEnableWeeks true', async () => {

--- a/src/components/Reports/ReportsTrafficSources/ReportsTrafficSources.js
+++ b/src/components/Reports/ReportsTrafficSources/ReportsTrafficSources.js
@@ -3,6 +3,7 @@ import { InjectAppServices } from '../../../services/pure-di';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Loading } from '../../Loading/Loading';
 import * as S from './ReportsTrafficSources.styles';
+import { fakeTrafficSourcesData } from '../../../services/datahub-client.doubles';
 
 const SafeDivide = (number, qVisitors) => {
   return qVisitors ? number / qVisitors : 0;
@@ -14,7 +15,10 @@ const ReportsTrafficSources = function ({
   dateTo,
   dependencies: { datahubClient },
 }) {
-  const [state, setState] = useState({ loading: true });
+  const [state, setState] = useState({
+    loading: true,
+    trafficSources: { items: fakeTrafficSourcesData },
+  });
 
   const numberFormatOptions = {
     style: 'percent',
@@ -53,9 +57,8 @@ const ReportsTrafficSources = function ({
         </h6>
       </div>
       <S.ContentContainer>
-        {state.loading ? (
-          <Loading />
-        ) : !state.trafficSources ? (
+        {state.loading && <Loading />}
+        {!state.loading && !state.trafficSources ? (
           <p className="dp-boxshadow--error bounceIn">
             <FormattedMessage id="common.unexpected_error" />
           </p>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -562,6 +562,7 @@ by Doppler and how many don't. By tracking the user's journey you'll be able to 
       `,
     domain: `Domain`,
     domain_not_verified_MD: `Your domain is not verified. It is necessary to start obtaining data about your visits. [VERIFY DOMAIN](${urlSiteTracking}).`,
+    no_information: `No information available`,
     pages: `Pages`,
     rank_time: `Time period`,
     title: `Track users behavior, analyze it and optimize your Marketing actions`,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -563,6 +563,7 @@ los usuarios, detecta puntos de fuga y oportunidades de mejora! Si necesitas ayu
       `,
     domain: `Dominio`,
     domain_not_verified_MD: `Tu dominio no está verificado. Es necesario para comenzar a obtener datos sobre tus visitas. [VERIFICAR DOMINIO](${urlSiteTracking}).`,
+    no_information: `No hay información disponible`,
     pages: `Página`,
     rank_time: `Período de tiempo analizado`,
     title: `Analiza el comportamiento de los usuarios y optimiza tu estrategia`,

--- a/src/services/datahub-client.doubles.ts
+++ b/src/services/datahub-client.doubles.ts
@@ -56,7 +56,7 @@ const fakePagesData = [
   },
 ];
 
-const fakeTrafficSourcesData = [
+export const fakeTrafficSourcesData = [
   {
     sourceType: 'Email',
     qVisits: 2000,
@@ -169,6 +169,22 @@ const getFakeVisitsWeekdayHoursData = () => {
       qVisitsWithEmail: Math.floor(Math.random() * 100),
     };
   });
+};
+
+export const prepareFakeVisitsWeekdayHoursData = () => {
+  const data = getFakeVisitsWeekdayHoursData();
+
+  const visits = data.map((x) => ({
+    weekday: new Date(x.periods[0].from).getDay(),
+    hour: new Date(x.periods[0].to).getHours(),
+    qVisitors: x.qVisitors,
+    qVisitorsWithEmail: x.qVisitorsWithEmail,
+    qVisitorsWithOutEmail: x.qVisitors - x.qVisitorsWithEmail,
+    qVisits: x.qVisits,
+    qVisitsWithEmail: x.qVisitsWithEmail,
+  }));
+
+  return visits;
 };
 
 export class HardcodedDatahubClient implements DatahubClient {
@@ -340,26 +356,11 @@ export class HardcodedDatahubClient implements DatahubClient {
     console.log('getVisitsQuantitySummarizedByWeekdayAndHour', { domainName, dateFrom, dateTo });
     await timeout(1000);
 
-    const data = getFakeVisitsWeekdayHoursData();
-
-    const visits = data.map((x) => ({
-      weekday: new Date(x.periods[0].from).getDay(),
-      hour: new Date(x.periods[0].to).getHours(),
-      qVisitors: x.qVisitors,
-      qVisitorsWithEmail: x.qVisitorsWithEmail,
-      qVisitorsWithOutEmail: x.qVisitors - x.qVisitorsWithEmail,
-      qVisits: x.qVisits,
-      qVisitsWithEmail: x.qVisitsWithEmail,
-    }));
+    const data = prepareFakeVisitsWeekdayHoursData();
 
     return {
       success: true,
-      value: visits,
+      value: data,
     };
-
-    //return {
-    //  success: false,
-    //  error: new Error('Dummy error'),
-    //};
   }
 }


### PR DESCRIPTION
### Fix spinner on reports page

**scenario:**

- The user navigates to /reports page when a verificated domain
- The user sees a spinner and after the user sees a spinner for each box with a placeholder content (fake data)

**Before:**
![image](https://user-images.githubusercontent.com/84402180/133318893-d265f3c7-57ec-4d1f-99b6-83f03784c112.png)

**After:**
![image](https://user-images.githubusercontent.com/84402180/133319195-d92f8603-0c0b-42a5-acf8-953aabe7ea75.png)

