### PR TITLE
[DAT-684] - Show or hide payment method options depending of billing country

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
@@ -47,6 +47,7 @@ const paymentMethods = [
 ];
 
 const countriesAvailableTransfer = ['ar', 'co', 'mx'];
+const countriesAvailableMercadoPago = ['ar'];
 
 //TODO: Remove the stykes when the UI Library is updated
 const considerationNoteStyle = {
@@ -70,6 +71,7 @@ const PaymentMethodField = ({ billingCountry, paymentMethodType, optionView, han
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
   const allowTransfer = countriesAvailableTransfer.filter((c) => c === billingCountry)[0];
+  const allowMercadoPago = countriesAvailableMercadoPago.filter((c) => c === billingCountry)[0];
 
   return (
     <Field name="paymentMethodName">
@@ -77,7 +79,8 @@ const PaymentMethodField = ({ billingCountry, paymentMethodType, optionView, han
         <ul role="group" aria-labelledby="checkbox-group" className="dp-radio-input">
           {paymentMethods.map((paymentMethod) =>
             (paymentMethod.value === paymentType.transfer && allowTransfer) ||
-            paymentMethod.value !== paymentType.transfer ? (
+            (paymentMethod.value === paymentType.mercadoPago && allowMercadoPago) ||
+            paymentMethod.value === paymentType.creditCard ? (
               <li key={paymentMethod.value}>
                 <div className="dp-volume-option">
                   <label>
@@ -90,7 +93,11 @@ const PaymentMethodField = ({ billingCountry, paymentMethodType, optionView, han
                       value={paymentMethod.value}
                       checked={field.value === paymentMethod.value}
                       disabled={
-                        optionView === actionPage.READONLY && field.value !== paymentMethod.value
+                        (optionView === actionPage.READONLY &&
+                          field.value !== paymentMethod.value) ||
+                        (optionView === actionPage.UPDATE &&
+                          paymentMethod.value === paymentType.transfer &&
+                          field.value !== paymentMethod.value)
                       }
                       onChange={handleChange}
                     />

--- a/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/PaymentMethod.js
@@ -70,8 +70,8 @@ const PaymentMethodField = ({ billingCountry, paymentMethodType, optionView, han
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 
-  const allowTransfer = countriesAvailableTransfer.filter((c) => c === billingCountry)[0];
-  const allowMercadoPago = countriesAvailableMercadoPago.filter((c) => c === billingCountry)[0];
+  const allowTransfer = countriesAvailableTransfer.find((c) => c === billingCountry);
+  const allowMercadoPago = countriesAvailableMercadoPago.find((c) => c === billingCountry);
 
   return (
     <Field name="paymentMethodName">


### PR DESCRIPTION
Show or hide payment method options depending of billing country

- If the country is **Argentina**, **"Transfer"** and **"Mercado Pago"** must be **displayed**.
- If the country is **Mexico** or **Colombia**, **"Transfer"** must be **shown** and **"Mercado Pago"** **hidden**.
- Any **other country** must be **hidden** **"Transfer"** and **"Mercado Pago"**.

**Notes:** If the user has selected credit card as payment method  the if the transfer is showing, it should be "disabled"

**Task:** [DAT-684](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-684)

**Screenshots:**

- *Payment method:** Credit Card and **Billing Country:** 'AR'

**Before:**

![image](https://user-images.githubusercontent.com/70591946/140759574-0b8ad7e4-b8af-4100-bf61-e4c503f0bd8c.png)

**After:**

![image](https://user-images.githubusercontent.com/70591946/140759657-5b81e25f-4991-4a24-9706-29ed43c18501.png)

- *Payment method:** Credit Card and **Billing Country:** 'CL'

**Before:**

![image](https://user-images.githubusercontent.com/70591946/140759787-a4732776-23a8-429b-9844-4eef98b7c87b.png)

**After:**

![image](https://user-images.githubusercontent.com/70591946/140759855-7c768069-0fa1-46dd-8f24-12de772a9bc0.png)

- *Payment method:** Credit Card and **Billing Country:** 'MX'

**Before:**

![image](https://user-images.githubusercontent.com/70591946/140760150-bdb811a3-38fe-4385-8abb-8b1e042964cf.png)

**After:**

![image](https://user-images.githubusercontent.com/70591946/140760224-aac4ab73-89be-4d3c-84a0-9e9da45e2ce5.png)

