### PR TITLE
fix: fix space between amount & currency

### DIFF
--- a/src/components/Plans/PlanCalculator/PlanPrice/PricePerExtraEmail/index.js
+++ b/src/components/Plans/PlanCalculator/PlanPrice/PricePerExtraEmail/index.js
@@ -20,7 +20,7 @@ export const PricePerExtraEmail = ({ selectedPlan }) => {
     <p className="dp-cost-per-email">
       {_('plan_calculator.cost_per_email')}{' '}
       <span className="dp-price-large-money">
-        <strong>US${extraEmailPrice}</strong>
+        <strong>US$ {extraEmailPrice}</strong>
       </span>
     </p>
   );

--- a/src/components/Plans/PlanCalculator/PlanPrice/PriceWithDiscount/index.js
+++ b/src/components/Plans/PlanCalculator/PlanPrice/PriceWithDiscount/index.js
@@ -23,11 +23,7 @@ export const PriceWithDiscount = ({ selectedPlan, selectedDiscount }) => {
       {_(
         'plan_calculator.with_' + selectedDiscount.subscriptionType.replace('-', '_') + '_discount',
       )}
-      <strong>
-        {' '}
-        US$
-        {planFeeWithDiscount}
-      </strong>
+      <strong> US$ {planFeeWithDiscount}</strong>
     </p>
   );
 };


### PR DESCRIPTION
Space between currency and amount in plan calculator

**When a discount is selected**

<img width="818" alt="Captura de Pantalla 2021-11-16 a la(s) 10 41 06 a  m" src="https://user-images.githubusercontent.com/84402180/142017069-d64fe3ad-7185-4571-80da-9147ea132674.png">

**When plan type is for emails**
<img width="392" alt="Captura de Pantalla 2021-11-16 a la(s) 10 43 14 a  m" src="https://user-images.githubusercontent.com/84402180/142017366-7c5c9338-4ebf-454b-aa36-d7cf4a981602.png">


