### PR TITLE
[DAT-629] - Set placeholder for the 'Purchase Summary' section when the page is loading

### DIFF
--- a/src/components/ChangePlan/Checkout/PurchaseSummary/PurchaseSummary.js
+++ b/src/components/ChangePlan/Checkout/PurchaseSummary/PurchaseSummary.js
@@ -252,7 +252,13 @@ export const PurchaseSummary = InjectAppServices(
   }) => {
     const location = useLocation();
     const history = useHistory();
-    const [state, setState] = useState({ loading: true, planData: {} });
+    const [state, setState] = useState({
+      loading: true,
+      planData: {},
+      amountDetails: { total: 0, discountPrepayment: { discountPercentage: 0 } },
+      plan: { fee: 0 },
+      discount: { discountPercentage: 0, monthsAmmount: 1 },
+    });
     const [saved, setSaved] = useState(false);
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState(false);
@@ -341,15 +347,11 @@ export const PurchaseSummary = InjectAppServices(
       }
     };
 
-    // TODO: create a placeholder for purchase summary
-    if (state.loading) {
-      return <Loading page />;
-    }
-
     const { total } = state.amountDetails;
 
     return (
       <>
+        {state.loading && <Loading />}
         <div className="dp-hiring-summary">
           <header className="dp-header-summary">
             <h6>{_('checkoutProcessForm.purchase_summary.header')}</h6>

--- a/src/components/ChangePlan/Checkout/PurchaseSummary/PurchaseSummary.test.js
+++ b/src/components/ChangePlan/Checkout/PurchaseSummary/PurchaseSummary.test.js
@@ -82,7 +82,7 @@ describe('PurchaseSummary component', () => {
 
     // Assert
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
   });
 
@@ -128,7 +128,7 @@ describe('PurchaseSummary component', () => {
 
       // Assert
       // Loader should disappear once request resolves
-      const loader = screen.getByTestId('wrapper-loading');
+      const loader = screen.getByTestId('loading-box');
       await waitForElementToBeRemoved(loader);
 
       const title =
@@ -167,7 +167,7 @@ describe('PurchaseSummary component', () => {
 
     // Assert
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     expect(screen.getByRole('listitem', { name: 'units' })).toHaveTextContent(1500);
@@ -205,7 +205,7 @@ describe('PurchaseSummary component', () => {
 
       // Assert
       // Loader should disappear once request resolves
-      const loader = screen.getByTestId('wrapper-loading');
+      const loader = screen.getByTestId('loading-box');
       await waitForElementToBeRemoved(loader);
 
       expect(screen.getByRole('listitem', { name: 'months to pay' })).toHaveTextContent(
@@ -240,7 +240,7 @@ describe('PurchaseSummary component', () => {
 
     // Assert
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     expect(
@@ -310,7 +310,7 @@ describe('PurchaseSummary component', () => {
 
       // Assert
       // Loader should disappear once request resolves
-      const loader = screen.getByTestId('wrapper-loading');
+      const loader = screen.getByTestId('loading-box');
       await waitForElementToBeRemoved(loader);
 
       const discount = screen.getByRole('listitem', { name: 'discount' });
@@ -352,7 +352,7 @@ describe('PurchaseSummary component', () => {
 
     // Assert
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     expect(
@@ -391,7 +391,7 @@ describe('PurchaseSummary component', () => {
 
     // Assert
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     expect(screen.getByText('checkoutProcessForm.purchase_summary.total')).toBeInTheDocument();
@@ -430,7 +430,7 @@ describe('PurchaseSummary component', () => {
 
     // Assert
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     expect(
@@ -470,7 +470,7 @@ describe('PurchaseSummary component', () => {
 
     // Assert
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     expect(
@@ -516,7 +516,7 @@ describe('PurchaseSummary component', () => {
     );
 
     // Loader should disappear once request resolves
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     // Assert
@@ -571,7 +571,7 @@ describe('PurchaseSummary component', () => {
     );
 
     // Assert
-    const loader = screen.getByTestId('wrapper-loading');
+    const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
     const submitButton = screen.getByRole('button', {


### PR DESCRIPTION
Set placeholder for the 'Purchase Summary' section when the page is loading

Screenshot:

Before:

![image](https://user-images.githubusercontent.com/70591946/135904725-590d5aed-da08-4bbc-84db-16a1bc2428a5.png)

After:

![image](https://user-images.githubusercontent.com/70591946/135904762-5bdf44b1-84ca-4aa6-bcfc-1f068c714f8d.png)


**Task:** [DAT-629](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-629)
