### PR TITLE
[DAT-675] - The free user cannot select payment method

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/Checkout.js
+++ b/src/components/ChangePlanDeprecated/Checkout/Checkout.js
@@ -128,7 +128,7 @@ const Checkout = () => {
                       setPaymentInformationAction(actionPage.READONLY);
                     }}
                     handleChangeDiscount={(discount) => {
-                      setSelectedDiscountId(discount.id);
+                      setSelectedDiscountId(discount?.id);
                     }}
                     handleChangePaymentMethod={(paymentMethod) => {
                       setSelectedPaymentMethod(paymentMethod);

--- a/src/components/ChangePlanDeprecated/Checkout/Discounts/Discounts.js
+++ b/src/components/ChangePlanDeprecated/Checkout/Discounts/Discounts.js
@@ -83,7 +83,7 @@ export const Discounts = ({
       );
       applyDiscount(disccountAplied);
     } else {
-      const discountFilter = discountsList.filter((d) => d.id === selectedDiscount.id)[0];
+      const discountFilter = discountsList.filter((d) => d.id === selectedDiscount?.id)[0];
       const discount = discountFilter ?? selectedPlanDiscount ?? discountsList[0];
       setSelectedDiscount(discount);
     }

--- a/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
@@ -12,6 +12,8 @@ import { actionPage } from '../Checkout';
 import { CreditCard, getCreditCardBrand } from './CreditCard';
 import { Transfer } from './Transfer';
 
+const none = 'NONE';
+
 export const fieldNames = {
   paymentMethodName: 'paymentMethodName',
   number: 'number',
@@ -189,12 +191,21 @@ export const PaymentMethod = InjectAppServices(
         const billingInformationResult =
           await dopplerBillingUserApiClient.getBillingInformationData();
         const paymentMethodData = await dopplerBillingUserApiClient.getPaymentMethodData();
-        const paymentMethod = paymentMethodData.success
+        let paymentMethod = paymentMethodData.success
           ? paymentMethodData.value.paymentMethodName
           : paymentType.creditCard;
 
         if (paymentMethodType === '') {
+          if (paymentMethod === none) {
+            paymentMethod = paymentType.creditCard;
+            handleChangeView(actionPage.UPDATE);
+          }
+
           setPaymentMethodType(paymentMethod);
+        }
+
+        if (!paymentMethodData.success) {
+          handleChangeView(actionPage.UPDATE);
         }
 
         const discountsData = await dopplerAccountPlansApiClient.getDiscountsData(
@@ -211,10 +222,6 @@ export const PaymentMethod = InjectAppServices(
           discounts: discountsData.success ? discountsData.value : [],
           plan: sessionPlan.plan,
         });
-
-        if (!paymentMethodData.success) {
-          handleChangeView(actionPage.UPDATE);
-        }
 
         setState({
           billingCountry: billingInformationResult.value.country,

--- a/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/Transfer.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/Transfer.js
@@ -64,7 +64,7 @@ export const TransferArgentina = ({ paymentMethod, consumerTypes }) => {
 
   const initializeDefaultValues = (consumerType) => {
     setValues({
-      [fieldNames.indentificationNumber]: '',
+      [fieldNames.identificationNumber]: '',
       [fieldNames.businessName]: '',
       [fieldNames.consumerType]: consumerType,
       [fieldNames.paymentMethodName]: paymentType.transfer,

--- a/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.js
@@ -24,11 +24,11 @@ export const PlanInformation = ({ plan, planType }) => {
   const getQuantity = () => {
     switch (planType) {
       case 'prepaid':
-        return plan.emailQty;
+        return plan?.emailQty;
       case 'subscribers':
-        return plan.subscribersQty;
+        return plan?.subscribersQty;
       case 'monthly-deliveries':
-        return plan.emailQty;
+        return plan?.emailQty;
       default:
         return 0;
     }
@@ -52,7 +52,7 @@ export const MonthsToPayInformation = ({ plan, discount }) => {
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
   const monthsCount = discount ? discount.monthsAmmount : 1;
-  const amount = discount ? plan.fee * discount.monthsAmmount : plan.fee;
+  const amount = discount ? plan?.fee * discount?.monthsAmmount : plan?.fee;
 
   return (
     <>
@@ -219,7 +219,7 @@ export const TotalPurchase = ({ totalPlan, priceToPay, state }) => {
         </li>
         <InvoiceInformation
           priceToPay={totalPlan}
-          discount={discountPrepayment.amount}
+          discount={discountPrepayment?.amount}
           paymentMethodType={state.paymentMethodType}
         />
       </ul>
@@ -239,7 +239,7 @@ export const ShoppingList = ({ state, planType }) => {
       <li aria-label="months to pay">
         <MonthsToPayInformation discount={discount} plan={plan} planType={planType} />
       </li>
-      {discountPrepayment.discountPercentage > 0 && (
+      {discountPrepayment?.discountPercentage > 0 && (
         <li aria-label="discount">
           <DiscountPrice discountPrepayment={discountPrepayment} plan={plan} />
         </li>
@@ -304,7 +304,7 @@ export const PurchaseSummary = InjectAppServices(
 
         const amountDetailsData = await dopplerAccountPlansApiClient.getPlanAmountDetailsData(
           selectedPlan,
-          selectedDiscountId,
+          selectedDiscountId ?? 0,
           '',
         );
 
@@ -315,7 +315,7 @@ export const PurchaseSummary = InjectAppServices(
           paymentMethodType,
           plan: planData.value,
           discount,
-          amountDetails: amountDetailsData.value,
+          amountDetails: amountDetailsData.success ? amountDetailsData.value : { total: 0 },
         });
       };
 
@@ -378,7 +378,7 @@ export const PurchaseSummary = InjectAppServices(
           <Promocode />
           <hr className="dp-hr-grey" />
           <TotalPurchase
-            totalPlan={state.plan.fee * state.discount?.monthsAmmount}
+            totalPlan={state.plan?.fee * state.discount?.monthsAmmount}
             priceToPay={total}
             state={state}
           />


### PR DESCRIPTION
Fix issue when the free user has not select payment method. 

Now when the user has not payment method the "Payment method' section is show in update mode and with 'Credit Card' option selected and also initialized the properties.

**Task:** [DAT-675](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-675)