### PR TITLE
[DAT-689] - Add available credit cards legend when the credit card section is in update view

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/CreditCard.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/CreditCard.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { InjectAppServices } from '../../../../services/pure-di';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useFormikContext } from 'formik';
 import { Loading } from '../../../Loading/Loading';
 import Cards from 'react-credit-cards';
@@ -54,6 +54,17 @@ export const getCreditCardBrand = (creditCardNumber) => {
     return 'amex';
   }
   return 'unknown';
+};
+
+const FormatMessageWithBoldWords = ({ id }) => {
+  return (
+    <FormattedMessage
+      id={id}
+      values={{
+        bold: (chunks) => <b>{chunks}</b>,
+      }}
+    />
+  );
 };
 
 export const CreditCard = InjectAppServices(
@@ -152,120 +163,131 @@ export const CreditCard = InjectAppServices(
                 />
               </li>
             ) : (
-              <FieldItem className="field-item field-credit-card">
-                <div className="campos">
-                  <div className="dp-field-inputs">
-                    <div className="campo-izq" style={{ flex: 1 }}>
-                      <FieldGroup>
-                        <InputMask
-                          mask={ccMask}
-                          value={number}
-                          onChange={(e) => onChangeNumber(e, setFieldValue)}
-                          onFocus={(e) => setFocus(e.target.name)}
-                          maskChar="-"
-                        >
-                          {(inputProps) => (
-                            <InputFieldItem
-                              {...inputProps}
-                              type="text"
-                              label={`*${_('checkoutProcessForm.payment_method.credit_card')}`}
-                              fieldName={fieldNames.number}
-                              id="number"
-                              required
-                            />
-                          )}
-                        </InputMask>
-                      </FieldGroup>
+              <>
+                <FieldItem className="field-item">
+                  <div className="dp-considerations">
+                    <p>
+                      <FormatMessageWithBoldWords id="checkoutProcessForm.payment_method.availabled_credit_cards_legend" />
+                    </p>
+                  </div>
+                </FieldItem>
+                <FieldItem className="field-item field-credit-card">
+                  <div className="campos">
+                    <div className="dp-field-inputs">
+                      <div className="campo-izq" style={{ flex: 1 }}>
+                        <FieldGroup>
+                          <InputMask
+                            mask={ccMask}
+                            value={number}
+                            onChange={(e) => onChangeNumber(e, setFieldValue)}
+                            onFocus={(e) => setFocus(e.target.name)}
+                            maskChar="-"
+                          >
+                            {(inputProps) => (
+                              <InputFieldItem
+                                {...inputProps}
+                                type="text"
+                                label={`*${_('checkoutProcessForm.payment_method.credit_card')}`}
+                                fieldName={fieldNames.number}
+                                id="number"
+                                required
+                              />
+                            )}
+                          </InputMask>
+                        </FieldGroup>
+                      </div>
+                      <div className="dp--expiry">
+                        <FieldGroup>
+                          <InputMask
+                            mask="99/99"
+                            maskChar="-"
+                            value={expiry}
+                            onChange={(e) => {
+                              setFieldValue(fieldNames.expiry, e.target.value);
+                              setExpiry(e.target.value);
+                            }}
+                            onFocus={(e) => setFocus(e.target.name)}
+                          >
+                            {(inputProps) => (
+                              <InputFieldItem
+                                {...inputProps}
+                                type="text"
+                                label={`*${_(
+                                  'checkoutProcessForm.payment_method.expiration_date',
+                                )}`}
+                                fieldName={fieldNames.expiry}
+                                id="expiry"
+                                required
+                              />
+                            )}
+                          </InputMask>
+                        </FieldGroup>
+                      </div>
                     </div>
-                    <div className="dp--expiry">
-                      <FieldGroup>
-                        <InputMask
-                          mask="99/99"
-                          maskChar="-"
-                          value={expiry}
-                          onChange={(e) => {
-                            setFieldValue(fieldNames.expiry, e.target.value);
-                            setExpiry(e.target.value);
-                          }}
-                          onFocus={(e) => setFocus(e.target.name)}
-                        >
-                          {(inputProps) => (
-                            <InputFieldItem
-                              {...inputProps}
-                              type="text"
-                              label={`*${_('checkoutProcessForm.payment_method.expiration_date')}`}
-                              fieldName={fieldNames.expiry}
-                              id="expiry"
-                              required
-                            />
-                          )}
-                        </InputMask>
-                      </FieldGroup>
+                    <div className="dp-field-inputs">
+                      <div className="campo-izq" style={{ flex: 1 }}>
+                        <FieldGroup>
+                          <InputFieldItem
+                            type="text"
+                            fieldName={fieldNames.name}
+                            id="name"
+                            label={`*${_('checkoutProcessForm.payment_method.holder_name')}`}
+                            required
+                            onChange={(e) => {
+                              setFieldValue('name', e.target.value);
+                              setName(e.target.value);
+                            }}
+                            onFocus={(e) => setFocus(e.target.name)}
+                            value={name}
+                            placeholder=""
+                          />
+                        </FieldGroup>
+                      </div>
+                      <div className="dp--cvv">
+                        <FieldGroup>
+                          <InputMask
+                            mask={cvcMask}
+                            maskChar="-"
+                            value={cvc}
+                            onChange={(e) => {
+                              setFieldValue(fieldNames.cvc, e.target.value);
+                              setCvc(e.target.value);
+                            }}
+                            onFocus={(e) => setFocus(e.target.name)}
+                          >
+                            {(inputProps) => (
+                              <InputFieldItem
+                                {...inputProps}
+                                type="tel"
+                                label={`*${_('checkoutProcessForm.payment_method.security_code')}`}
+                                fieldName={fieldNames.cvc}
+                                id="cvc"
+                                required
+                              />
+                            )}
+                          </InputMask>
+                        </FieldGroup>
+                      </div>
                     </div>
                   </div>
-                  <div className="dp-field-inputs">
-                    <div className="campo-izq" style={{ flex: 1 }}>
-                      <FieldGroup>
-                        <InputFieldItem
-                          type="text"
-                          fieldName={fieldNames.name}
-                          id="name"
-                          label={`*${_('checkoutProcessForm.payment_method.holder_name')}`}
-                          required
-                          onChange={(e) => {
-                            setFieldValue('name', e.target.value);
-                            setName(e.target.value);
-                          }}
-                          onFocus={(e) => setFocus(e.target.name)}
-                          value={name}
-                          placeholder=""
-                        />
-                      </FieldGroup>
-                    </div>
-                    <div className="dp--cvv">
-                      <FieldGroup>
-                        <InputMask
-                          mask={cvcMask}
-                          maskChar="-"
-                          value={cvc}
-                          onChange={(e) => {
-                            setFieldValue(fieldNames.cvc, e.target.value);
-                            setCvc(e.target.value);
-                          }}
-                          onFocus={(e) => setFocus(e.target.name)}
-                        >
-                          {(inputProps) => (
-                            <InputFieldItem
-                              {...inputProps}
-                              type="tel"
-                              label={`*${_('checkoutProcessForm.payment_method.security_code')}`}
-                              fieldName={fieldNames.cvc}
-                              id="cvc"
-                              required
-                            />
-                          )}
-                        </InputMask>
-                      </FieldGroup>
+                  <div className="tarjeta">
+                    <div className="dp-credit-card">
+                      <Cards
+                        cvc={cvc}
+                        expiry={expiry}
+                        focused={focus}
+                        name={name}
+                        number={number}
+                        acceptedCards={['visa', 'mastercard', 'amex']}
+                        placeholders={{
+                          name: _('checkoutProcessForm.payment_method.placeholder_holder_name'),
+                        }}
+                        locale={{ valid: _('checkoutProcessForm.payment_method.valid_thru') }}
+                      />
                     </div>
                   </div>
-                </div>
-                <div className="tarjeta">
-                  <div className="dp-credit-card">
-                    <Cards
-                      cvc={cvc}
-                      expiry={expiry}
-                      focused={focus}
-                      name={name}
-                      number={number}
-                      acceptedCards={['visa', 'mastercard', 'amex']}
-                      placeholders={{
-                        name: _('checkoutProcessForm.payment_method.placeholder_holder_name'),
-                      }}
-                      locale={{ valid: _('checkoutProcessForm.payment_method.valid_thru') }}
-                    />
-                  </div>
-                </div>
-              </FieldItem>
+                </FieldItem>
+              </>
             )}
           </FieldGroup>
         )}

