### PR TITLE
feat(checkout): Add purchuse legend when the buy is by credits

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.js
@@ -8,6 +8,7 @@ import { useLocation } from 'react-router';
 import queryString from 'query-string';
 import useTimeout from '../../../../hooks/useTimeout';
 import { paymentType } from '../PaymentMethod/PaymentMethod';
+import { PLAN_TYPE } from '../../../../doppler-types';
 
 const dollarSymbol = 'US$';
 
@@ -170,9 +171,25 @@ export const Promocode = () => {
   );
 };
 
-export const InvoiceInformation = ({ priceToPay, discount, paymentMethodType }) => {
+export const InvoiceInformation = ({ priceToPay, discount, paymentMethodType, planType }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  const getTaxesLegend = (paymentMethodType, planType) => {
+    switch (planType) {
+      case PLAN_TYPE.byCredit:
+        return paymentMethodType === paymentType.creditCard
+          ? ''
+          : `*${_('checkoutProcessForm.purchase_summary.explanatory_legend_by_credits')}`;
+      case PLAN_TYPE.byContact:
+      case PLAN_TYPE.byEmail:
+        return paymentMethodType === paymentType.creditCard
+          ? `*${_('checkoutProcessForm.purchase_summary.explanatory_legend')}`
+          : `*${_('checkoutProcessForm.purchase_summary.transfer_explanatory_legend')}`;
+      default:
+        return '';
+    }
+  };
 
   return (
     <>
@@ -191,11 +208,7 @@ export const InvoiceInformation = ({ priceToPay, discount, paymentMethodType }) 
         </li>
       )}
       <li>
-        <span className="dp-renewal">
-          {paymentMethodType === paymentType.creditCard
-            ? `*${_('checkoutProcessForm.purchase_summary.explanatory_legend')}`
-            : `*${_('checkoutProcessForm.purchase_summary.transfer_explanatory_legend')}`}
-        </span>
+        <span className="dp-renewal">{getTaxesLegend(paymentMethodType, planType)}</span>
       </li>
     </>
   );
@@ -218,6 +231,7 @@ export const TotalPurchase = ({ totalPlan, priceToPay, state }) => {
           </span>
         </li>
         <InvoiceInformation
+          planType={state.planType}
           priceToPay={totalPlan}
           discount={discountPrepayment?.amount}
           paymentMethodType={state.paymentMethodType}
@@ -316,6 +330,7 @@ export const PurchaseSummary = InjectAppServices(
           plan: planData.value,
           discount,
           amountDetails: amountDetailsData.success ? amountDetailsData.value : { total: 0 },
+          planType,
         });
       };
 
