### PR TITLE
[DOI-358] Disable control panel boxes for free users and hidde plans&specs box

### DIFF
--- a/src/services/control-panel-service.test.ts
+++ b/src/services/control-panel-service.test.ts
@@ -84,8 +84,8 @@ describe('Control Panel Service', () => {
     const result = controlPanelService.getControlPanelSections();
 
     // Assert
-    expect(result[0].boxes[1].disabled === true).toBe(true);
-    expect(result[0].boxes[3].disabled === true).toBe(true);
-    expect(result[0].boxes[4].disabled === true).toBe(true);
+    expect(result[0].boxes[1].disabled).toBe(true);
+    expect(result[0].boxes[3].disabled).toBe(true);
+    expect(result[0].boxes[4].disabled).toBe(true);
   });
 });

--- a/src/services/control-panel-service.test.ts
+++ b/src/services/control-panel-service.test.ts
@@ -23,6 +23,9 @@ describe('Control Panel Service', () => {
     const userData = {
       user: {
         hasClientManager: false,
+        plan: {
+          isFreeAccount: false,
+        },
       },
     };
 
@@ -48,9 +51,9 @@ describe('Control Panel Service', () => {
     const userData = {
       user: {
         hasClientManager: true,
-      },
-      features: {
-        siteTrackingEnabled: false,
+        plan: {
+          isFreeAccount: false,
+        },
       },
     };
 
@@ -61,6 +64,28 @@ describe('Control Panel Service', () => {
 
     // Assert
     expect(result[0].boxes[3].linkUrl.includes('GetBillingInformation')).toBe(true);
+    expect(result[0].boxes[4].disabled === true).toBe(true);
+  });
+
+  it('Account history, billing information and SMS settings boxes should be disabled ', async () => {
+    // Arrange
+    const userData = {
+      user: {
+        hasClientManager: false,
+        plan: {
+          isFreeAccount: true,
+        },
+      },
+    };
+
+    const controlPanelService = createControlPanelService(userData);
+
+    // Act
+    const result = controlPanelService.getControlPanelSections();
+
+    // Assert
+    expect(result[0].boxes[1].disabled === true).toBe(true);
+    expect(result[0].boxes[3].disabled === true).toBe(true);
     expect(result[0].boxes[4].disabled === true).toBe(true);
   });
 });

--- a/src/services/control-panel-service.ts
+++ b/src/services/control-panel-service.ts
@@ -96,6 +96,7 @@ export class ControlPanelService implements ControlPanelService {
         ? this.appSessionRef.current.userData
         : 'none';
     const isClientManager = account !== 'none' ? account.user.hasClientManager : false;
+    const isFreeAccount = account !== 'none' ? account.user.plan.isFreeAccount : false;
 
     return [
       {
@@ -112,6 +113,7 @@ export class ControlPanelService implements ControlPanelService {
             imgSrc: account_movements_icon,
             imgAlt: 'control_panel.account_preferences.account_movements_title',
             iconName: 'control_panel.account_preferences.account_movements_title',
+            disabled: isFreeAccount,
           },
           {
             linkUrl: `${urlAccountPreferences}/GetContactInformation`,
@@ -126,19 +128,21 @@ export class ControlPanelService implements ControlPanelService {
             imgSrc: billing_information_icon,
             imgAlt: 'control_panel.account_preferences.billing_information_title',
             iconName: 'control_panel.account_preferences.billing_information_title',
+            disabled: isFreeAccount,
           },
           {
             linkUrl: `${urlAccountPreferences}/GetSmsConfiguration`,
             imgSrc: sms_settings_icon,
             imgAlt: 'control_panel.account_preferences.sms_settings_title',
             iconName: 'control_panel.account_preferences.sms_settings_title',
-            disabled: isClientManager,
+            disabled: isFreeAccount || isClientManager,
           },
           {
             linkUrl: 'AccountPreferences/plan-selection',
             imgSrc: plans_and_specs_icon,
             imgAlt: 'control_panel.account_preferences.plans_and_specs_title',
             iconName: 'control_panel.account_preferences.plans_and_specs_title',
+            hidden: true,
           },
         ],
       },


### PR DESCRIPTION
To maintain the same flow as the current control panel I'm adding a few changes.

- hide the plans and specs box
- disable account history, SMS settings, and billing information boxes for free users.

Before:
![image](https://user-images.githubusercontent.com/34007887/142692425-98ce4206-169f-41a1-b5a9-fc7e6f7333e5.png)

After:
![image](https://user-images.githubusercontent.com/34007887/142692454-01dd1356-1a30-4894-b378-4b63a93a3b85.png)
