### PR TITLE
fix: fix per month label for credits plan

### DIFF
--- a/src/components/Plans/PlanCalculator/PlanPrice/PricePerMonth/index.js
+++ b/src/components/Plans/PlanCalculator/PlanPrice/PricePerMonth/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
+import { PLAN_TYPE } from '../../../../../doppler-types';
 import { getPlanFee, thousandSeparatorNumber } from '../../../../../utils';
 
 export const PricePerMonth = ({ selectedPlan, discountPercentage }) => {
@@ -10,6 +11,7 @@ export const PricePerMonth = ({ selectedPlan, discountPercentage }) => {
     intl.defaultLocale,
     discountPercentage ? planFee * (1 - discountPercentage / 100) : planFee,
   );
+
   return (
     <>
       <h2 className="dp-price-large">
@@ -18,7 +20,11 @@ export const PricePerMonth = ({ selectedPlan, discountPercentage }) => {
           {planFeeWithDiscount}
         </span>
       </h2>
-      <span className="dp-for-time">{_('plan_calculator.per_month')}</span>
+      {selectedPlan.type !== PLAN_TYPE.byCredit ? (
+        <span className="dp-for-time">{_('plan_calculator.per_month')}</span>
+      ) : (
+        ''
+      )}
     </>
   );
 };

--- a/src/components/Plans/PlanCalculator/PlanPrice/PricePerMonth/index.test.js
+++ b/src/components/Plans/PlanCalculator/PlanPrice/PricePerMonth/index.test.js
@@ -29,4 +29,20 @@ describe('PricePerMonth component', () => {
     //Assert
     expect(screen.getByText(planFeeWithDiscount.toString())).toBeInTheDocument();
   });
+
+  it(`should hide the label "per month" when the plan is for credits`, () => {
+    //Arrange
+    const myFakePlan = allPlans.find((plan) => plan.type === PLAN_TYPE.byCredit);
+    const discountPercentage = 0;
+
+    //Act
+    render(
+      <IntlProvider>
+        <PricePerMonth selectedPlan={myFakePlan} discountPercentage={discountPercentage} />
+      </IntlProvider>,
+    );
+
+    //Assert
+    expect(screen.queryByText('plan_calculator.per_month')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### **Fix Per Month Label for Credits plan**
**details task:** https://makingsense.atlassian.net/browse/DW-1305

**Description**
Remove the "per month" text for credit plans

<img width="774" alt="Captura de Pantalla 2021-11-25 a la(s) 7 50 19 a  m" src="https://user-images.githubusercontent.com/84402180/143444923-059d20f5-527b-4a23-81b3-909a94d13ad3.png">
 