### PR TITLE
feat(bigquery): show message when success and fail saving data

### DIFF
--- a/src/components/Integrations/BigQuery/AuthorizationPage.js
+++ b/src/components/Integrations/BigQuery/AuthorizationPage.js
@@ -7,6 +7,9 @@ import { useIntl } from 'react-intl';
 import dataStudioGif from './google-data-studio.gif';
 import bigQueryLogo from './bigquery_logo.png';
 import { FormattedMessageMarkdown } from '../../../i18n/FormattedMessageMarkdown';
+import { ShowLikeFlash } from '../../shared/ShowLikeFlash/ShowLikeFlash';
+import { IconMessage } from '../../form-helpers/form-helpers';
+import { successMessageDelay } from '../../../utils';
 
 const AuthorizationLayout = ({ dependencies: { bigQueryClient, dopplerUserApiClient } }) => {
   const intl = useIntl();
@@ -14,6 +17,7 @@ const AuthorizationLayout = ({ dependencies: { bigQueryClient, dopplerUserApiCli
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [bigQueryEnabled, setBigQueryEnabled] = useState(false);
+  const [messageData, setMessageData] = useState(null);
 
   useEffect(() => {
     const isBigQueryPolicyEnabled = async () => {
@@ -32,13 +36,28 @@ const AuthorizationLayout = ({ dependencies: { bigQueryClient, dopplerUserApiCli
     fetchData();
   }, [bigQueryClient, dopplerUserApiClient]);
 
-  const onSubmit = async (values, emailsToNotify) => {
+  const FieldItemMessage = ({ message }) => (
+    <ShowLikeFlash delay={message.delay}>
+      <IconMessage {...message} className="bounceIn" />
+    </ShowLikeFlash>
+  );
+
+  const onSubmit = async (values) => {
     const emailsData = { emails: [...values.emails] };
     const { success } = await bigQueryClient.saveEmailsData(emailsData);
+
     if (success) {
-      alert('success');
+      setMessageData({
+        text: 'big_query.plus_message_saved',
+        type: 'success',
+        delay: successMessageDelay,
+      });
     } else {
-      alert('error saving data');
+      setMessageData({
+        text: 'big_query.plus_message_error',
+        type: 'cancel',
+        delay: successMessageDelay,
+      });
     }
   };
 
@@ -113,6 +132,9 @@ const AuthorizationLayout = ({ dependencies: { bigQueryClient, dopplerUserApiCli
                 <FormattedMessageMarkdown id="big_query.plus_step_one_paragraph_MD" />
               </div>
               <AuthorizationForm emails={data} onSubmit={onSubmit} />
+            </div>
+            <div className="p-t-30">
+              {messageData ? <FieldItemMessage message={messageData} /> : <></>}
             </div>
           </div>
           <div className="col-lg-6 col-md-12 col-sm-12 m-b-24 p-b-42">

--- a/src/components/Integrations/BigQuery/AuthorizationPage.test.js
+++ b/src/components/Integrations/BigQuery/AuthorizationPage.test.js
@@ -148,4 +148,65 @@ describe('test for validate authorization form component ', () => {
     await act(async () => userEvent.click(submitButton));
     window.alert = jsdomAlert;
   });
+
+  it('control panel show success message', async () => {
+    //Arrange
+    const bigQueryEnabled = true;
+    const success = true;
+
+    //act
+    render(
+      <AppServicesProvider
+        forcedServices={{
+          bigQueryClient: bigQueryClientDouble(success),
+          dopplerUserApiClient: dopplerUserApiClientDouble(bigQueryEnabled, success),
+        }}
+      >
+        <IntlProvider>
+          <AuthorizationPage />
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    //assert
+    const loader = screen.getByTestId('wrapper-loading');
+    await waitForElementToBeRemoved(loader);
+    expect(screen.getByRole('form')).toBeInTheDocument();
+    expect(screen.queryByText('big_query.free_title')).not.toBeInTheDocument();
+    // simulate submit form
+    const submitButton = screen.getByRole('button', { name: 'common.save' });
+    await act(async () => userEvent.click(submitButton));
+    expect(screen.queryByText('big_query.plus_message_saved')).toBeInTheDocument();
+  });
+
+  it('control panel show error message', async () => {
+    //Arrange
+    const bigQueryEnabled = true;
+    const userApiSuccess = true;
+    const bigQuerySuccess = false;
+
+    //act
+    render(
+      <AppServicesProvider
+        forcedServices={{
+          bigQueryClient: bigQueryClientDouble(bigQuerySuccess),
+          dopplerUserApiClient: dopplerUserApiClientDouble(bigQueryEnabled, userApiSuccess),
+        }}
+      >
+        <IntlProvider>
+          <AuthorizationPage />
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    //assert
+    const loader = screen.getByTestId('wrapper-loading');
+    await waitForElementToBeRemoved(loader);
+    expect(screen.getByRole('form')).toBeInTheDocument();
+    expect(screen.queryByText('big_query.free_title')).not.toBeInTheDocument();
+    // simulate submit form
+    const submitButton = screen.getByRole('button', { name: 'common.save' });
+    await act(async () => userEvent.click(submitButton));
+    expect(screen.queryByText('big_query.plus_message_error')).toBeInTheDocument();
+  });
 });

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -76,6 +76,7 @@ const messages_en = {
     plus_configuration: `Configuration`,
     plus_control_panel: `Control Panel`,
     plus_header_MD: `Get detailed reports to analyze the performance of your Email & Automation Marketing Campaigns.`,
+    plus_message_error: `Error saving changes.`,
     plus_message_remember: `Remember to save changes.`,
     plus_message_saved: `Changes saved successfully.`,
     plus_paragraph_two: `Google BigQuery`,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -76,6 +76,7 @@ const messages_es = {
     plus_configuration: `Configuración`,
     plus_control_panel: `Panel de Control`,
     plus_header_MD: `Accede a reportes detallados para analizar el rendimiento de tus Campañas de Email & Automation Marketing.`,
+    plus_message_error: `Error guardando los cambios`,
     plus_message_remember: `Recuerda guardar los cambios`,
     plus_message_saved: `Cambios guardados con éxito`,
     plus_paragraph_two: `Google BigQuery`,

--- a/src/services/doppler-user-api-client.double.ts
+++ b/src/services/doppler-user-api-client.double.ts
@@ -20,7 +20,7 @@ export const fakeContactInformation = {
 
 const featuresResult = {
   contactPolicies: true,
-  bigQuery: false,
+  bigQuery: true,
 };
 
 export class HardcodedDopplerUserApiClient implements DopplerUserApiClient {


### PR DESCRIPTION
1. Add success message when api response 200
![onSuccess](https://user-images.githubusercontent.com/11965643/137159024-cdf7b3d9-4104-4602-8be7-a86cd94837b1.gif)
2. Add error messages when api response 500
![onError](https://user-images.githubusercontent.com/11965643/137159088-a4403932-79b3-4dad-a315-b9d882d15115.gif)
3. Add test for verify response on ui
<img width="857" alt="TestSuit" src="https://user-images.githubusercontent.com/11965643/137159179-19e0e409-1120-4af0-bfc2-e57db6018af5.PNG">


