### PR TITLE
fix: fix the order of discounts in the plan calculator

### DIFF
--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
@@ -28,7 +28,8 @@ export const plansByTypeReducer = (state, action) => {
     case PLANS_BY_TYPE_ACTIONS.RECEIVE_PLANS_BY_TYPE:
       const { payload: plansByType } = action;
       const sliderValuesRange = plansByType.map(amountByPlanType);
-      const discounts = plansByType[0].billingCycleDetails?.map(mapDiscount) ?? [];
+      const discounts =
+        plansByType[0].billingCycleDetails?.map(mapDiscount).sort(orderDiscount) ?? [];
       return {
         ...state,
         loading: false,
@@ -52,7 +53,9 @@ export const plansByTypeReducer = (state, action) => {
     case PLANS_BY_TYPE_ACTIONS.SEARCH_DISCOUNTS_BY_INDEX_PLAN:
       const { payload: selectedPlanIndex } = action;
       const _discounts =
-        state.plansByType[selectedPlanIndex].billingCycleDetails?.map(mapDiscount) ?? [];
+        state.plansByType[selectedPlanIndex].billingCycleDetails
+          ?.map(mapDiscount)
+          .sort(orderDiscount) ?? [];
 
       return {
         ...state,
@@ -85,6 +88,9 @@ export const mapDiscount = (discount) => ({
   numberMonths: getMonthsByCycle(discount.billingCycle),
   discountPercentage: discount.discountPercentage,
 });
+
+export const orderDiscount = (currentDiscount, nextDiscount) =>
+  currentDiscount.numberMonths - nextDiscount.numberMonths;
 
 export const getMonthsByCycle = (subscriptionType) => {
   switch (subscriptionType) {

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
@@ -4,6 +4,7 @@ import {
   amountByPlanType,
   INITIAL_STATE_PLANS_BY_TYPE,
   mapDiscount,
+  orderDiscount,
   plansByTypeReducer,
   PLANS_BY_TYPE_ACTIONS,
 } from './plansByTypeReducer';
@@ -35,7 +36,8 @@ describe('plansByTypeReducer', () => {
     const newState = plansByTypeReducer(INITIAL_STATE_PLANS_BY_TYPE, action);
 
     // Assert
-    const discounts = plansByType[0].billingCycleDetails?.map(mapDiscount) ?? [];
+    const discounts =
+      plansByType[0].billingCycleDetails?.map(mapDiscount).sort(orderDiscount) ?? [];
     expect(newState).toEqual({
       ...INITIAL_STATE_PLANS_BY_TYPE,
       loading: false,


### PR DESCRIPTION
### **Fix the order of discounts in the Plan Calculator**
**details task:** https://makingsense.atlassian.net/browse/DW-1289

**Before:**

<img width="539" alt="Captura de Pantalla 2021-11-17 a la(s) 7 50 08 a  m" src="https://user-images.githubusercontent.com/84402180/142203867-f42b97f4-9969-4fcb-9350-eefb9914107a.png">

**After:**

<img width="502" alt="Captura de Pantalla 2021-11-17 a la(s) 7 50 28 a  m" src="https://user-images.githubusercontent.com/84402180/142203957-58feca88-232b-45f2-9697-ec22069cbd82.png">


