### PR TITLE
fix (checkout): When the user changes the country the state was left with the previous value

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/BillingInformation/BillingInformation.js
+++ b/src/components/ChangePlanDeprecated/Checkout/BillingInformation/BillingInformation.js
@@ -117,6 +117,7 @@ export const BillingInformation = InjectAppServices(
       setFieldValue(fieldNames.country, country);
       const result = await staticDataClient.getStatesData(country, language);
       setStates(result.success ? result.value : []);
+      setFieldValue(fieldNames.province, '');
     };
 
     const submitBillingInformationForm = async (values) => {


### PR DESCRIPTION
Fix issue when the user changes the country, the state was left with the previous value instead of the the empty value

**Bug:** [DAT-685](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-685)