### PR TITLE
feat: [DAT-643] Change message error position for credit card payment

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
@@ -287,16 +287,6 @@ export const PaymentMethod = InjectAppServices(
                         handleChange={(e) => handleChange(e, setFieldValue)}
                       />
                     </FieldItem>
-                    {error ? (
-                      <FieldItem className="field-item">
-                        <div className="dp-wrap-message dp-wrap-cancel">
-                          <span className="dp-message-icon"></span>
-                          <div className="dp-content-message">
-                            <p>{_('checkoutProcessForm.payment_method.error')}</p>
-                          </div>
-                        </div>
-                      </FieldItem>
-                    ) : null}
                     <PaymentType paymentMethodType={paymentMethodType} optionView={optionView} />
                     <FieldItem className="field-item">
                       <Discounts
@@ -308,6 +298,16 @@ export const PaymentMethod = InjectAppServices(
                       />
                     </FieldItem>
                     <PaymentNotes paymentMethodType={paymentMethodType} />
+                    {error ? (
+                      <FieldItem className="field-item">
+                        <div className="dp-wrap-message dp-wrap-cancel">
+                          <span className="dp-message-icon"></span>
+                          <div className="dp-content-message">
+                            <p>{_('checkoutProcessForm.payment_method.error')}</p>
+                          </div>
+                        </div>
+                      </FieldItem>
+                    ) : null}
                     {optionView === actionPage.UPDATE ? (
                       <FieldItem className="field-item">
                         <div className="dp-buttons-actions">


### PR DESCRIPTION
# Background
We need to change position of message error for credit card payment

Before:

![image](https://user-images.githubusercontent.com/6796523/138713837-9caf8b19-2e4e-4e6d-99e5-c119e4d3ea82.png)

After:

![image](https://user-images.githubusercontent.com/6796523/138711840-5d38be7f-423b-41b1-b366-c40b5855cf90.png)
