### PR TITLE
[DAT-726] - pass 'extraCredits' instead of 'promo-code' as parameter to the 'CheckoutSummary' page

### DIFF
--- a/src/components/Plans/Checkout/CheckoutSummary.test.js
+++ b/src/components/Plans/Checkout/CheckoutSummary.test.js
@@ -166,7 +166,7 @@ describe('CheckoutSummary component', () => {
 
   describe.each([
     [
-      'without promocode',
+      'without extra credits',
       {
         url: 'checkout-summary',
         dopplerAccountPlansApiClientDouble: {
@@ -182,9 +182,9 @@ describe('CheckoutSummary component', () => {
       },
     ],
     [
-      'with promocode',
+      'with extra credits',
       {
-        url: 'checkout-summary?promo-code=test',
+        url: 'checkout-summary?extraCredits=2500',
         dopplerAccountPlansApiClientDouble: {
           ...dopplerAccountPlansApiClientDoubleBase,
           getPlanData: async () => {
@@ -192,9 +192,6 @@ describe('CheckoutSummary component', () => {
               success: true,
               value: fakePrepaidPlan,
             };
-          },
-          validatePromocode: async () => {
-            return { success: true, value: fakePromotion };
           },
         },
         showPromocodeSection: true,

--- a/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.js
+++ b/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.js
@@ -395,7 +395,7 @@ export const PurchaseSummary = InjectAppServices(
           window.location.href = `/checkout-summary?planId=${selectedPlan}&paymentMethod=${
             state.paymentMethodType
           }${state.discount?.description ? `&discount=${state.discount.description}` : ''}${
-            state.promotion?.promocode ? `&promo-code=${state.promotion.promocode}` : ''
+            state.promotion?.extraCredits ? `&extraCredits=${state.promotion.extraCredits}` : ''
           }`;
         }, 3000);
       }

--- a/src/components/Plans/Checkout/Reducers/checkoutSummaryReducer.js
+++ b/src/components/Plans/Checkout/Reducers/checkoutSummaryReducer.js
@@ -6,7 +6,7 @@ export const INITIAL_STATE_CHECKOUT_SUMMARY = {
   planType: PLAN_TYPE.byCredit,
   discount: '',
   quantity: '',
-  promotion: {},
+  extraCredits: 0,
   remainingCredits: 0,
   loading: false,
   hasError: false,
@@ -40,7 +40,7 @@ export const checkoutSummaryReducer = (state, action) => {
       };
     case CHECKOUT_SUMMARY_ACTIONS.FINISH_FETCH:
       const {
-        payload: { billingInformation, currentUserPlan, promotion, discount, paymentMethod },
+        payload: { billingInformation, currentUserPlan, extraCredits, discount, paymentMethod },
       } = action;
       const planType = currentUserPlan.planType;
 
@@ -52,7 +52,7 @@ export const checkoutSummaryReducer = (state, action) => {
         planType,
         discount: discount ?? '',
         quantity: getQuantity(planType, currentUserPlan),
-        promotion,
+        extraCredits,
         remainingCredits: currentUserPlan.remainingCredits,
       };
 

--- a/src/components/Plans/Checkout/Reducers/checkoutSummaryReducer.test.js
+++ b/src/components/Plans/Checkout/Reducers/checkoutSummaryReducer.test.js
@@ -1,8 +1,4 @@
-import { PLAN_TYPE } from '../../../../doppler-types';
-import { fakePromotion } from '../../../../services/doppler-account-plans-api-client.double';
 import {
-  fakePaymentMethodInformation,
-  fakePaymentMethodInformationWithTransfer,
   fakeBillingInformation,
   fakeUserPlan,
 } from '../../../../services/doppler-billing-user-api-client.double';
@@ -32,7 +28,7 @@ describe('checkoutSummaryReducer', () => {
     // Arrange
     const billingInformation = fakeBillingInformation;
     const currentUserPlan = fakeUserPlan;
-    const promotion = fakePromotion;
+    const extraCredits = 1500;
     const discount = 'quarterly';
     const paymentMethod = 'CC';
 
@@ -45,7 +41,7 @@ describe('checkoutSummaryReducer', () => {
       payload: {
         billingInformation,
         currentUserPlan,
-        promotion,
+        extraCredits,
         discount,
         paymentMethod,
       },
@@ -60,7 +56,7 @@ describe('checkoutSummaryReducer', () => {
         loading: false,
         billingCountry: billingInformation.country,
         remainingCredits: currentUserPlan.remainingCredits,
-        promotion,
+        extraCredits,
         discount,
         paymentMethod,
         quantity: currentUserPlan.emailQty,


### PR DESCRIPTION
Pass 'extraCredits' instead of 'promo-code' as parameter to the 'CheckoutSummary' page

**Screenshot:**

![image](https://user-images.githubusercontent.com/70591946/146989965-a295e01a-c76d-4d44-813f-196bdad706b7.png)

**Task:** [DAT-726](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-726)