### PR TITLE
feat: add overlay to contact summary section

### DIFF
--- a/src/components/Dashboard/ContactSummary/index.js
+++ b/src/components/Dashboard/ContactSummary/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useReducer } from 'react';
+import { FormattedMessageMarkdown } from '../../../i18n/FormattedMessageMarkdown';
 import { InjectAppServices } from '../../../services/pure-di';
 import { fakeContactsSummary } from '../../../services/reports/index.double';
 import { Kpi } from '../Kpis/Kpi';
@@ -33,13 +34,19 @@ export const ContactSummary = InjectAppServices(({ dependencies: { contactSummar
     fetchData();
   }, [contactSummaryService]);
 
+  const showOverlay = kpis[0]?.kpiValue === 0;
+
   return (
     <>
       <div className="dp-dashboard-title">
         <DashboardIconSubTitle title="dashboard.contacts.section_name" iconClass="subscribers" />
         <DashboardIconLink linkTitle="dashboard.contacts.link_title" link="#" />
       </div>
-      <KpiGroup loading={loading}>
+      <KpiGroup
+        loading={loading}
+        disabled={showOverlay}
+        overlay={<FormattedMessageMarkdown id="dashboard.contacts.overlayMessage" />}
+      >
         {kpis.map((kpi) => (
           <Kpi key={kpi.id} {...kpi} />
         ))}

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -424,6 +424,7 @@ Want to know more? Press [HELP](${urlHelp}/contact-policy).`,
     },
     contacts: {
       link_title: 'SEE MASTER LIST',
+      overlayMessage: `Here you’ll see some relevant information about your Contacts. [Create a List and add Contacts](${urlCreateSubscriberList}).`,
       section_name: 'My Contacts',
       totalContacts: 'Contacts',
       totalNewContacts: 'New Contacts',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -425,6 +425,7 @@ Define la **cantidad máxima de Emails** que tus Contactos podrán recibir en un
     },
     contacts: {
       link_title: 'VER LISTADO MAESTRO',
+      overlayMessage: `Aquí verás información relevante sobre tus Contactos. [Crea una Lista y añade Contactos](${urlCreateSubscriberList}).`,
       section_name: 'Mis Contactos',
       totalContacts: 'Contactos',
       totalNewContacts: 'Contactos nuevos',


### PR DESCRIPTION
### **Add overlay to Contact summary**
**details task:** https://makingsense.atlassian.net/browse/DW-1061

**description:**
add overlay to the contact summary section when  has no contact

<img width="858" alt="Captura de Pantalla 2021-12-10 a la(s) 12 19 22 p  m" src="https://user-images.githubusercontent.com/84402180/145615070-a5cfeed9-907a-4458-bcc3-af417574487e.png">

