### PR TITLE
Refactoring PlanCalculator and plansByTypeReducer

### DIFF
--- a/src/components/Plans/PlanCalculator/index.js
+++ b/src/components/Plans/PlanCalculator/index.js
@@ -35,6 +35,7 @@ export const PlanCalculator = InjectAppServices(
     const [
       {
         selectedPlanIndex,
+        selectedPlan,
         plansByType,
         sliderValuesRange,
         discounts,
@@ -114,10 +115,8 @@ export const PlanCalculator = InjectAppServices(
       return <UnexpectedError />;
     }
 
-    const isEqualPlan = sessionPlan.plan.idPlan === plansByType[selectedPlanIndex]?.id;
+    const isEqualPlan = sessionPlan.plan.idPlan === selectedPlan?.id;
     const hightestPlan = plansByType.length === 1 && isEqualPlan;
-
-    const selectedPlan = plansByType[selectedPlanIndex];
 
     return (
       <>
@@ -173,7 +172,7 @@ export const PlanCalculator = InjectAppServices(
                   </article>
                 </S.PlanTabContainer>
                 <PlanCalculatorButtons
-                  selectedPlanId={plansByType[selectedPlanIndex]?.id}
+                  selectedPlanId={selectedPlan?.id}
                   selectedDiscountId={selectedDiscount?.id}
                 />
               </div>

--- a/src/components/Plans/PlanCalculator/index.js
+++ b/src/components/Plans/PlanCalculator/index.js
@@ -68,16 +68,16 @@ export const PlanCalculator = InjectAppServices(
     useEffect(() => {
       const fetchPlansByType = async () => {
         try {
-          dispatchPlansByType({ type: PLANS_BY_TYPE_ACTIONS.FETCHING_STARTED });
+          dispatchPlansByType({ type: PLANS_BY_TYPE_ACTIONS.START_FETCH });
           const _plansByType = await planService.getPlansByType(
             getPlanTypeFromUrlSegment(planTypeUrlSegment),
           );
           dispatchPlansByType({
-            type: PLANS_BY_TYPE_ACTIONS.RECEIVE_PLANS_BY_TYPE,
+            type: PLANS_BY_TYPE_ACTIONS.FINISH_FETCH,
             payload: _plansByType,
           });
         } catch (error) {
-          dispatchPlansByType({ type: PLANS_BY_TYPE_ACTIONS.FETCH_FAILED });
+          dispatchPlansByType({ type: PLANS_BY_TYPE_ACTIONS.FAIL_FETCH });
         }
       };
 
@@ -97,14 +97,14 @@ export const PlanCalculator = InjectAppServices(
       const _selectedPlanIndex = parseInt(value);
       setSelectedPlanIndex(_selectedPlanIndex);
       dispatchPlansByType({
-        type: PLANS_BY_TYPE_ACTIONS.SEARCH_DISCOUNTS_BY_INDEX_PLAN,
+        type: PLANS_BY_TYPE_ACTIONS.SELECT_PLAN,
         payload: _selectedPlanIndex,
       });
     };
 
     const handleDiscountChange = (discount) => {
       dispatchPlansByType({
-        type: PLANS_BY_TYPE_ACTIONS.CHANGE_SELECTED_DISCOUNT,
+        type: PLANS_BY_TYPE_ACTIONS.SELECT_DISCOUNT,
         payload: discount,
       });
     };

--- a/src/components/Plans/PlanCalculator/index.js
+++ b/src/components/Plans/PlanCalculator/index.js
@@ -26,7 +26,6 @@ import {
 import { Slider } from './Slider';
 import { UnexpectedError } from './UnexpectedError';
 
-const INITIAL_VALUE_OF_SLIDER = 0;
 export const PlanCalculator = InjectAppServices(
   ({ dependencies: { planService, appSessionRef } }) => {
     const [{ planTypes, loading, hasError }, dispatch] = useReducer(
@@ -35,6 +34,7 @@ export const PlanCalculator = InjectAppServices(
     );
     const [
       {
+        selectedPlanIndex,
         plansByType,
         sliderValuesRange,
         discounts,
@@ -44,7 +44,6 @@ export const PlanCalculator = InjectAppServices(
       dispatchPlansByType,
     ] = useReducer(plansByTypeReducer, INITIAL_STATE_PLANS_BY_TYPE);
     const [activeClass, setActiveClass] = useState('active');
-    const [selectedPlanIndex, setSelectedPlanIndex] = useState(INITIAL_VALUE_OF_SLIDER);
     const createTimeout = useTimeout();
     const intl = useIntl();
     const _ = (id, values) => intl.formatMessage({ id: id }, values);
@@ -82,7 +81,6 @@ export const PlanCalculator = InjectAppServices(
       };
 
       if (planTypes.length > 0) {
-        setSelectedPlanIndex(INITIAL_VALUE_OF_SLIDER);
         fetchPlansByType();
       }
     }, [planService, planTypeUrlSegment, planTypes]);
@@ -95,7 +93,6 @@ export const PlanCalculator = InjectAppServices(
     const handleSliderChange = (e) => {
       const { value } = e.target;
       const _selectedPlanIndex = parseInt(value);
-      setSelectedPlanIndex(_selectedPlanIndex);
       dispatchPlansByType({
         type: PLANS_BY_TYPE_ACTIONS.SELECT_PLAN,
         payload: _selectedPlanIndex,

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
@@ -2,6 +2,7 @@ import { PLAN_TYPE, SUBSCRIPTION_TYPE } from '../../../../doppler-types';
 
 export const INITIAL_STATE_PLANS_BY_TYPE = {
   selectedPlanIndex: 0,
+  selectedPlan: null,
   plansByType: [],
   sliderValuesRange: [],
   discounts: [],
@@ -34,6 +35,7 @@ export const plansByTypeReducer = (state, action) => {
       return {
         ...state,
         selectedPlanIndex: 0,
+        selectedPlan: plansByType[0], // Assuming that there is at leas one plan
         loading: false,
         plansByType,
         sliderValuesRange,
@@ -62,6 +64,7 @@ export const plansByTypeReducer = (state, action) => {
       return {
         ...state,
         selectedPlanIndex,
+        selectedPlan: state.plansByType[selectedPlanIndex],
         discounts: _discounts,
         selectedDiscount: _discounts[0],
       };

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
@@ -10,22 +10,22 @@ export const INITIAL_STATE_PLANS_BY_TYPE = {
 };
 
 export const PLANS_BY_TYPE_ACTIONS = {
-  FETCHING_STARTED: 'FETCHING_STARTED',
-  RECEIVE_PLANS_BY_TYPE: 'RECEIVE_PLANS_BY_TYPE',
-  CHANGE_SELECTED_DISCOUNT: 'CHANGE_SELECTED_DISCOUNT',
-  SEARCH_DISCOUNTS_BY_INDEX_PLAN: 'SEARCH_DISCOUNTS_BY_INDEX_PLAN',
-  FETCH_FAILED: 'FETCH_FAILED',
+  START_FETCH: 'START_FETCH',
+  FINISH_FETCH: 'FINISH_FETCH',
+  SELECT_DISCOUNT: 'SELECT_DISCOUNT',
+  SELECT_PLAN: 'SELECT_PLAN',
+  FAIL_FETCH: 'FAIL_FETCH',
 };
 
 export const plansByTypeReducer = (state, action) => {
   switch (action.type) {
-    case PLANS_BY_TYPE_ACTIONS.FETCHING_STARTED:
+    case PLANS_BY_TYPE_ACTIONS.START_FETCH:
       return {
         ...state,
         loading: true,
         hasError: false,
       };
-    case PLANS_BY_TYPE_ACTIONS.RECEIVE_PLANS_BY_TYPE:
+    case PLANS_BY_TYPE_ACTIONS.FINISH_FETCH:
       const { payload: plansByType } = action;
       const sliderValuesRange = plansByType.map(amountByPlanType);
       const discounts =
@@ -38,19 +38,19 @@ export const plansByTypeReducer = (state, action) => {
         discounts,
         selectedDiscount: discounts[0],
       };
-    case PLANS_BY_TYPE_ACTIONS.FETCH_FAILED:
+    case PLANS_BY_TYPE_ACTIONS.FAIL_FETCH:
       return {
         ...state,
         loading: false,
         hasError: true,
       };
-    case PLANS_BY_TYPE_ACTIONS.CHANGE_SELECTED_DISCOUNT:
+    case PLANS_BY_TYPE_ACTIONS.SELECT_DISCOUNT:
       const { payload: selectedDiscount } = action;
       return {
         ...state,
         selectedDiscount,
       };
-    case PLANS_BY_TYPE_ACTIONS.SEARCH_DISCOUNTS_BY_INDEX_PLAN:
+    case PLANS_BY_TYPE_ACTIONS.SELECT_PLAN:
       const { payload: selectedPlanIndex } = action;
       const _discounts =
         state.plansByType[selectedPlanIndex].billingCycleDetails

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
@@ -1,6 +1,7 @@
 import { PLAN_TYPE, SUBSCRIPTION_TYPE } from '../../../../doppler-types';
 
 export const INITIAL_STATE_PLANS_BY_TYPE = {
+  selectedPlanIndex: 0,
   plansByType: [],
   sliderValuesRange: [],
   discounts: [],
@@ -32,6 +33,7 @@ export const plansByTypeReducer = (state, action) => {
         plansByType[0].billingCycleDetails?.map(mapDiscount).sort(orderDiscount) ?? [];
       return {
         ...state,
+        selectedPlanIndex: 0,
         loading: false,
         plansByType,
         sliderValuesRange,
@@ -59,6 +61,7 @@ export const plansByTypeReducer = (state, action) => {
 
       return {
         ...state,
+        selectedPlanIndex,
         discounts: _discounts,
         selectedDiscount: _discounts[0],
       };

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
@@ -28,13 +28,17 @@ describe('plansByTypeReducer', () => {
   it(`${PLANS_BY_TYPE_ACTIONS.FINISH_FETCH} action`, () => {
     // Arrange
     const plansByType = allPlans.filter((plan) => plan.type === PLAN_TYPE.byContact);
+    const initialState = {
+      ...INITIAL_STATE_PLANS_BY_TYPE,
+      selectedPlanIndex: 15, // An arbitrary plan
+    };
     const action = {
       type: PLANS_BY_TYPE_ACTIONS.FINISH_FETCH,
       payload: plansByType,
     };
 
     // Act
-    const newState = plansByTypeReducer(INITIAL_STATE_PLANS_BY_TYPE, action);
+    const newState = plansByTypeReducer(initialState, action);
 
     // Assert
     const discounts =
@@ -42,6 +46,7 @@ describe('plansByTypeReducer', () => {
     expect(newState).toEqual(
       expect.objectContaining({
         loading: false,
+        selectedPlanIndex: 0,
         plansByType,
         sliderValuesRange: plansByType.map(amountByPlanType),
         discounts,
@@ -88,6 +93,31 @@ describe('plansByTypeReducer', () => {
       ...INITIAL_STATE_PLANS_BY_TYPE,
       selectedDiscount,
     });
+  });
+
+  it(`${PLANS_BY_TYPE_ACTIONS.SELECT_PLAN} action`, () => {
+    // Arrange
+    // TODO: it is not a realistic test because selectedPlanIndex should be one of the
+    // available plans
+    const initialState = {
+      ...INITIAL_STATE_PLANS_BY_TYPE,
+      plansByType: [{}, {}, {}, {}, {}, {}, {} ],
+    };
+    const selectedPlanIndex = 5;
+    const action = {
+      type: PLANS_BY_TYPE_ACTIONS.SELECT_PLAN,
+      payload: selectedPlanIndex,
+    };
+
+    // Act
+    const newState = plansByTypeReducer(initialState, action);
+
+    // Assert
+    expect(newState).toEqual(
+      expect.objectContaining({
+        selectedPlanIndex,
+      }),
+    );
   });
 
   it('should return initialState when the action is not defined', () => {

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
@@ -18,10 +18,11 @@ describe('plansByTypeReducer', () => {
     const newState = plansByTypeReducer(INITIAL_STATE_PLANS_BY_TYPE, action);
 
     // Assert
-    expect(newState).toEqual({
-      ...INITIAL_STATE_PLANS_BY_TYPE,
-      loading: !INITIAL_STATE_PLANS_BY_TYPE.loading,
-    });
+    expect(newState).toEqual(
+      expect.objectContaining({
+        loading: true,
+      }),
+    );
   });
 
   it(`${PLANS_BY_TYPE_ACTIONS.RECEIVE_PLANS_BY_TYPE} action`, () => {
@@ -38,14 +39,15 @@ describe('plansByTypeReducer', () => {
     // Assert
     const discounts =
       plansByType[0].billingCycleDetails?.map(mapDiscount).sort(orderDiscount) ?? [];
-    expect(newState).toEqual({
-      ...INITIAL_STATE_PLANS_BY_TYPE,
-      loading: false,
-      plansByType,
-      sliderValuesRange: plansByType.map(amountByPlanType),
-      discounts,
-      selectedDiscount: discounts[0],
-    });
+    expect(newState).toEqual(
+      expect.objectContaining({
+        loading: false,
+        plansByType,
+        sliderValuesRange: plansByType.map(amountByPlanType),
+        discounts,
+        selectedDiscount: discounts[0],
+      }),
+    );
   });
 
   it(`${PLANS_BY_TYPE_ACTIONS.FETCH_FAILED} action`, () => {
@@ -56,15 +58,18 @@ describe('plansByTypeReducer', () => {
     const newState = plansByTypeReducer(INITIAL_STATE_PLANS_BY_TYPE, action);
 
     // Assert
-    expect(newState).toEqual({
-      ...INITIAL_STATE_PLANS_BY_TYPE,
-      loading: false,
-      hasError: true,
-    });
+    expect(newState).toEqual(
+      expect.objectContaining({
+        loading: false,
+        hasError: true,
+      }),
+    );
   });
 
   it(`${PLANS_BY_TYPE_ACTIONS.CHANGE_SELECTED_DISCOUNT} action`, () => {
     // Arrange
+    // TODO: it is not a realistic test because selectedDiscount should be one of the
+    // plan's discounts
     const selectedDiscount = {
       id: 2,
       subscriptionType: SUBSCRIPTION_TYPE.quarterly,

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
@@ -10,9 +10,9 @@ import {
 } from './plansByTypeReducer';
 
 describe('plansByTypeReducer', () => {
-  it(`${PLANS_BY_TYPE_ACTIONS.FETCHING_STARTED} action`, () => {
+  it(`${PLANS_BY_TYPE_ACTIONS.START_FETCH} action`, () => {
     // Arrange
-    const action = { type: PLANS_BY_TYPE_ACTIONS.FETCHING_STARTED };
+    const action = { type: PLANS_BY_TYPE_ACTIONS.START_FETCH };
 
     // Act
     const newState = plansByTypeReducer(INITIAL_STATE_PLANS_BY_TYPE, action);
@@ -25,11 +25,11 @@ describe('plansByTypeReducer', () => {
     );
   });
 
-  it(`${PLANS_BY_TYPE_ACTIONS.RECEIVE_PLANS_BY_TYPE} action`, () => {
+  it(`${PLANS_BY_TYPE_ACTIONS.FINISH_FETCH} action`, () => {
     // Arrange
     const plansByType = allPlans.filter((plan) => plan.type === PLAN_TYPE.byContact);
     const action = {
-      type: PLANS_BY_TYPE_ACTIONS.RECEIVE_PLANS_BY_TYPE,
+      type: PLANS_BY_TYPE_ACTIONS.FINISH_FETCH,
       payload: plansByType,
     };
 
@@ -50,9 +50,9 @@ describe('plansByTypeReducer', () => {
     );
   });
 
-  it(`${PLANS_BY_TYPE_ACTIONS.FETCH_FAILED} action`, () => {
+  it(`${PLANS_BY_TYPE_ACTIONS.FAIL_FETCH} action`, () => {
     // Arrange
-    const action = { type: PLANS_BY_TYPE_ACTIONS.FETCH_FAILED };
+    const action = { type: PLANS_BY_TYPE_ACTIONS.FAIL_FETCH };
 
     // Act
     const newState = plansByTypeReducer(INITIAL_STATE_PLANS_BY_TYPE, action);
@@ -66,7 +66,7 @@ describe('plansByTypeReducer', () => {
     );
   });
 
-  it(`${PLANS_BY_TYPE_ACTIONS.CHANGE_SELECTED_DISCOUNT} action`, () => {
+  it(`${PLANS_BY_TYPE_ACTIONS.SELECT_DISCOUNT} action`, () => {
     // Arrange
     // TODO: it is not a realistic test because selectedDiscount should be one of the
     // plan's discounts
@@ -76,7 +76,7 @@ describe('plansByTypeReducer', () => {
       discountPercentage: 10,
     };
     const action = {
-      type: PLANS_BY_TYPE_ACTIONS.CHANGE_SELECTED_DISCOUNT,
+      type: PLANS_BY_TYPE_ACTIONS.SELECT_DISCOUNT,
       payload: selectedDiscount,
     };
 

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
@@ -47,6 +47,7 @@ describe('plansByTypeReducer', () => {
       expect.objectContaining({
         loading: false,
         selectedPlanIndex: 0,
+        selectedPlan: plansByType[0],
         plansByType,
         sliderValuesRange: plansByType.map(amountByPlanType),
         discounts,
@@ -97,11 +98,10 @@ describe('plansByTypeReducer', () => {
 
   it(`${PLANS_BY_TYPE_ACTIONS.SELECT_PLAN} action`, () => {
     // Arrange
-    // TODO: it is not a realistic test because selectedPlanIndex should be one of the
-    // available plans
+    const desiredPlan = { desiredPlan: true };
     const initialState = {
       ...INITIAL_STATE_PLANS_BY_TYPE,
-      plansByType: [{}, {}, {}, {}, {}, {}, {} ],
+      plansByType: [{}, {}, {}, {}, {}, desiredPlan, {}],
     };
     const selectedPlanIndex = 5;
     const action = {
@@ -116,6 +116,7 @@ describe('plansByTypeReducer', () => {
     expect(newState).toEqual(
       expect.objectContaining({
         selectedPlanIndex,
+        selectedPlan: desiredPlan,
       }),
     );
   });


### PR DESCRIPTION
Hi team!

I think that the state management in the PlanCalculator component is a little complex. In my opinion, we can do it better by taking advantage of the reducers.

In this PR, I moved `selectedPlanIndex` and `selectedPlan` values into the reducer state.

I think that the next step is merging `plansByTypeReducer` and `planTypesReducer` into only one reducer in order to make the logic clear and test it easier.

Another thing that we need to do is make the reducer test easier to understand, but I know that @silsanchez8 has worked on that, so it is out of the scope of this PR.

@jcamposmk, @silsanchez8 could you give it a look?