--- a/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/CreditCard.test.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PaymentMethod/CreditCard.test.js
@@ -7,6 +7,7 @@ import { fakeAccountPlanDiscounts } from '../../../../services/doppler-account-p
 import { actionPage } from '../Checkout';
 import { CreditCard } from './CreditCard';
 import { Formik } from 'formik';
+import '@testing-library/jest-dom/extend-expect';
 
 const dependencies = (withError) => ({
   appSessionRef: {
@@ -205,5 +206,34 @@ describe('CreditCard component', () => {
     expect(cardHolderElement.textContent).toEqual(emptyHolderName);
     expect(expiryDateElement.textContent).toEqual(emptyExpiryDate);
     expect(securityCodeElement.textContent).toEqual('');
+  });
+
+  it('update view - should show the available credit cards legend', async () => {
+    // Act
+    render(<CreditCardElement withError={false} updateView={actionPage.UPDATE} />);
+
+    // Assert
+    const avalilableCrediCardsLegend = screen.getByText(
+      'checkoutProcessForm.payment_method.availabled_credit_cards_legend',
+    );
+
+    expect(avalilableCrediCardsLegend).toBeInTheDocument();
+  });
+
+  it('readonly view - should hide the available credit cards legend', async () => {
+    // Act
+    render(<CreditCardElement withError={false} updateView={actionPage.READONLY} />);
+
+    // Assert
+    // Loader should disappear once request resolves
+    const loader = screen.getByTestId('wrapper-loading');
+    await waitForElementToBeRemoved(loader);
+
+    // Assert
+    const avalilableCrediCardsLegend = screen.queryByText(
+      'checkoutProcessForm.payment_method.availabled_credit_cards_legend',
+    );
+
+    expect(avalilableCrediCardsLegend).not.toBeInTheDocument();
   });
 });

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -202,6 +202,7 @@ const messages_en = {
     edit: 'Edit',
     empty_option_select: `Please select an option`,
     payment_method: {
+      availabled_credit_cards_legend: 'You can pay with any international credit card <bold>Visa, Mastercard or American Express</bold>.',
       business_name: 'Business name',
       considerations: 'Consideration:',
       considerations_credit_card_note_1: '<bold>Invoices in USD will be issued from United States</bold>, where is located our subsidiary Doppler LLC.',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -203,6 +203,7 @@ const messages_es = {
     edit: 'Editar',
     empty_option_select: `Selecciona una opción`,
     payment_method: {
+      availabled_credit_cards_legend: 'Puedes pagar con cualquier tarjeta de crédito internacional <bold>Visa, Mastercard o American Express</bold>.',
       business_name: 'Razón social',
       considerations: 'Consideraciones:',
       considerations_credit_card_note_1: 'Emitiremos una <bold>factura en dólares desde Estados Unidos</bold>, donde se encuentra nuestra filial Doppler LLC.',


### PR DESCRIPTION
Add available credit cards legend when the credit card section is in update view.

**Before:**

![image](https://user-images.githubusercontent.com/70591946/141142002-7c3e6420-ec62-458c-8918-1687ca5fdcfb.png)

**After:**

![image](https://user-images.githubusercontent.com/70591946/141142303-984bdd89-5b40-4882-a94a-3dc0c86313c5.png)

**Task:** [DAT-689](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-689)

