### PR TITLE
Dw 1052 add campaign report service

### DIFF
--- a/.env.int
+++ b/.env.int
@@ -19,3 +19,4 @@ REACT_APP_DOPPLER_USERS_API_URL=https://apisint.fromdoppler.net/doppler-users-ap
 REACT_APP_DOPPLER_BILLING_USER_API_URL=https://apisint.fromdoppler.net/doppler-billing-user
 REACT_APP_DOPPLER_ACCOUNT_PLANS_API_URL=https://apisint.fromdoppler.net/doppler-account-plans
 REACT_APP_DOPPLER_HELP_URL= https://help.fromdoppler.com
+REACT_APP_DOPPLER_REPORTING_URL= https://apisint.fromdoppler.net/reporting

--- a/.env.production
+++ b/.env.production
@@ -19,3 +19,4 @@ REACT_APP_DOPPLER_USERS_API_URL=https://apis.fromdoppler.com/doppler-users-api
 REACT_APP_DOPPLER_BILLING_USER_API_URL=https://apis.fromdoppler.com/doppler-billing-user
 REACT_APP_DOPPLER_ACCOUNT_PLANS_API_URL=https://apis.fromdoppler.com/doppler-account-plans
 REACT_APP_DOPPLER_HELP_URL= https://help.fromdoppler.com
+REACT_APP_DOPPLER_REPORTING_URL= https://apis.fromdoppler.com/reporting

--- a/.env.qa
+++ b/.env.qa
@@ -19,3 +19,4 @@ REACT_APP_DOPPLER_USERS_API_URL=https://apisqa.fromdoppler.net/doppler-users-api
 REACT_APP_DOPPLER_BILLING_USER_API_URL=https://apisqa.fromdoppler.net/doppler-billing-user
 REACT_APP_DOPPLER_ACCOUNT_PLANS_API_URL=https://apisqa.fromdoppler.net/doppler-account-plans
 REACT_APP_DOPPLER_HELP_URL= https://help.fromdoppler.com
+REACT_APP_DOPPLER_REPORTING_URL= https://apisqa.fromdoppler.net/reporting

--- a/src/components/Dashboard/CampaignSummary/index.js
+++ b/src/components/Dashboard/CampaignSummary/index.js
@@ -1,19 +1,13 @@
 import React, { useEffect, useReducer } from 'react';
-import useTimeout from '../../../hooks/useTimeout';
+import { InjectAppServices } from '../../../services/pure-di';
+import { fakeCampaignsSummary } from '../../../services/reports/index.double';
 import { Kpi } from '../Kpis/Kpi';
 import { DashboardIconLink, DashboardIconSubTitle, KpiGroup } from '../Kpis/KpiGroup';
 import {
   ACTIONS_CAMPAIGNS_SUMMARY,
   campaignSummaryReducer,
   initCampaignSummaryReducer,
-  mapCampaignsSummary,
 } from './reducers/campaignSummaryReducer';
-
-export const fakeCampaignsSummary = {
-  totalSentEmails: 21.458,
-  totalOpenClicks: 57,
-  clickThroughRate: 15,
-};
 
 export const INITIAL_STATE_CAMPAIGNS_SUMMARY = {
   loading: false,
@@ -21,28 +15,23 @@ export const INITIAL_STATE_CAMPAIGNS_SUMMARY = {
   kpis: fakeCampaignsSummary,
 };
 
-export const CampaignSummary = () => {
+export const CampaignSummary = InjectAppServices(({ dependencies: { campaignSummaryService } }) => {
   const [{ loading, kpis }, dispatch] = useReducer(
     campaignSummaryReducer,
     INITIAL_STATE_CAMPAIGNS_SUMMARY,
     initCampaignSummaryReducer,
   );
-  const createTimeout = useTimeout();
 
   useEffect(() => {
     const fetchData = async () => {
       dispatch({ type: ACTIONS_CAMPAIGNS_SUMMARY.START_FETCH });
-      const data = await new Promise((resolve) => {
-        createTimeout(() => {
-          resolve(fakeCampaignsSummary);
-        }, 2000);
-      });
-      const mappedData = mapCampaignsSummary(data);
-      dispatch({ type: ACTIONS_CAMPAIGNS_SUMMARY.FINISH_FETCH, payload: mappedData });
+      const response = await campaignSummaryService.getCampaignsSummary();
+      // TODO: define what to do in case of error
+      dispatch({ type: ACTIONS_CAMPAIGNS_SUMMARY.FINISH_FETCH, payload: response.value });
     };
 
     fetchData();
-  }, [createTimeout]);
+  }, [campaignSummaryService]);
 
   return (
     <>
@@ -57,4 +46,4 @@ export const CampaignSummary = () => {
       </KpiGroup>
     </>
   );
-};
+});

