### PR TITLE
fix: fix checkout url in plan calculator

### DIFF
--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
@@ -67,15 +67,17 @@ const getLegacyCheckoutPurchaseUrl = ({
 }) => {
   return (
     controlPanelUrl +
-    `/AccountPreferences/UpgradeAccountStep2${currentQueryParams}&IdUserTypePlan=${planId}&fromStep1=True` +
-    `${discountId ? `&IdDiscountPlan=${discountId}` : ''}`
+    `/AccountPreferences/UpgradeAccountStep2?IdUserTypePlan=${planId}&fromStep1=True` +
+    `${discountId ? `&IdDiscountPlan=${discountId}` : ''}` +
+    `${currentQueryParams}`
   );
 };
 
 const getNewCheckoutPurchaseUrl = ({ planType, planId, discountId, currentQueryParams }) => {
   return (
-    `/checkout/premium/${planType}${currentQueryParams}&selected-plan=${planId}` +
-    `${discountId ? `&discountId=${discountId}` : ''}`
+    `/checkout/premium/${planType}?selected-plan=${planId}` +
+    `${discountId ? `&discountId=${discountId}` : ''}` +
+    `${currentQueryParams}`
   );
 };
 
@@ -87,7 +89,7 @@ const getBuyPurchaseUrl = ({
   newCheckoutEnabled,
   search,
 }) => {
-  const currentQueryParams = search ? `${search.replace('promo-code', 'PromoCode')}` : '';
+  const currentQueryParams = search ? `&${search.slice(1).replace('promo-code', 'PromoCode')}` : '';
   return newCheckoutEnabled
     ? getNewCheckoutPurchaseUrl({ planType, planId, discountId, currentQueryParams })
     : getLegacyCheckoutPurchaseUrl({ controlPanelUrl, planId, discountId, currentQueryParams });

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
@@ -56,8 +56,9 @@ describe('PlanCalculator component', () => {
     expect(purchaseLink).toHaveAttribute(
       'href',
       'common.control_panel_section_url' +
-        `/AccountPreferences/UpgradeAccountStep2?PromoCode=fake-promo-code&origin_inbound=fake&IdUserTypePlan=${selectedPlanId}&fromStep1=True` +
-        `&IdDiscountPlan=${selectedDiscountId}`,
+        `/AccountPreferences/UpgradeAccountStep2?IdUserTypePlan=${selectedPlanId}&fromStep1=True` +
+        `&IdDiscountPlan=${selectedDiscountId}` +
+        `&PromoCode=fake-promo-code&origin_inbound=fake`,
     );
   });
 
@@ -100,8 +101,9 @@ describe('PlanCalculator component', () => {
     expect(purchaseLink).not.toHaveClass('disabled');
     expect(purchaseLink).toHaveAttribute(
       'href',
-      `/checkout/premium/${PLAN_TYPE.byContact}?PromoCode=fake-promo-code&origin_inbound=fake&selected-plan=${selectedPlanId}` +
-        `&discountId=${selectedDiscountId}`,
+      `/checkout/premium/${PLAN_TYPE.byContact}?selected-plan=${selectedPlanId}` +
+        `&discountId=${selectedDiscountId}` +
+        `&PromoCode=fake-promo-code&origin_inbound=fake`,
     );
   });
 


### PR DESCRIPTION
**Fix checkout url in plan calculator**

**legacy url**
`/ControlPanel/AccountPreferences/UpgradeAccountStep2&IdUserTypePlan=19&fromStep1=True&IdDiscountPlan=8` **to** `/ControlPanel/AccountPreferences/UpgradeAccountStep2?IdUserTypePlan=19&fromStep1=True&IdDiscountPlan=8`

**new url**
`/checkout/premium/subscribers&selected-plan=19&discountId=8` **to** `/checkout/premium/subscribers?selected-plan=19&discountId=8`