### PR TITLE
[DAT-678] - Remove the harcoded values and use the values declared in doppler-types.js

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.js
@@ -24,11 +24,11 @@ export const PlanInformation = ({ plan, planType }) => {
 
   const getQuantity = () => {
     switch (planType) {
-      case 'prepaid':
+      case PLAN_TYPE.byCredit:
         return plan?.emailQty;
-      case 'subscribers':
+      case PLAN_TYPE.byContact:
         return plan?.subscribersQty;
-      case 'monthly-deliveries':
+      case PLAN_TYPE.byEmail:
         return plan?.emailQty;
       default:
         return 0;
@@ -346,9 +346,9 @@ export const PurchaseSummary = InjectAppServices(
 
     const getPlanTypeTitle = () => {
       switch (planType) {
-        case 'prepaid':
-        case 'subscribers':
-        case 'monthly-deliveries':
+        case PLAN_TYPE.byCredit:
+        case PLAN_TYPE.byContact:
+        case PLAN_TYPE.byEmail:
           return (
             _('checkoutProcessForm.purchase_summary.plan_premium_title') +
             ' - ' +


### PR DESCRIPTION
Remove the harcoded values and use the values declared in doppler-types.js.

For example:

**Replace:**

```case 'prepaid':```

**to use:**

```case PLAN_TYPE.byCredit:```

**Task:** [DAT-678](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-678)