--- a/src/components/Dashboard/CampaignSummary/index.test.js
+++ b/src/components/Dashboard/CampaignSummary/index.test.js
@@ -1,8 +1,17 @@
 import '@testing-library/jest-dom/extend-expect';
 import { getByText, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { CampaignSummary, fakeCampaignsSummary } from '.';
+import { CampaignSummary } from '.';
 import IntlProvider from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
-import { mapCampaignsSummary } from './reducers/campaignSummaryReducer';
+import { fakeCampaignsSummary } from '../../../services/reports/index.double';
+import { AppServicesProvider } from '../../../services/pure-di';
+import { mapCampaignsSummary } from '../../../services/campaignSummary';
+
+const reportClientDouble = () => ({
+  getCampaignsSummary: async () => ({
+    success: true,
+    value: fakeCampaignsSummary,
+  }),
+});
 
 describe('CampaignSummary component', () => {
   it('should render CampaignSummary component', async () => {
@@ -11,9 +20,11 @@ describe('CampaignSummary component', () => {
 
     // Act
     render(
-      <IntlProvider>
-        <CampaignSummary />
-      </IntlProvider>,
+      <AppServicesProvider forcedServices={{ reportClient: reportClientDouble() }}>
+        <IntlProvider>
+          <CampaignSummary />
+        </IntlProvider>
+      </AppServicesProvider>,
     );
 
     // Assert

--- a/src/components/Dashboard/CampaignSummary/reducers/campaignSummaryReducer.js
+++ b/src/components/Dashboard/CampaignSummary/reducers/campaignSummaryReducer.js
@@ -1,29 +1,10 @@
+import { mapCampaignsSummary } from '../../../../services/campaignSummary';
+
 export const ACTIONS_CAMPAIGNS_SUMMARY = {
   START_FETCH: 'START_FETCH',
   FINISH_FETCH: 'FINISH_FETCH',
   FAIL_FETCH: 'FAIL_FETCH',
 };
-
-export const mapCampaignsSummary = (campaignsSummary) => [
-  {
-    id: 1,
-    kpiTitleId: 'dashboard.campaigns.totalCampaigns',
-    kpiValue: campaignsSummary.totalSentEmails,
-    iconClass: 'deliveries',
-  },
-  {
-    id: 2,
-    kpiTitleId: 'dashboard.campaigns.totalOpen',
-    kpiValue: `${campaignsSummary.totalOpenClicks}%`,
-    iconClass: 'open-rate',
-  },
-  {
-    id: 3,
-    kpiTitleId: 'dashboard.campaigns.totalCtr',
-    kpiValue: `${campaignsSummary.clickThroughRate}%`,
-    iconClass: 'ctr',
-  },
-];
 
 export const initCampaignSummaryReducer = (state) => ({
   ...state,

--- a/src/components/Dashboard/CampaignSummary/reducers/campaignSummaryReducer.test.js
+++ b/src/components/Dashboard/CampaignSummary/reducers/campaignSummaryReducer.test.js
@@ -1,9 +1,7 @@
-import { fakeCampaignsSummary, INITIAL_STATE_CAMPAIGNS_SUMMARY } from '..';
-import {
-  ACTIONS_CAMPAIGNS_SUMMARY,
-  campaignSummaryReducer,
-  mapCampaignsSummary,
-} from './campaignSummaryReducer';
+import { INITIAL_STATE_CAMPAIGNS_SUMMARY } from '..';
+import { mapCampaignsSummary } from '../../../../services/campaignSummary';
+import { fakeCampaignsSummary } from '../../../../services/reports/index.double';
+import { ACTIONS_CAMPAIGNS_SUMMARY, campaignSummaryReducer } from './campaignSummaryReducer';
 
 describe('campaignSummaryReducer', () => {
   it(`${ACTIONS_CAMPAIGNS_SUMMARY.START_FETCH} action`, () => {

--- a/src/components/Dashboard/Dashboard.test.js
+++ b/src/components/Dashboard/Dashboard.test.js
@@ -1,10 +1,19 @@
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { MemoryRouter as Router } from 'react-router-dom';
 import IntlProvider from '../../i18n/DopplerIntlProvider.double-with-ids-as-values';
 import { AppServicesProvider } from '../../services/pure-di';
+import { fakeCampaignsSummary } from '../../services/reports/index.double';
 import { Dashboard } from './Dashboard';
+
+const reportClientDouble = () => ({
+  getCampaignsSummary: async () => ({
+    success: true,
+    value: fakeCampaignsSummary,
+  }),
+});
 
 describe('Dashboard component', () => {
   const dependencies = {
@@ -17,38 +26,44 @@ describe('Dashboard component', () => {
         },
       },
     },
+    reportClient: reportClientDouble(),
   };
 
   it('should show the hero-banner with personal welcome message', async () => {
     // Act
-    render(
-      <Router>
-        <AppServicesProvider forcedServices={dependencies}>
-          <IntlProvider>
-            <Dashboard />
-          </IntlProvider>
-        </AppServicesProvider>
-      </Router>,
-    );
+    await act(async () => {
+      render(
+        <Router>
+          <AppServicesProvider forcedServices={dependencies}>
+            <IntlProvider>
+              <Dashboard />
+            </IntlProvider>
+          </AppServicesProvider>
+        </Router>,
+      );
+    });
 
     // Assert
     const header = screen.getByRole('banner');
     expect(header).toBeInTheDocument();
     expect(screen.getByText(/Cecilia/i)).toBeInTheDocument();
     expect(screen.getByText(/dashboard.welcome_message_header/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('figure')).toHaveLength(6);
   });
 
   it('should render Campaings and Subscribers KpiGroup Component', async () => {
     // Act
-    render(
-      <Router>
-        <AppServicesProvider forcedServices={dependencies}>
-          <IntlProvider>
-            <Dashboard />
-          </IntlProvider>
-        </AppServicesProvider>
-      </Router>,
-    );
+    await act(async () => {
+      render(
+        <Router>
+          <AppServicesProvider forcedServices={dependencies}>
+            <IntlProvider>
+              <Dashboard />
+            </IntlProvider>
+          </AppServicesProvider>
+        </Router>,
+      );
+    });
 
     // Assert
     expect(screen.getAllByRole('figure')).toHaveLength(6);

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import { HardcodedDopplerBillingUserApiClient } from './services/doppler-billing
 import { HardcodedDopplerAccountPlansApiClient } from './services/doppler-account-plans-api-client.double';
 
 import Offline from './components/Offline/Offline';
+import { HardcodedReportClient } from './services/reports/index.double';
 polyfill();
 
 if (document.querySelector('body').setActive) {
@@ -48,6 +49,7 @@ const forcedServices =
         ipinfoClient: new HardcodedIpinfoClient(),
         dopplerBillingApiClient: new HardcodedDopplerBillingApiClient(),
         bigQueryClient: new HardcodedBigQueryClient(),
+        reportClient: new HardcodedReportClient(),
         dopplerUserApiClient: new HardcodedDopplerUserApiClient(),
         dopplerContactPolicyApiClient: new HardcodedDopplerContactPolicyApiClient(),
         staticDataClient: new HardcodedStaticDataClient(),

--- a/src/services/campaignSummary.test.ts
+++ b/src/services/campaignSummary.test.ts
@@ -1,0 +1,19 @@
+import { CampaignSummaryService, mapCampaignsSummary } from './campaignSummary';
+import { fakeCampaignsSummary, HardcodedReportClient } from './reports/index.double';
+
+describe('CampaignSummaryService', () => {
+  it('should get campaign kpis', async () => {
+    // Arrange
+    const reportClient = new HardcodedReportClient();
+    const spyGetCampaignsSummary = jest.spyOn(reportClient, 'getCampaignsSummary');
+
+    // Act
+    const campaignSummaryService = new CampaignSummaryService({ reportClient });
+    const response = await campaignSummaryService.getCampaignsSummary();
+
+    // Assert
+    expect(spyGetCampaignsSummary).toHaveBeenCalled();
+    expect(response.success).toBe(true);
+    expect(response.value).toEqual(mapCampaignsSummary(fakeCampaignsSummary));
+  });
+});

--- a/src/services/campaignSummary.ts
+++ b/src/services/campaignSummary.ts
@@ -1,0 +1,59 @@
+import { ResultWithoutExpectedErrors } from '../doppler-types';
+import { addDays, getStartOfDate } from '../utils';
+import { CampaignSummary, ReportClient } from './reports/index';
+
+export interface CampaignKpi {
+  id: Number;
+  kpiTitleId: String;
+  kpiValue: Number | String;
+  iconClass: String;
+}
+
+export interface CampaignSummaryInterface {
+  getCampaignsSummary(): Promise<any>;
+}
+
+export class CampaignSummaryService implements CampaignSummaryInterface {
+  private readonly reportClient: ReportClient;
+
+  constructor({ reportClient }: { reportClient: ReportClient }) {
+    this.reportClient = reportClient;
+  }
+
+  async getCampaignsSummary(): Promise<ResultWithoutExpectedErrors<CampaignKpi[]>> {
+    const dateTo = getStartOfDate(new Date()) ?? new Date();
+    const dateFrom = addDays(dateTo, -30);
+    const response = await this.reportClient.getCampaignsSummary({
+      dateFrom,
+      dateTo,
+    });
+
+    return response.success
+      ? {
+          ...response,
+          value: mapCampaignsSummary(response.value),
+        }
+      : response;
+  }
+}
+
+export const mapCampaignsSummary = (campaignsSummary: CampaignSummary): CampaignKpi[] => [
+  {
+    id: 1,
+    kpiTitleId: 'dashboard.campaigns.totalCampaigns',
+    kpiValue: campaignsSummary.totalSentEmails,
+    iconClass: 'deliveries',
+  },
+  {
+    id: 2,
+    kpiTitleId: 'dashboard.campaigns.totalOpen',
+    kpiValue: `${campaignsSummary.totalOpenClicks}%`,
+    iconClass: 'open-rate',
+  },
+  {
+    id: 3,
+    kpiTitleId: 'dashboard.campaigns.totalCtr',
+    kpiValue: `${campaignsSummary.clickThroughRate}%`,
+    iconClass: 'ctr',
+  },
+];

--- a/src/services/pure-di.tsx
+++ b/src/services/pure-di.tsx
@@ -31,6 +31,8 @@ import {
 } from './doppler-account-plans-api-client';
 import { PlanService } from './planService';
 import { ControlPanelService } from './control-panel-service';
+import { HttpReportClient, ReportClient } from './reports';
+import { CampaignSummaryService } from './campaignSummary';
 
 interface AppConfiguration {
   dopplerBillingApiUrl: string;
@@ -62,6 +64,7 @@ export interface AppServices {
   originResolver: OriginResolver;
   shopifyClient: ShopifyClient;
   bigQueryClient: BigQueryClient;
+  reportClient: ReportClient;
   dopplerSitesClient: DopplerSitesClient;
   experimentalFeatures: ExperimentalFeatures;
   dopplerApiClient: DopplerApiClient;
@@ -76,6 +79,7 @@ export interface AppServices {
   dopplerBillingUserApiClient: DopplerBillingUserApiClient;
   dopplerAccountPlansApiClient: DopplerAccountPlansApiClient;
   planService: PlanService;
+  campaignSummaryService: CampaignSummaryService;
   controlPanelService: ControlPanelService;
 }
 
@@ -123,6 +127,7 @@ export class AppCompositionRoot implements AppServices {
       },
       shopifyUrl: process.env.REACT_APP_SHOPIFY_URL as string,
       bigQueryUrl: process.env.REACT_APP_BIGQUERY_URL as string,
+      reportingUrl: process.env.REACT_APP_DOPPLER_REPORTING_URL as string,
       dopplerApiUrl: process.env.REACT_APP_DOPPLER_API_URL as string,
       reportsUrl: process.env.REACT_APP_REPORTS_URL as string,
       dopplerBillingApiUrl: process.env.REACT_APP_DOPPLER_BILLING_API_URL as string,
@@ -190,6 +195,18 @@ export class AppCompositionRoot implements AppServices {
         new HttpBigQueryClient({
           axiosStatic: this.axiosStatic,
           baseUrl: this.appConfiguration.bigQueryUrl,
+          connectionDataRef: this.appSessionRef,
+        }),
+    );
+  }
+
+  get reportClient() {
+    return this.singleton(
+      'reportClient',
+      () =>
+        new HttpReportClient({
+          axiosStatic: this.axiosStatic,
+          baseUrl: this.appConfiguration.reportingUrl,
           connectionDataRef: this.appSessionRef,
         }),
     );
@@ -289,6 +306,16 @@ export class AppCompositionRoot implements AppServices {
         new PlanService({
           dopplerLegacyClient: this.dopplerLegacyClient,
           appSessionRef: this.appSessionRef,
+        }),
+    );
+  }
+
+  get campaignSummaryService() {
+    return this.singleton(
+      'campaignSummaryService',
+      () =>
+        new CampaignSummaryService({
+          reportClient: this.reportClient,
         }),
     );
   }

--- a/src/services/reports/index.double.ts
+++ b/src/services/reports/index.double.ts
@@ -1,0 +1,21 @@
+import { ResultWithoutExpectedErrors } from '../../doppler-types';
+import { timeout } from '../../utils';
+import { CampaignSummary, ReportClient } from './index';
+
+export const fakeCampaignsSummary = {
+  totalSentEmails: 21.458,
+  totalOpenClicks: 57,
+  clickThroughRate: 15,
+};
+
+const response = {
+  data: fakeCampaignsSummary,
+};
+
+export class HardcodedReportClient implements ReportClient {
+  public async getCampaignsSummary(): Promise<ResultWithoutExpectedErrors<CampaignSummary>> {
+    await timeout(500);
+
+    return { success: true, value: response.data };
+  }
+}

--- a/src/services/reports/index.test.ts
+++ b/src/services/reports/index.test.ts
@@ -1,0 +1,57 @@
+import { AxiosStatic } from 'axios';
+import { RefObject } from 'react';
+import { addDays, getStartOfDate } from '../../utils';
+import { DopplerLegacyUserData } from '../doppler-legacy-client';
+import { AppSession } from '../app-session';
+import { HttpReportClient } from '.';
+
+function createHttpReportClient(axios: any) {
+  const axiosStatic = {
+    create: () => axios,
+  } as AxiosStatic;
+  const connectionDataRef = {
+    current: {
+      status: 'authenticated',
+      jwtToken: 'jwtToken',
+      userData: {} as DopplerLegacyUserData,
+    },
+  } as RefObject<AppSession>;
+  const reportClient = new HttpReportClient({
+    axiosStatic,
+    baseUrl: 'http://reporting.test',
+    connectionDataRef,
+  });
+  return reportClient;
+}
+
+describe('HttpReportClient', () => {
+  it('should get campaign summary', async () => {
+    // Arrange
+    const dateTo = getStartOfDate(new Date()) ?? new Date();
+    const dateFrom = addDays(dateTo, -30);
+    const response = {
+      headers: {},
+      data: {
+        totalSentEmails: 21.458,
+        totalOpenClicks: 57,
+        clickThroughRate: 17,
+      },
+    };
+    const request = jest.fn(async () => response);
+    const reportClient = createHttpReportClient({ request });
+
+    // Act
+    const result = await reportClient.getCampaignsSummary({
+      dateFrom,
+      dateTo,
+    });
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
+    expect(result.value.totalSentEmails).toEqual(response.data.totalSentEmails);
+    expect(result.value.totalOpenClicks).toEqual(response.data.totalOpenClicks);
+    expect(result.value.clickThroughRate).toEqual(response.data.clickThroughRate);
+  });
+});

--- a/src/services/reports/index.ts
+++ b/src/services/reports/index.ts
@@ -1,0 +1,48 @@
+import { HttpBaseClient } from '../http-base-client';
+import { ResultWithoutExpectedErrors } from '../../doppler-types';
+
+export interface CampaignSummary {
+  totalSentEmails: Number;
+  totalOpenClicks: Number;
+  clickThroughRate: Number;
+}
+
+export interface ReportClient {
+  getCampaignsSummary(query: {
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<ResultWithoutExpectedErrors<CampaignSummary>>;
+}
+
+export class HttpReportClient extends HttpBaseClient implements ReportClient {
+  private clientName = 'Report';
+
+  public async getCampaignsSummary({
+    dateFrom,
+    dateTo,
+  }: {
+    dateFrom: Date;
+    dateTo: Date;
+  }): Promise<ResultWithoutExpectedErrors<CampaignSummary>> {
+    try {
+      const { jwtToken, email } = this.getApiConnectionData(this.clientName);
+      const response = await this.axios.request({
+        method: 'GET',
+        url: `/${email}/summary/campaigns`,
+        params: {
+          startDate: dateFrom.toISOString(),
+          endDate: dateTo.toISOString(),
+        },
+        headers: { Authorization: `bearer ${jwtToken}` },
+      });
+
+      return {
+        success: true,
+        value: response.data,
+      };
+    } catch (error) {
+      console.error(error);
+      return { success: false, error };
+    }
+  }
+}


### PR DESCRIPTION
### **Create and apply campaign summary service** 
**details task:** https://makingsense.atlassian.net/browse/DW-1052


**Description:**

Connects the campaigns summary component with the back
<img width="878" alt="Captura de Pantalla 2021-12-07 a la(s) 3 37 54 p  m" src="https://user-images.githubusercontent.com/84402180/145102658-a25fe40a-211a-4d69-b53a-9db625b9d1ff.png">