@@ -326,6 +341,7 @@ export const PurchaseSummary = InjectAppServices(
       selectedDiscountId,
       selectedPlan,
       paymentMethod,
+      planType,
     ]);
 
     const getPlanTypeTitle = () => {

--- a/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.test.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.test.js
@@ -8,6 +8,7 @@ import { fakePaymentMethodInformation } from '../../../../services/doppler-billi
 import { fakeAccountPlanDiscounts } from '../../../../services/doppler-account-plans-api-client.double';
 import { fakePlanAmountDetails } from '../../../..//services/doppler-account-plans-api-client';
 import user from '@testing-library/user-event';
+import { PLAN_TYPE } from '../../../../doppler-types';
 
 const dependencies = (dopplerAccountPlansApiClientDouble, dopplerBillingUserApiClientDouble) => ({
   dopplerBillingUserApiClient: dopplerBillingUserApiClientDouble,
@@ -591,7 +592,7 @@ describe('PurchaseSummary component', () => {
 
 describe.each([
   [
-    'the payment method is "Credit Card"',
+    'the payment method is "Credit Card" and not prepaid',
     {
       fakePaymentMethodInformation: {
         ccHolderName: 'Juan Perez',
@@ -602,10 +603,11 @@ describe.each([
         paymentMethodName: 'CC',
       },
       informationLegend: '*checkoutProcessForm.purchase_summary.explanatory_legend',
+      planType: PLAN_TYPE.byContact,
     },
   ],
   [
-    'the payment method is "Transfer"',
+    'the payment method is "Transfer" and not prepaid',
     {
       fakePaymentMethodInformation: {
         paymentMethodName: 'TRANSF',
@@ -615,6 +617,21 @@ describe.each([
         identificationNumber: '12345678',
       },
       informationLegend: '*checkoutProcessForm.purchase_summary.transfer_explanatory_legend',
+      planType: PLAN_TYPE.byContact,
+    },
+  ],
+  [
+    'the payment method is "Transfer" and prepaid',
+    {
+      fakePaymentMethodInformation: {
+        paymentMethodName: 'TRANSF',
+        razonSocial: 'test',
+        idConsumerType: 'CF',
+        identificationType: '',
+        identificationNumber: '12345678',
+      },
+      informationLegend: '*checkoutProcessForm.purchase_summary.explanatory_legend_by_credits',
+      planType: PLAN_TYPE.byCredit,
     },
   ],
 ])('should show the correct information legend when', (testName, context) => {
@@ -642,7 +659,7 @@ describe.each([
     // Act
     render(
       <PurchaseSummaryElement
-        url={`checkout/standard/subscribers`}
+        url={`checkout/standard/${context.planType}`}
         dopplerAccountPlansApiClientDouble={dopplerAccountPlansApiClientDouble}
         dopplerBillingUserApiClientDouble={dopplerBillingUserApiClientDouble}
         paymentMethod={''}

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -225,6 +225,7 @@ const messages_en = {
       edit_add_recipients_button: 'Edit or add recipients',
       error_message: 'Your payment couldn’t be processed. Choose a different payment method or try it later.',
       explanatory_legend: 'The renewal is automatic and you can cancel it whenever you want. Price Plan may be taxable.',
+      explanatory_legend_by_credits: 'Price Plan may be taxable, according to your tax category. You’ll find them detailed on the invoice.',
       header: 'Purchase summary',
       month_with_plural: `{monthsCount, plural, one {# month}other {# months} }`,
       months_to_pay: 'Months to pay:',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -226,6 +226,7 @@ const messages_es = {
       edit_add_recipients_button: 'Editar o agregar destinatarios',
       error_message: 'Tu pago no pudo procesarse. Elige otro método de pago o inténtalo más tarde.',
       explanatory_legend: 'La renovación es automática y puedes cancelarla cuando quieras. El precio del Plan puede estar sujeto a impuestos.',
+      explanatory_legend_by_credits: 'El precio del Plan puede estar sujeto a impuestos, de acuerdo a la categoría impositiva. Estos estarán detallados en tu factura.',
       header: 'Resumen de compra',
       month_with_plural: `{monthsCount, plural, one {# mes}other {# meses} }`,
       months_to_pay: 'Meses a abonar:',


### PR DESCRIPTION
Show new purchuse legends when the buy is by credits.

**Screenshots:**

**Before:**

**Credit Card:**

![image](https://user-images.githubusercontent.com/70591946/140336719-96c9c030-1818-4295-93ac-8dca81de94e7.png)

**Transfer:**

![image](https://user-images.githubusercontent.com/70591946/140336873-e7e70aee-f603-47c7-a2df-f987a2e074a5.png)

**After:**

**Credit Card:**

![image](https://user-images.githubusercontent.com/70591946/140336969-9fbc7eb1-97df-4492-b050-22f48d6fd2ce.png)

**Transfer:**

![image](https://user-images.githubusercontent.com/70591946/140337016-e0f803f1-92aa-466f-a1f2-272ee45af633.png)

The refenrecen abot the changes in the legends are in: [Nuevo Flujo de Checkout](https://makingsense.atlassian.net/wiki/spaces/DOP/pages/1453785101/Nuevo+Flujo+de+Checkout)

**Task:** [DAT-676](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-676)
