### PR TITLE
[No ticket] Modify integration status response mapping to be dynamic.

### DIFF
--- a/src/services/doppler-user-api-client.double.ts
+++ b/src/services/doppler-user-api-client.double.ts
@@ -42,6 +42,9 @@ const integrationsStatusResult: IntegrationsStatus = {
   wooCommerceStatus: 'disconnected',
   easycommerceStatus: 'connected',
   bmwRspCrmStatus: 'alert',
+  vtexStatus: 'alert',
+  googleAnaliyticStatus: 'connected',
+  bigQueryStatus: 'disconnected',
 };
 
 export class HardcodedDopplerUserApiClient implements DopplerUserApiClient {

--- a/src/services/doppler-user-api-client.ts
+++ b/src/services/doppler-user-api-client.ts
@@ -54,6 +54,9 @@ export interface IntegrationsStatus {
   wooCommerceStatus: IntegrationStatus;
   easycommerceStatus: IntegrationStatus;
   bmwRspCrmStatus: IntegrationStatus;
+  vtexStatus: IntegrationStatus;
+  googleAnaliyticStatus: IntegrationStatus;
+  bigQueryStatus: IntegrationStatus;
 }
 
 export class HttpDopplerUserApiClient implements DopplerUserApiClient {

--- a/src/services/doppler-user-api-client.ts
+++ b/src/services/doppler-user-api-client.ts
@@ -41,22 +41,7 @@ export interface Features {
 }
 
 export interface IntegrationsStatus {
-  apiKeyStatus: IntegrationStatus;
-  dkimStatus: IntegrationStatus;
-  customDomainStatus: IntegrationStatus;
-  tokkoStatus: IntegrationStatus;
-  tiendanubeStatus: IntegrationStatus;
-  datahubStatus: IntegrationStatus;
-  prestashopStatus: IntegrationStatus;
-  shopifyStatus: IntegrationStatus;
-  magentoStatus: IntegrationStatus;
-  zohoStatus: IntegrationStatus;
-  wooCommerceStatus: IntegrationStatus;
-  easycommerceStatus: IntegrationStatus;
-  bmwRspCrmStatus: IntegrationStatus;
-  vtexStatus: IntegrationStatus;
-  googleAnaliyticStatus: IntegrationStatus;
-  bigQueryStatus: IntegrationStatus;
+  [key: string]: IntegrationStatus;
 }
 
 export class HttpDopplerUserApiClient implements DopplerUserApiClient {


### PR DESCRIPTION
I added some new integration status to return from the users API's integrations/status endpoint. To avoid having to add every integration that we implement in the future I made the Integrations status response a dynamic object.