### PR TITLE
chore: [DAT-631] Add idSelectedPlan property in PaymentMethod object

### DIFF
--- a/src/components/ChangePlan/Checkout/PaymentMethod/PaymentMethod.js
+++ b/src/components/ChangePlan/Checkout/PaymentMethod/PaymentMethod.js
@@ -245,6 +245,7 @@ export const PaymentMethod = InjectAppServices(
         ...values,
         discountId: discountsInformation.selectedPlanDiscount,
         ccType: getCreditCardBrand(values.number),
+        idSelectedPlan: selectedPlan,
       });
 
       setError(!result.success);

--- a/src/services/doppler-billing-user-api-client.double.ts
+++ b/src/services/doppler-billing-user-api-client.double.ts
@@ -49,8 +49,9 @@ export const fakePaymentMethod = {
   number: 'data.number',
   cvc: 'data.cvc',
   paymentMethodName: 'data.paymentMethodName',
-  expiry: 'data.expiry',
+  expiry: '12/21',
   ccType: 'data.ccType',
+  idSelectedPlan: 'data.idSelectedPlan',
 };
 
 export class HardcodedDopplerBillingUserApiClient implements DopplerBillingUserApiClient {

--- a/src/services/doppler-billing-user-api-client.test.ts
+++ b/src/services/doppler-billing-user-api-client.test.ts
@@ -76,6 +76,42 @@ describe('HttpDopplerBillingUserApiClient', () => {
     expect(result.success).toBe(true);
   });
 
+  it('should update billing information with idselectedPlan correctly', async () => {
+    // Arrange
+    const values = fakePaymentMethod;
+
+    const response = {
+      status: 200,
+    };
+
+    const request = jest.fn(async () => response);
+    const dopplerBillingUserApiClient = createHttpDopplerBillingUserApiClient({ request });
+
+    // Act
+    const result = await dopplerBillingUserApiClient.updatePaymentMethod(values);
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
+    expect(request).toBeCalledWith(
+      expect.objectContaining({
+        method: 'PUT',
+        data: {
+          ccHolderFullName: 'data.name',
+          ccNumber: 'data.number',
+          ccVerification: 'data.cvc',
+          paymentMethodName: 'data.paymentMethodName',
+          ccExpYear: '21',
+          ccExpMonth: '12',
+          ccType: 'data.ccType',
+          idSelectedPlan: 'data.idSelectedPlan',
+        },
+        url: '/accounts/email@mail.com/payment-methods/current',
+      }),
+    );
+  });
+
   it('should set error when the connecting fail', async () => {
     // Arrange
     const values = fakeBillingInformation;

--- a/src/services/doppler-billing-user-api-client.ts
+++ b/src/services/doppler-billing-user-api-client.ts
@@ -136,6 +136,7 @@ export class HttpDopplerBillingUserApiClient implements DopplerBillingUserApiCli
       ccExpYear: data.expiry.split('/')[1],
       ccExpMonth: data.expiry.split('/')[0],
       ccType: data.ccType,
+      idSelectedPlan: data.idSelectedPlan,
     };
   }
 


### PR DESCRIPTION
# Background
We need to send idSelectedPlan in the PUT paymentMethod/current endpoint to send this information to SAP
Example:
`{
    "ccHolderFullName":"test",
    "ccNumber":"4111 111111111111",
    "ccVerification":"123",
    "paymentMethodName":"CC",
    "ccExpYear":"21",
    "ccExpMonth":"12",
    "ccType":"visa",
    "idSelectedPlan":"37"
}`