### PR TITLE
DW-1121: fix(SiteTrackingRequired): Remove intermediate screen

### DIFF
--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.js
@@ -68,50 +68,26 @@ export const SiteTrackingRequired = InjectAppServices(
     return (
       <section className="container-reports bg-message--grey">
         <div className="dp-wrapper-messages">
-          {reason === SiteTrackingNotAvailableReasons.trialNotAccepted ? (
-            // Any paid account can enable the trial
-            <>
-              <FormattedMessage tagName="h2" id="reports.allow_enable_trial_title" />
-              <FormattedMessageMarkdown
-                tagName="div"
-                linkTarget={'_blank'}
-                id="reports.allow_enable_trial_MD"
-              />
-              <div className="dp-messages-actions">
-                <button
-                  onClick={activateTrial}
-                  className={
-                    'dp-button button-medium primary-green' +
-                    ((state.isLoading && ' button--loading') || '')
-                  }
-                  disabled={state.isLoading}
-                >
-                  <FormattedMessage id="reports.allow_enable_trial_button" />
-                </button>
-              </div>
-            </>
-          ) : (
-            // SiteTrackingNotAvailableReasons.featureDisabled
-            // SiteTrackingNotAvailableReasons.thereAreNotDomains
-            // SiteTrackingNotAvailableReasons.noDatahubId
-            <>
-              <FormattedMessage tagName="h2" id="reports.datahub_not_domains_title" />
-              <FormattedMessageMarkdown
-                className="patch-no-domains"
-                linkTarget={'_blank'}
-                id="reports.no_domains_MD"
-              />
-              <div className="dp-messages-actions">
-                <FormattedMessage id="reports.no_domains_button_destination">
-                  {(url) => (
-                    <a href={url} className="dp-button button-medium primary-green">
-                      <FormattedMessage id="reports.no_domains_button" />
-                    </a>
-                  )}
-                </FormattedMessage>
-              </div>
-            </>
-          )}
+          <>
+            <FormattedMessage tagName="h2" id="reports.datahub_not_domains_title" />
+            <FormattedMessageMarkdown
+              className="patch-no-domains"
+              linkTarget={'_blank'}
+              id="reports.no_domains_MD"
+            />
+            <div className="dp-messages-actions">
+              <button
+                onClick={activateTrial}
+                className={
+                  'dp-button button-medium primary-green' +
+                  ((state.isLoading && ' button--loading') || '')
+                }
+                disabled={state.isLoading}
+              >
+                <FormattedMessage id="reports.no_domains_button" />
+              </button>
+            </div>
+          </>
         </div>
       </section>
     );

--- a/src/components/SiteTrackingRequired/SiteTrackingRequired.test.js
+++ b/src/components/SiteTrackingRequired/SiteTrackingRequired.test.js
@@ -39,7 +39,7 @@ describe('site tracking', () => {
     );
 
     // Assert
-    expect(getByText('reports.allow_enable_trial_title')).toBeInTheDocument();
+    expect(getByText('reports.datahub_not_domains_title')).toBeInTheDocument();
   });
 
   it('should show not domains messages', () => {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -516,11 +516,6 @@ You'll find an Email with steps to follow.`,
     unknown_amount_description: ' ',
   },
   reports: {
-    allow_enable_trial_MD: `Activate the trial period and access detailed Reports on the behavior of users inside your
-    Website or E-commerce. Discover which are the most visited pages,
-    how many visitors have an Email identified by Doppler and how many don't. Any doubts? Press [HELP](${urlHelpAdvancedReports})`,
-    allow_enable_trial_button: `Start the trial`,
-    allow_enable_trial_title: `Try On-Site Tracking Automation for a limited time`,
     datahub_not_domains_title: `Add your web domain and analyze the behavior of your users`,
     no_domains_MD: `
 Register the domain (s) you want to track and access to detailed Reports. Discover which are the

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -517,11 +517,6 @@ Encontrarás un Email con los pasos a seguir.`,
     unknown_amount_description: ' ',
   },
   reports: {
-    allow_enable_trial_MD: `Activa el periodo de prueba y accede a Reportes detallados sobre el comportamiento de los
-    usuarios en tu Sitio Web o E-commerce. Descubre cuáles son las páginas más visitadas, cuántos
-    visitantes poseen un Email que Doppler ha identificado y cuántos no. ¿Necesitas ayuda? [HELP](${urlHelpAdvancedReports}).`,
-    allow_enable_trial_button: `Activa período de prueba`,
-    allow_enable_trial_title: `Prueba Automation de Comportamiento en Sitio por tiempo limitado`,
     datahub_not_domains_title: `Agrega el dominio de tu Web y analiza el comportamiento de tus usuarios`,
     no_domains_MD: `
 Registra el o los dominios sobre los que quieres realizar el seguimiento y accede a Reportes


### PR DESCRIPTION
Before if a paid user never accesed into advanced reports he saw this:

![image](https://user-images.githubusercontent.com/2439363/135468888-4fa065d1-b498-4dea-beb3-43d10f140537.png)

Now he will see the second screen directly:

![image](https://user-images.githubusercontent.com/2439363/135469996-6eced62f-134f-40ed-8d64-f859d9c4ea5d.png)
