### PR TITLE
Dw 1056 add overlay

### DIFF
--- a/src/components/Dashboard/CampaignSummary/index.js
+++ b/src/components/Dashboard/CampaignSummary/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useReducer } from 'react';
+import { FormattedMessageMarkdown } from '../../../i18n/FormattedMessageMarkdown';
 import { InjectAppServices } from '../../../services/pure-di';
 import { fakeCampaignsSummary } from '../../../services/reports/index.double';
 import { Kpi } from '../Kpis/Kpi';
@@ -33,13 +34,20 @@ export const CampaignSummary = InjectAppServices(({ dependencies: { campaignSumm
     fetchData();
   }, [campaignSummaryService]);
 
+  //   TODO: move logic to the service of campaigns
+  const showOverlay = kpis[0]?.kpiValue === 0;
+
   return (
     <>
       <div className="dp-dashboard-title">
         <DashboardIconSubTitle title="dashboard.campaigns.section_name" iconClass="deliveries" />
         <DashboardIconLink linkTitle="dashboard.campaigns.link_title" link="#" />
       </div>
-      <KpiGroup loading={loading}>
+      <KpiGroup
+        loading={loading}
+        disabled={showOverlay}
+        overlay={<FormattedMessageMarkdown id="dashboard.campaigns.overlayMessage" />}
+      >
         {kpis.map((kpi) => (
           <Kpi key={kpi.id} {...kpi} />
         ))}

--- a/src/components/Dashboard/CampaignSummary/index.test.js
+++ b/src/components/Dashboard/CampaignSummary/index.test.js
@@ -6,21 +6,20 @@ import { fakeCampaignsSummary } from '../../../services/reports/index.double';
 import { AppServicesProvider } from '../../../services/pure-di';
 import { mapCampaignsSummary } from '../../../services/campaignSummary';
 
-const reportClientDouble = () => ({
-  getCampaignsSummary: async () => ({
-    success: true,
-    value: fakeCampaignsSummary,
-  }),
-});
-
 describe('CampaignSummary component', () => {
-  it('should render CampaignSummary component', async () => {
+  it('should render CampaignSummary component when has info', async () => {
     // Arrange
     const kpis = mapCampaignsSummary(fakeCampaignsSummary);
+    const campaignSummaryService = {
+      getCampaignsSummary: async () => ({
+        success: true,
+        value: mapCampaignsSummary(fakeCampaignsSummary),
+      }),
+    };
 
     // Act
     render(
-      <AppServicesProvider forcedServices={{ reportClient: reportClientDouble() }}>
+      <AppServicesProvider forcedServices={{ campaignSummaryService }}>
         <IntlProvider>
           <CampaignSummary />
         </IntlProvider>
@@ -36,5 +35,34 @@ describe('CampaignSummary component', () => {
       const node = allKpis[index];
       expect(getByText(node, kpi.kpiTitleId)).toBeInTheDocument();
     });
+  });
+
+  it('should render CampaignSummary component when has not info', async () => {
+    // Arrange
+    const campaignSummaryService = {
+      getCampaignsSummary: async () => ({
+        success: true,
+        value: mapCampaignsSummary({
+          totalSentEmails: 0,
+          totalOpenClicks: 0,
+          clickThroughRate: 0,
+        }),
+      }),
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={{ campaignSummaryService }}>
+        <IntlProvider>
+          <CampaignSummary />
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    // Assert
+    const loader = screen.getByTestId('loading-box');
+    await waitForElementToBeRemoved(loader, { timeout: 4500 });
+
+    expect(screen.getByText('dashboard.campaigns.overlayMessage')).toBeInTheDocument();
   });
 });

--- a/src/components/Dashboard/Kpis/KpiGroup.js
+++ b/src/components/Dashboard/Kpis/KpiGroup.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Loading } from '../../Loading/Loading';
@@ -25,38 +25,19 @@ export const DashboardIconLink = ({ linkTitle, link }) => {
   );
 };
 
-export const KpiOverlay = ({ titleLink, kpiOverlayLink }) => {
+export const KpiGroup = ({ children, loading, disabled, overlay }) => {
   return (
-    <div className="dp-overlay">
-      <a href={`${kpiOverlayLink}`}>${titleLink}</a>
-    </div>
-  );
-};
-
-export const KpiGroup = ({ children, disabled, loading }) => {
-  const [showOverlay, setShowOverlay] = useState(false);
-  const toggleShow = () => setShowOverlay(!showOverlay);
-
-  return (
-    <div
-      className={`dp-rowflex dp-dashboard-panel ${disabled ? `disabled` : ``} ${
-        showOverlay && disabled ? `show` : ``
-      } `}
-      onMouseLeave={toggleShow}
-      onMouseEnter={toggleShow}
-      data-testid="dp-dashboard-panel"
-    >
+    <div className={`dp-rowflex dp-dashboard-panel ${disabled ? `disabled` : ''}`}>
       {loading && <Loading />}
       {children}
-      <KpiOverlay
-        titleLink="Empieza a enviar Campañas para ver tus resultados aquí"
-        kpiOverlayLink="#"
-      ></KpiOverlay>
+      <div className={`dp-overlay ${disabled ? `show` : ''}`}>{overlay}</div>
     </div>
   );
 };
 
 KpiGroup.propTypes = {
   children: PropTypes.node,
+  overlay: PropTypes.node,
+  loading: PropTypes.bool,
   disabled: PropTypes.bool,
 };

--- a/src/components/Dashboard/Kpis/KpiGroup.test.js
+++ b/src/components/Dashboard/Kpis/KpiGroup.test.js
@@ -1,23 +1,53 @@
-import React from 'react';
-import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
 import { KpiGroup } from './KpiGroup';
-import { Kpi } from './Kpi';
 
 describe('KpiGroup component', () => {
-  it('should render KpiGroup Component', async () => {
-    //act
-    render(<KpiGroup {...KpiGroup} />);
-    //assert
-    expect(screen.getByTestId('dp-dashboard-panel')).toBeInTheDocument();
+  it('should render KpiGroup Component when is loading', async () => {
+    // Act
+    render(<KpiGroup loading={true} />);
+
+    // Assert
+    expect(screen.getByTestId('loading-box')).toBeInTheDocument();
   });
 
-  it('should show loading when flag is set to loading', async () => {
-    //Arrange
-    const loading = true;
-    //act
-    render(<KpiGroup {...KpiGroup} loading={loading} />);
-    //assert
-    expect(screen.getByTestId('loading-box')).toBeInTheDocument();
+  it('should render KpiGroup Component when is not loading', async () => {
+    // Act
+    render(<KpiGroup loading={false} />);
+
+    // Assert
+    expect(screen.queryByTestId('loading-box')).not.toBeInTheDocument();
+  });
+
+  it('should render KpiGroup when is disabled', async () => {
+    // Arrange
+    const props = {
+      disabled: true,
+      loading: false,
+      overlay: <p>lorem ipsum dolor sit amet...</p>,
+    };
+
+    // Act
+    const { container } = render(<KpiGroup {...props} />);
+
+    // Assert
+    expect(container.querySelector('.dp-overlay.show')).toBeInTheDocument();
+    expect(screen.getByText('lorem ipsum dolor sit amet...')).toBeInTheDocument();
+  });
+
+  it('should render KpiGroup when is not disabled', async () => {
+    // Arrange
+    const props = {
+      disabled: false,
+      loading: false,
+      overlay: <p>lorem ipsum dolor sit amet...</p>,
+    };
+
+    // Act
+    const { container } = render(<KpiGroup {...props} />);
+
+    // Assert
+    expect(container.querySelector('.dp-overlay.show')).not.toBeInTheDocument();
   });
 });

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -416,6 +416,7 @@ Want to know more? Press [HELP](${urlHelp}/contact-policy).`,
   dashboard: {
     campaigns: {
       link_title: 'SENT DELIVERIES',
+      overlayMessage: `Here you’ll see some relevant information about your Campaigns. [Create your Campaign](${urlDopplerLegacy}/Campaigns/BasicInfo).`,
       section_name: 'My Deliveries',
       totalCampaigns: 'Total sends',
       totalCtr: 'Click Through Rate',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -417,6 +417,7 @@ Define la **cantidad máxima de Emails** que tus Contactos podrán recibir en un
   dashboard: {
     campaigns: {
       link_title: 'CAMPAÑAS ENVIADAS',
+      overlayMessage: `Aquí verás información relevante sobre tus Campañas. [Crea tu Campaña](${urlDopplerLegacy}/Campaigns/BasicInfo).`,
       section_name: 'Mis Campañas',
       totalCampaigns: 'Envíos totales',
       totalCtr: 'Tasa de Clics',


### PR DESCRIPTION
### **Add overlay to Campaign summary**
**details task:** https://makingsense.atlassian.net/browse/DW-1056

**description:**
 add overlay to the campaign summary section when no campaigns have been sent in the last 30 days

<img width="883" alt="Captura de Pantalla 2021-12-10 a la(s) 10 12 24 a  m" src="https://user-images.githubusercontent.com/84402180/145596479-f1558b11-744a-4dd4-a656-5866c6533cee.png">

