### PR TITLE
feat: add query params when the user navigates between tabs

### DIFF
--- a/src/components/Plans/PlanCalculator/NavigatorTabs/NavigatorTabs.js
+++ b/src/components/Plans/PlanCalculator/NavigatorTabs/NavigatorTabs.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { URL_PLAN_TYPE } from '../../../../doppler-types';
 import { TooltipContainer } from './../../../TooltipContainer/TooltipContainer';
 
 export const NavigatorTabs = ({ tabs, selectedPlanType }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const location = useLocation();
 
   const getTypePlanDescriptionWithTooltip = (type) => {
     return (
@@ -29,7 +30,7 @@ export const NavigatorTabs = ({ tabs, selectedPlanType }) => {
         {tabs.map((type) => (
           <li data-testid="tab-item--plan-calculator" className="tab--item" key={type}>
             <Link
-              to={`/plan-selection/premium/${URL_PLAN_TYPE[type]}`}
+              to={`/plan-selection/premium/${URL_PLAN_TYPE[type]}${location.search}`}
               className={type === selectedPlanType ? 'tab--link active' : 'tab--link'}
             >
               {getTypePlanDescriptionWithTooltip(type)}

--- a/src/components/Plans/PlanCalculator/NavigatorTabs/NavigatorTabs.test.js
+++ b/src/components/Plans/PlanCalculator/NavigatorTabs/NavigatorTabs.test.js
@@ -11,6 +11,7 @@ describe('NavigatorTabs Component', () => {
     //Arrange
     const planTypes = [PLAN_TYPE.byContact, PLAN_TYPE.byEmail, PLAN_TYPE.byCredit];
     const selectedPlanType = PLAN_TYPE.byContact;
+
     //Act
     render(
       <IntlProvider>
@@ -19,6 +20,7 @@ describe('NavigatorTabs Component', () => {
         </Router>
       </IntlProvider>,
     );
+
     //Assert
     const allTabs = screen.queryAllByRole('listitem');
     expect(allTabs.length).toBe(planTypes.length);
@@ -29,6 +31,39 @@ describe('NavigatorTabs Component', () => {
       expect(link).toHaveAttribute(
         'href',
         `/plan-selection/premium/${URL_PLAN_TYPE[planTypes[index]]}`,
+      );
+    });
+  });
+
+  test('NavigatorTab component render a tab for each planType with query params', () => {
+    //Arrange
+    const planTypes = [PLAN_TYPE.byContact, PLAN_TYPE.byEmail, PLAN_TYPE.byCredit];
+    const selectedPlanType = PLAN_TYPE.byContact;
+    const search = '?origin=hello_bar&promo-code=fake-promo-code';
+
+    //Act
+    render(
+      <IntlProvider>
+        <Router
+          initialEntries={[
+            `/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byContact]}${search}`,
+          ]}
+        >
+          <NavigatorTabs tabs={planTypes} selectedPlanType={selectedPlanType} />
+        </Router>
+      </IntlProvider>,
+    );
+
+    //Assert
+    const allTabs = screen.queryAllByRole('listitem');
+    expect(allTabs.length).toBe(planTypes.length);
+
+    const links = screen.getAllByRole('link');
+
+    links.forEach((link, index) => {
+      expect(link).toHaveAttribute(
+        'href',
+        `/plan-selection/premium/${URL_PLAN_TYPE[planTypes[index]]}${search}`,
       );
     });
   });


### PR DESCRIPTION
### **Add query params when the user navigates between tabs**
**details task:** https://makingsense.atlassian.net/browse/DW-1270
**CDN int:** https://cdn.fromdoppler.com/doppler-webapp/int-build4165/#/plan-selection/premium/by-credits?promo-code=fake-promo-code&origin=hello_bar
 
**Result:**
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/84402180/141318297-d455ac12-0913-49de-bad0-4f256cac8d8d.gif)

 