### PR TITLE
fix: enable button of contact policy when a list is deleted

### DIFF
--- a/src/components/ContactPolicy/ContactPolicy.js
+++ b/src/components/ContactPolicy/ContactPolicy.js
@@ -330,9 +330,7 @@ export const ContactPolicy = InjectAppServices(
                             <span className="align-button m-l-24">
                               <button
                                 type="submit"
-                                disabled={
-                                  !(isValid && dirty) || isSubmitting || (formSubmitted && !error)
-                                }
+                                disabled={!isValid || !dirty || isSubmitting}
                                 className={
                                   'dp-button button-medium primary-green' +
                                   ((isSubmitting && ' button--loading') || '')


### PR DESCRIPTION
### **Enable save button of contact policy when a list is deleted**
**details task:** https://makingsense.atlassian.net/browse/DW-1274

**Description**

1. The user navigates to /sending-preferences/contact-policy
2. The contact policy is enabled
3. The user adds a list and the save button is clicked 
4. The user delete a list 
5. The save button is enabled
 