### PR TITLE
feat: filter plans by contacts for users with a prepaid account

### DIFF
--- a/src/components/ChangePlan/PlanCalculator/PlanCalculator.js
+++ b/src/components/ChangePlan/PlanCalculator/PlanCalculator.js
@@ -82,6 +82,7 @@ const PlanCalculator = ({ location, dependencies: { planService, appSessionRef }
         sessionPlan.planType,
         sessionPlan.idPlan,
         sessionPlan.planSubscription,
+        sessionPlan.subscribersCount,
         planList,
       );
       const planTypes = planService.getPlanTypes(currentPlan, pathType, planList);

--- a/src/doppler-types.ts
+++ b/src/doppler-types.ts
@@ -70,6 +70,7 @@ export interface PrepaidPack {
   name: string;
   credits: number;
   price: number;
+  subscribersCount: number;
   featureSet: 'standard';
 }
 

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -297,6 +297,7 @@ interface PlanEntry {
   idPlan: number;
   planDiscount: number;
   planSubscription: number;
+  subscribersCount: number;
 }
 
 interface SmsEntry {
@@ -414,6 +415,7 @@ function mapPlanEntry(json: any): PlanEntry {
     idPlan: json.idUserTypePlan ? json.idUserTypePlan : 0,
     planDiscount: json.planDiscount,
     planSubscription: json.monthPlan,
+    subscribersCount: json.subscribersCount,
   };
 }
 function mapSmsEntry(json: any): SmsEntry {

--- a/src/services/plan-service.test.js
+++ b/src/services/plan-service.test.js
@@ -109,6 +109,76 @@ describe('Doppler plan client', () => {
     expect(paths.filter((plan) => plan.current).length > 0);
   });
 
+  it('should get the plans greater than or equal to the current subscribers', async () => {
+    // Arrange
+    const subscribersCount = 2600;
+    const pathType = 'standard';
+    const planType = 'subscribers';
+    const currentPlan = {
+      type: 'prepaid',
+      id: 2,
+      name: '1500-CREDITS',
+      credits: 1500,
+      price: 45,
+      featureSet: 'standard',
+      subscribersCount,
+    };
+
+    // Act
+    const plans = await planService.getPlans(currentPlan, pathType, planType, planList);
+
+    // Assert
+    expect(plans.length).toBe(1);
+    expect(plans[0].subscriberLimit >= subscribersCount).toBe(true);
+  });
+
+  it('should not return plans for contacts when the allowed amount is exceeded', async () => {
+    // Arrange
+    const subscribersCount = 10000;
+    const pathType = 'standard';
+    const planType = 'subscribers';
+    const currentPlan = {
+      type: 'prepaid',
+      id: 2,
+      name: '1500-CREDITS',
+      credits: 1500,
+      price: 45,
+      featureSet: 'standard',
+      subscribersCount,
+    };
+
+    // Act
+    const plans = await planService.getPlans(currentPlan, pathType, planType, planList);
+
+    // Assert
+    expect(plans.length).toBe(0);
+  });
+
+  it('should return all plans by contacts if the current contacts is less', async () => {
+    // Arrange
+    const subscribersCount = 1000;
+    const pathType = 'standard';
+    const planType = 'subscribers';
+    const currentPlan = {
+      type: 'prepaid',
+      id: 2,
+      name: '1500-CREDITS',
+      credits: 1500,
+      price: 45,
+      featureSet: 'standard',
+      subscribersCount,
+    };
+
+    // Act
+    const plans = await planService.getPlans(currentPlan, pathType, planType, planList);
+
+    // Assert
+    expect(plans.length).toBe(2);
+    plans.forEach((plan) => {
+      expect(plan.subscriberLimit >= subscribersCount).toBe(true);
+    });
+  });
+
   it('should get correct path for a current prepaid user', async () => {
     // Arrange
     const currentPlan = {
@@ -118,6 +188,7 @@ describe('Doppler plan client', () => {
       credits: 2500,
       price: 45,
       featureSet: 'standard',
+      subscribersCount: 0,
     };
 
     // Act
@@ -215,6 +286,7 @@ describe('Doppler plan client', () => {
       credits: 1500,
       price: 15,
       featureSet: 'standard',
+      subscribersCount: 0,
     };
 
     // Act
@@ -311,6 +383,7 @@ describe('Doppler plan client', () => {
       credits: 1500,
       price: 15,
       featureSet: 'standard',
+      subscribersCount: 0,
     };
 
     // Act

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -166,7 +166,10 @@ const getPotentialUpgrades = (userPlan: Plan, planList: Plan[]): Plan[] => {
       potentialUpgradePlans = [
         ...getPrepaidPacks(planList),
         ...getUpgradeMonthlyPlans(planList),
-        ...getUpgradeSubscribersPlans(planList),
+        ...getUpgradeSubscribersPlans(planList, {
+          minFee: 0,
+          minSubscriberLimit: userPlan.subscribersCount,
+        }),
       ];
       break;
 
@@ -291,6 +294,7 @@ export class PlanService implements PlanHierarchy {
     planType: PlanType,
     planId: number,
     subscription: number,
+    subscribersCount: number = 0,
     planList: Plan[],
   ) => {
     const exclusivePlan = { type: 'exclusive' };
@@ -305,7 +309,7 @@ export class PlanService implements PlanHierarchy {
             : monthlyPlan
           : exclusivePlan;
       case 'prepaid':
-        return getCheapestPrepaidPlan(planList);
+        return { ...getCheapestPrepaidPlan(planList), subscribersCount };
       case 'agencies':
         return {
           type: 'agency',


### PR DESCRIPTION
### filter plans by contacts for users with a prepaid account
task: https://makingsense.atlassian.net/browse/DW-1140

**scenarios:** 

**The user has more subscribers than what was offered in the account per contact**

- The user navigates to `/plan-selection/standard/prepaid` with a prepaid account
- The user don't see the contact tab

Example when the user has 120.000 subscribers: 
![image](https://user-images.githubusercontent.com/84402180/133808183-c0bf2a2a-cd95-4b1e-bbfc-382b22be86d2.png)

**The user has less subscribers than what was offered in the account per contact**

- The user navigates to `/plan-selection/standard/prepaid` with a prepaid account
- The user sees the contact tab

Example when the user has 1600 subscribers:
![image](https://user-images.githubusercontent.com/84402180/133807974-dc5375eb-11ee-4800-9a7f-7b4a70e32286.png)

**The user has the same number of subscribers as the maximum offered in the accounts per contact**

- The user navigates to `/plan-selection/standard/prepaid` with a prepaid account
- The user sees the contact tab, but the slider is at maximum

Example when the user has 100000 subscribers (100k)
![image](https://user-images.githubusercontent.com/84402180/133809554-720e3e1e-94ed-4e7c-bbb3-06a4ed01972f.png)


