### PR TITLE
fix: fix error in plan selection view

### DIFF
--- a/src/components/ChangePlan/ChangePlan.js
+++ b/src/components/ChangePlan/ChangePlan.js
@@ -245,6 +245,7 @@ const ChangePlan = ({ location, dependencies: { planService, appSessionRef } }) 
         sessionPlan.planType,
         sessionPlan.idPlan,
         sessionPlan.planSubscription,
+        sessionPlan.subscribersCount,
         planList,
       );
       const pathList = await planService.getPaths(currentPlan, planList);


### PR DESCRIPTION
### Fix error in plan selection view

**scenario**

- The user navigates to /plan-selection with a prepaid account
- The user sees the plans

