### PR TITLE
fix: [DAT-597] Update PaymentMethod properties

### DIFF
--- a/src/components/ChangePlan/Checkout/PaymentMethod/CreditCard.js
+++ b/src/components/ChangePlan/Checkout/PaymentMethod/CreditCard.js
@@ -40,23 +40,20 @@ const getCreditCardIssuer = (ccType) => {
   return ccType;
 };
 
-const getCreditCardBrand = (creditCardNumber) => {
-  // start without knowing the credit card brand
-  var result = 'unknown';
-
+export const getCreditCardBrand = (creditCardNumber) => {
   // first check for MasterCard
   if (/^5[1-5]/.test(creditCardNumber)) {
-    result = 'mastercard';
+    return 'mastercard';
   }
   // then check for Visa
   else if (/^4/.test(creditCardNumber)) {
-    result = 'visa';
+    return 'visa';
   }
   // then check for AmEx
   else if (/^3[47]/.test(creditCardNumber)) {
-    result = 'amex';
+    return 'amex';
   }
-  return result;
+  return 'unknown';
 };
 
 export const CreditCard = InjectAppServices(

--- a/src/components/ChangePlan/Checkout/PaymentMethod/PaymentMethod.js
+++ b/src/components/ChangePlan/Checkout/PaymentMethod/PaymentMethod.js
@@ -9,7 +9,7 @@ import { getFormInitialValues, extractParameter } from '../../../../utils';
 import { FieldGroup, FieldItem, SubmitButton } from '../../../form-helpers/form-helpers';
 import { Discounts } from '../Discounts/Discounts';
 import { actionPage } from '../Checkout';
-import { CreditCard } from './CreditCard';
+import { CreditCard, getCreditCardBrand } from './CreditCard';
 
 export const fieldNames = {
   paymentMethodName: 'paymentMethodName',
@@ -243,7 +243,8 @@ export const PaymentMethod = InjectAppServices(
     const submitPaymentMethodForm = async (values) => {
       const result = await dopplerBillingUserApiClient.updatePaymentMethod({
         ...values,
-        discountId: discountsInformation.selectedPlanDiscount.id,
+        discountId: discountsInformation.selectedPlanDiscount,
+        ccType: getCreditCardBrand(values.number),
       });
 
       setError(!result.success);

--- a/src/services/doppler-billing-user-api-client.double.ts
+++ b/src/services/doppler-billing-user-api-client.double.ts
@@ -44,6 +44,15 @@ export const fakePaymentMethodInformation = {
   identificationNumber: '',
 };
 
+export const fakePaymentMethod = {
+  name: 'data.name',
+  number: 'data.number',
+  cvc: 'data.cvc',
+  paymentMethodName: 'data.paymentMethodName',
+  expiry: 'data.expiry',
+  ccType: 'data.ccType',
+};
+
 export class HardcodedDopplerBillingUserApiClient implements DopplerBillingUserApiClient {
   public async getBillingInformationData(): Promise<
     ResultWithoutExpectedErrors<BillingInformation>

--- a/src/services/doppler-billing-user-api-client.test.ts
+++ b/src/services/doppler-billing-user-api-client.test.ts
@@ -6,6 +6,7 @@ import { HttpDopplerBillingUserApiClient } from './doppler-billing-user-api-clie
 import {
   fakeBillingInformation,
   fakePaymentMethodInformation,
+  fakePaymentMethod,
 } from './doppler-billing-user-api-client.double';
 
 const consoleError = console.error;
@@ -131,9 +132,46 @@ describe('HttpDopplerBillingUserApiClient', () => {
     expect(result.success).toBe(false);
   });
 
+  it('should put payment method information', async () => {
+    // Arrange
+    const values = fakePaymentMethod;
+    const response = {
+      status: 200,
+    };
+    const request = jest.fn(async () => response);
+    const dopplerBillingUserApiClient = createHttpDopplerBillingUserApiClient({ request });
+
+    // Act
+    const result = await dopplerBillingUserApiClient.updatePaymentMethod(values);
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
+  });
+
+  it('should set error when the connecting fail to put payment method information', async () => {
+    // Arrange
+    const values = fakePaymentMethod;
+    const response = {
+      status: 500,
+    };
+
+    const request = jest.fn(async () => response);
+    const dopplerBillingUserApiClient = createHttpDopplerBillingUserApiClient({ request });
+
+    // Act
+    const result = await dopplerBillingUserApiClient.updatePaymentMethod(values);
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(false);
+  });
+
   it('should update payment method', async () => {
     // Arrange
-    const values = fakePaymentMethodInformation;
+    const values = fakePaymentMethod;
 
     const response = {
       status: 200,

--- a/src/services/doppler-billing-user-api-client.ts
+++ b/src/services/doppler-billing-user-api-client.ts
@@ -127,6 +127,18 @@ export class HttpDopplerBillingUserApiClient implements DopplerBillingUserApiCli
     };
   }
 
+  private mapCreditCardPaymentMethod(data: any): any {
+    return {
+      ccHolderFullName: data.name,
+      ccNumber: data.number,
+      ccVerification: data.cvc,
+      paymentMethodName: data.paymentMethodName,
+      ccExpYear: data.expiry.split('/')[1],
+      ccExpMonth: data.expiry.split('/')[0],
+      ccType: data.ccType,
+    };
+  }
+
   public async getBillingInformationData(): Promise<
     ResultWithoutExpectedErrors<BillingInformation>
   > {
@@ -196,8 +208,8 @@ export class HttpDopplerBillingUserApiClient implements DopplerBillingUserApiCli
 
       const response = await this.axios.request({
         method: 'PUT',
-        url: `/accounts/${email}/payment-methods/current `,
-        data: values,
+        url: `/accounts/${email}/payment-methods/current`,
+        data: this.mapCreditCardPaymentMethod(values),
         headers: { Authorization: `bearer ${jwtToken}` },
       });
 


### PR DESCRIPTION
# Background
We update name of properties to PUT Payment method endpoint
Add mapper
```
{
      ccHolderFullName: data.name,
      ccNumber: data.number,
      ccVerification: data.cvc,
      paymentMethodName: data.paymentMethodName,
      ccExpYear: data.expiry.split('/')[1],
      ccExpMonth: data.expiry.split('/')[0],
      ccType: data.ccType
   };
```