### PR TITLE
fix(CloudTags): temporarily remove dp-recently-add class

### DIFF
--- a/src/components/CloudTags/index.js
+++ b/src/components/CloudTags/index.js
@@ -32,7 +32,6 @@ export const CloudTags = ({ tags, remove, afterRemove, disabled, render }) => {
           <span
             className={classNames({
               'dp-tag': true,
-              'dp-recently-add': index + 1 === tags.length,
             })}
           >
             {tag}

--- a/src/components/CloudTags/index.test.js
+++ b/src/components/CloudTags/index.test.js
@@ -17,7 +17,6 @@ describe('CloudTags component', () => {
     // Assert
     const allTags = screen.queryAllByRole('listitem');
     expect(allTags.length).toBe(tags.length);
-    expect(allTags[allTags.length - 1].querySelector('span')).toHaveClass('dp-recently-add');
   });
 
   it('should render CloudTags component when it has no tags', () => {


### PR DESCRIPTION
### Remove green glow
Remove green glow from the last tag, that did not indicate nothing in particular to avoid confusion. 

This must be replaced in the future by adding the glow for the last unsaved tags added. 
[Jira ticket link](https://makingsense.atlassian.net/browse/DW-1161)

Before
![image](https://user-images.githubusercontent.com/2439363/133833899-d55712cd-b060-4b8f-9b37-f2910629f88a.png)
After
![image](https://user-images.githubusercontent.com/2439363/133833846-4d840c12-4884-46c0-9abe-d9a89e0bf63f.png)
