### PR TITLE
[DAT-622] - Update 'EditAddRecipients' component to supports add or edit.

### DIFF
--- a/src/components/ChangePlanDeprecated/Checkout/Checkout.test.js
+++ b/src/components/ChangePlanDeprecated/Checkout/Checkout.test.js
@@ -13,7 +13,10 @@ import {
 } from '../../../services/static-data-client.double';
 import { fakePlanAmountDetails } from '../../../services/doppler-account-plans-api-client';
 import { fakePlan } from '../../../services/doppler-account-plans-api-client.double';
-import { fakePaymentMethodInformation } from '../../../services//doppler-billing-user-api-client.double';
+import {
+  fakeInvoiceRecipients,
+  fakePaymentMethodInformation,
+} from '../../../services//doppler-billing-user-api-client.double';
 import { fakeAccountPlanDiscounts } from '../../../services/doppler-account-plans-api-client.double';
 
 describe('Checkout component', () => {
@@ -32,6 +35,20 @@ describe('Checkout component', () => {
   };
 
   const dependencies = {
+    appSessionRef: {
+      current: {
+        userData: {
+          user: {
+            email: 'hardcoded@email.com',
+            plan: {
+              planType: '1',
+              planSubscription: 1,
+              monthPlan: 1,
+            },
+          },
+        },
+      },
+    },
     dopplerUserApiClient: {
       getContactInformationData: async () => {
         return { success: true, value: contactInformation };
@@ -48,6 +65,12 @@ describe('Checkout component', () => {
     dopplerBillingUserApiClient: {
       getPaymentMethodData: async () => {
         return { success: true, value: fakePaymentMethodInformation };
+      },
+      getInvoiceRecipientsData: async () => {
+        return { success: true, value: fakeInvoiceRecipients };
+      },
+      updateInvoiceRecipients: async () => {
+        return { success: true };
       },
     },
     dopplerAccountPlansApiClient: {

--- a/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/InvoiceRecipients.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/InvoiceRecipients.js
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { useIntl, FormattedMessage } from 'react-intl';
+import { FieldGroup, FieldItem, SubmitButton } from '../../../form-helpers/form-helpers';
+import { Form, Formik } from 'formik';
+import { validateEmail } from '../../../../validations';
+import { CloudTagField } from '../../../form-helpers/CloudTagField';
+
+const fieldNames = {
+  editRecipients: 'editRecipients',
+};
+
+export const InvoiceRecipients = ({ emails, viewOnly, onSubmit }) => {
+  const intl = useIntl();
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const [edit, setEdit] = useState(!viewOnly);
+
+  const _validateEmail = (value) => {
+    const errorKey = validateEmail(value);
+    return errorKey ? <FormattedMessage id={errorKey} /> : null;
+  };
+
+  const submitEditRecipients = (values) => {
+    setEdit(false);
+    onSubmit(values);
+  };
+
+  const formikConfig = {
+    enableReinitialize: true,
+    initialValues: { [fieldNames.editRecipients]: emails },
+    validateOnChange: false,
+    validateOnBlur: false,
+    onSubmit: submitEditRecipients,
+  };
+
+  return (
+    <>
+      <hr className="dp-hr-summary"></hr>
+      <p className="m-b-12">
+        {_('checkoutProcessForm.purchase_summary.send_invoice_email_message')}
+      </p>
+      {!edit ? (
+        <>
+          <p className="m-b-12">
+            <strong>{emails?.join(', ')}</strong>
+          </p>
+          <button className="dp-button link-green" onClick={() => setEdit(true)}>
+            {_('checkoutProcessForm.purchase_summary.edit_add_recipients_button')}
+          </button>
+        </>
+      ) : (
+        <>
+          <Formik {...formikConfig}>
+            {() => (
+              <Form className="dp-add-tags" aria-label="form" noValidate>
+                <legend>{_('checkoutProcessForm.purchase_summary.header')}</legend>
+                <fieldset>
+                  <FieldGroup className="m-b-24">
+                    <CloudTagField
+                      fieldName={fieldNames.editRecipients}
+                      validateTag={_validateEmail}
+                      render={({ value, onChange, onKeyDown }) => (
+                        <input
+                          type="email"
+                          placeholder={'Agregar destinatario'}
+                          value={value}
+                          onChange={onChange}
+                          onKeyDown={onKeyDown}
+                          className="dp--dashed"
+                        />
+                      )}
+                    />
+                  </FieldGroup>
+                  <FieldGroup>
+                    <FieldItem className="field-item">
+                      <div className="dp-buttons-actions">
+                        <SubmitButton className="dp-button button-medium primary-green">
+                          {_(
+                            'checkoutProcessForm.purchase_summary.edit_add_recipients_confirmation_button',
+                          )}
+                        </SubmitButton>
+                      </div>
+                    </FieldItem>
+                  </FieldGroup>
+                </fieldset>
+              </Form>
+            )}
+          </Formik>
+        </>
+      )}
+    </>
+  );
+};

--- a/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/InvoiceRecipients.test.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/InvoiceRecipients.test.js
@@ -1,0 +1,156 @@
+import { render, screen, act } from '@testing-library/react';
+import { AppServicesProvider } from '../../../../services/pure-di';
+import IntlProvider from '../../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+import { InvoiceRecipients } from './InvoiceRecipients';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+
+const mockedOnSubmit = jest.fn();
+
+const InvoiceRecipientsElement = ({ emails, viewOnly }) => {
+  return (
+    <AppServicesProvider>
+      <IntlProvider>
+        <InvoiceRecipients emails={emails} viewOnly={viewOnly} onSubmit={mockedOnSubmit} />
+      </IntlProvider>
+    </AppServicesProvider>
+  );
+};
+
+describe('InvoiceRecipients component', () => {
+  it('readonly view - should show the invoice emails separated by comma', async () => {
+    //Arrange
+    const emails = ['mail1@test.com', 'mail2@test.com'];
+
+    // Act
+    render(<InvoiceRecipientsElement emails={emails} viewOnly={true} />);
+
+    // Assert
+    const emailsSeparatedByComma = emails.join(', ');
+    const submitButton = screen.getByRole('button', {
+      name: 'checkoutProcessForm.purchase_summary.edit_add_recipients_button',
+    });
+
+    expect(submitButton).toBeInTheDocument();
+    expect(screen.getByText(emailsSeparatedByComma)).toBeInTheDocument();
+  });
+
+  it('edit view - should not show tag cloud', () => {
+    // Arrange
+    const emails = [];
+
+    // Act
+    render(<InvoiceRecipientsElement emails={emails} viewOnly={false} />);
+
+    // Assert
+    expect(screen.queryByRole('list', { name: 'cloud tags' })).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox').value).toBe('');
+  });
+
+  it('edit view - should show the tag cloud with the initial values', () => {
+    // Arrange
+    const emails = ['harcode_1@mail.com', 'harcode_2@mail.com'];
+
+    // Act
+    render(<InvoiceRecipientsElement emails={emails} viewOnly={false} />);
+
+    // Assert
+    const cloudTags = screen.getByRole('list', { name: 'cloud tags' });
+    expect(cloudTags).toBeInTheDocument();
+    expect(cloudTags.querySelectorAll('li').length).toBe(emails.length);
+    expect(screen.getByRole('textbox').value).toBe('');
+  });
+
+  it('edit view - should add tags when passing validations and submit form', async () => {
+    // Arrange
+    const tagToAdd1 = 'harcode_1@mail.com';
+    const invalidTag = 'harcode_fail';
+    const tagToAdd2 = 'harcode_2@mail.com';
+    const emails = [];
+
+    // Act
+    render(<InvoiceRecipientsElement emails={emails} viewOnly={false} />);
+
+    // Assert
+    const getCloudTags = () => screen.queryByRole('list', { name: 'cloud tags' });
+    const getErrors = () => screen.queryByRole('alert');
+
+    let cloudTags = getCloudTags();
+    let errors;
+    const input = screen.getByRole('textbox');
+    const addButton = screen.getByRole('button', { name: 'add tag' });
+    expect(getCloudTags()).not.toBeInTheDocument();
+    expect(input.value).toBe('');
+
+    // add first tag
+    userEvent.type(input, tagToAdd1);
+    userEvent.click(addButton);
+    cloudTags = getCloudTags();
+    errors = getErrors();
+    expect(cloudTags).toBeInTheDocument();
+    expect(errors).not.toBeInTheDocument();
+
+    // emails.length + 1 because the first tag was added
+    expect(cloudTags.querySelectorAll('li').length).toBe(emails.length + 1);
+
+    // fails when add second tag (simulated with enter event)
+    userEvent.type(input, invalidTag);
+    userEvent.type(input, '{enter}');
+    cloudTags = getCloudTags();
+    errors = getErrors();
+
+    // the same amount of tag is kept because it was not added
+    expect(cloudTags.querySelectorAll('li').length).toBe(emails.length + 1);
+    expect(errors).toBeInTheDocument();
+
+    // success when add second tag (simulated with enter event)
+    userEvent.clear(input);
+    userEvent.type(input, tagToAdd2);
+    userEvent.type(input, '{enter}');
+    cloudTags = getCloudTags();
+    errors = getErrors();
+
+    // emails.length+2 because the second tag was added
+    expect(cloudTags.querySelectorAll('li').length).toBe(emails.length + 2);
+    expect(errors).not.toBeInTheDocument();
+  });
+
+  it('edit view - should call onSubmit function if the submit was succesfully', async () => {
+    // Arrange
+    const tagToAdd1 = 'harcode_1@mail.com';
+    const emails = [];
+
+    // Act
+    render(<InvoiceRecipientsElement emails={emails} viewOnly={false} />);
+
+    // Assert
+    const getCloudTags = () => screen.queryByRole('list', { name: 'cloud tags' });
+    const getErrors = () => screen.queryByRole('alert');
+
+    let cloudTags = getCloudTags();
+    let errors;
+    const input = screen.getByRole('textbox');
+    const addButton = screen.getByRole('button', { name: 'add tag' });
+    expect(getCloudTags()).not.toBeInTheDocument();
+    expect(input.value).toBe('');
+
+    // add first tag
+    userEvent.type(input, tagToAdd1);
+    userEvent.click(addButton);
+    cloudTags = getCloudTags();
+    errors = getErrors();
+    expect(cloudTags).toBeInTheDocument();
+    expect(errors).not.toBeInTheDocument();
+
+    // emails.length + 1 because the first tag was added
+    expect(cloudTags.querySelectorAll('li').length).toBe(emails.length + 1);
+    expect(errors).not.toBeInTheDocument();
+
+    // Click save button
+    const submitButton = screen.getByRole('button', {
+      name: 'checkoutProcessForm.purchase_summary.edit_add_recipients_confirmation_button',
+    });
+    await act(async () => userEvent.click(submitButton));
+    expect(mockedOnSubmit).toBeCalledTimes(1);
+  });
+});

--- a/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.test.js
+++ b/src/components/ChangePlanDeprecated/Checkout/PurchaseSummary/PurchaseSummary.test.js
@@ -4,13 +4,30 @@ import { AppServicesProvider } from '../../../../services/pure-di';
 import '@testing-library/jest-dom/extend-expect';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { PurchaseSummary } from './PurchaseSummary';
-import { fakePaymentMethodInformation } from '../../../../services/doppler-billing-user-api-client.double';
+import {
+  fakeInvoiceRecipients,
+  fakePaymentMethodInformation,
+} from '../../../../services/doppler-billing-user-api-client.double';
 import { fakeAccountPlanDiscounts } from '../../../../services/doppler-account-plans-api-client.double';
 import { fakePlanAmountDetails } from '../../../..//services/doppler-account-plans-api-client';
 import user from '@testing-library/user-event';
 import { PLAN_TYPE } from '../../../../doppler-types';
 
 const dependencies = (dopplerAccountPlansApiClientDouble, dopplerBillingUserApiClientDouble) => ({
+  appSessionRef: {
+    current: {
+      userData: {
+        user: {
+          email: 'hardcoded@email.com',
+          plan: {
+            planType: '1',
+            planSubscription: 1,
+            monthPlan: 1,
+          },
+        },
+      },
+    },
+  },
   dopplerBillingUserApiClient: dopplerBillingUserApiClientDouble,
   dopplerAccountPlansApiClient: dopplerAccountPlansApiClientDouble,
 });
@@ -24,6 +41,12 @@ const dopplerAccountPlansApiClientDoubleBase = {
 const dopplerBillingUserApiClientDoubleBase = {
   getPaymentMethodData: async () => {
     return { success: true, value: fakePaymentMethodInformation };
+  },
+  getInvoiceRecipientsData: async () => {
+    return { success: true, value: fakeInvoiceRecipients };
+  },
+  updateInvoiceRecipients: async () => {
+    return { success: true };
   },
 };
 
@@ -711,6 +734,12 @@ describe.each([
       },
       purchase: async () => {
         return { success: false };
+      },
+      getInvoiceRecipientsData: async () => {
+        return { success: true, value: fakeInvoiceRecipients };
+      },
+      updateInvoiceRecipients: async () => {
+        return { success: true };
       },
     };
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -224,6 +224,7 @@ const messages_en = {
       discount_for_payment_paid: 'Positive balance:',
       discount_for_prepayment: 'Discount for prepayment:',
       edit_add_recipients_button: 'Edit or add recipients',
+      edit_add_recipients_confirmation_button: 'Confirm edit',
       error_message: 'Your payment couldn’t be processed. Choose a different payment method or try it later.',
       explanatory_legend: 'The renewal is automatic and you can cancel it whenever you want. Price Plan may be taxable.',
       explanatory_legend_by_credits: 'Price Plan may be taxable, according to your tax category. You’ll find them detailed on the invoice.',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -225,6 +225,7 @@ const messages_es = {
       discount_for_payment_paid: 'Saldo a favor:',
       discount_for_prepayment: 'Descuento por pago adelantado:',
       edit_add_recipients_button: 'Editar o agregar destinatarios',
+      edit_add_recipients_confirmation_button: 'Confirmar edición',
       error_message: 'Tu pago no pudo procesarse. Elige otro método de pago o inténtalo más tarde.',
       explanatory_legend: 'La renovación es automática y puedes cancelarla cuando quieras. El precio del Plan puede estar sujeto a impuestos.',
       explanatory_legend_by_credits: 'El precio del Plan puede estar sujeto a impuestos, de acuerdo a la categoría impositiva. Estos estarán detallados en tu factura.',

--- a/src/services/doppler-billing-user-api-client.double.ts
+++ b/src/services/doppler-billing-user-api-client.double.ts
@@ -74,6 +74,8 @@ export const fakePaymentMethodInformationWithTransfer = {
   identificationNumber: '12345678',
 };
 
+export const fakeInvoiceRecipients = ['harcode_1@mail.com', 'harcode_2@mail.com'];
+
 export class HardcodedDopplerBillingUserApiClient implements DopplerBillingUserApiClient {
   public async getBillingInformationData(): Promise<
     ResultWithoutExpectedErrors<BillingInformation>
@@ -119,5 +121,27 @@ export class HardcodedDopplerBillingUserApiClient implements DopplerBillingUserA
     console.log('purchase', values);
     await timeout(1500);
     return { success: true };
+  }
+
+  public async getInvoiceRecipientsData(): Promise<ResultWithoutExpectedErrors<string[]>> {
+    console.log('getInvoiceRecipientsData');
+    await timeout(1500);
+
+    return {
+      value: fakeInvoiceRecipients,
+      success: true,
+    };
+  }
+
+  public async updateInvoiceRecipients(
+    values: any,
+    planId: number,
+  ): Promise<EmptyResultWithoutExpectedErrors> {
+    await timeout(1500);
+    console.log('updateInvoiceRecipients');
+    console.log(values);
+    return {
+      success: true,
+    };
   }
 }

--- a/src/services/doppler-billing-user-api-client.test.ts
+++ b/src/services/doppler-billing-user-api-client.test.ts
@@ -8,6 +8,7 @@ import {
   fakePaymentMethodInformation,
   fakePaymentMethod,
   fakeAgreement,
+  fakeInvoiceRecipients,
 } from './doppler-billing-user-api-client.double';
 
 const consoleError = console.error;
@@ -273,5 +274,62 @@ describe('HttpDopplerBillingUserApiClient', () => {
         url: '/accounts/email@mail.com/agreements',
       }),
     );
+  });
+
+  it('should get invoice recipients information', async () => {
+    // Arrange
+    const invoiceRecipients = {
+      data: fakeInvoiceRecipients,
+      status: 200,
+    };
+    const request = jest.fn(async () => invoiceRecipients);
+    const dopplerBillingUserApiClient = createHttpDopplerBillingUserApiClient({ request });
+
+    // Act
+    const result = await dopplerBillingUserApiClient.getInvoiceRecipientsData();
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
+  });
+
+  it('should set error when the connecting fail to get invoice recipients information', async () => {
+    // Arrange
+    const response = {
+      status: 500,
+    };
+
+    const request = jest.fn(async () => response);
+    const dopplerBillingUserApiClient = createHttpDopplerBillingUserApiClient({ request });
+
+    // Act
+    const result = await dopplerBillingUserApiClient.getInvoiceRecipientsData();
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(false);
+  });
+
+  it('should update invoice recipients', async () => {
+    // Arrange
+    const values = fakeInvoiceRecipients;
+    const planId = 5;
+
+    const response = {
+      status: 200,
+    };
+
+    const request = jest.fn(async () => response);
+    const dopplerBillingUserApiClient = createHttpDopplerBillingUserApiClient({ request });
+
+    // Act
+    const result = await dopplerBillingUserApiClient.updateInvoiceRecipients(values, planId);
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
   });
 });


### PR DESCRIPTION
Allow client to add or edit the invoice recipients.

**View only:**

![image](https://user-images.githubusercontent.com/70591946/142415925-49b546c9-bf5c-4f88-a12a-af63c69f647c.png)

**Edition view:**

![image](https://user-images.githubusercontent.com/70591946/142482464-b9f55b9d-69b4-47b5-b16a-e4e2782193e9.png)


**Note:** The idea of this PR is only include the changes in the component and fix unit tests, in the future I will create anothers PRs to include the integrations with the API and also include some unit tests.


**Task:** [DAT-622](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-622)