### PR TITLE
feat: add redirect from /plan-selection to /plan-selection/premium/by…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,7 @@ import { CheckoutSummary } from './components/ChangePlanDeprecated/Checkout/Chec
 import { Dashboard } from './components/Dashboard/Dashboard';
 import { ControlPanel } from './components/ControlPanel/ControlPanel';
 import { PlanCalculator } from './components/Plans/PlanCalculator';
+import { PLAN_TYPE, URL_PLAN_TYPE } from './doppler-types';
 
 /**
  * @param { Object } props - props
@@ -163,6 +164,11 @@ const App = ({ locale, location, window, dependencies: { appSessionRef, sessionM
                 to="/forgot-password?lang=es"
               />
               <RedirectWithQuery exact from="/forgot-password" to="/login/reset-password" />
+              <RedirectWithQuery
+                exact
+                from="/plan-selection"
+                to={`/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byContact]}`}
+              />
               {/* TODO: Implement NotFound page in place of redirect all to reports */}
               {/* <Route component={NotFound} /> */}
               <Route component={() => <Redirect to={{ pathname: '/reports' }} />} />


### PR DESCRIPTION
### **Redirect to /plan-selection/premium/by-contacts**
**details task:** https://makingsense.atlassian.net/browse/DW-1269
CDN Int: https://cdn.fromdoppler.com/doppler-webapp/int-build4149/#/plan-selection

**Description**
When the user navigates to /plan-selection URL will be redirected to /plan-selection/premium/by-contacts

**Preview:**
![ezgif com-gif-maker](https://user-images.githubusercontent.com/84402180/141140700-36dbf4f9-8439-40ba-a00b-508c5484a628.gif)

