### PR TITLE
feat: allow to redirect to external webapps in the same domain

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -198,6 +198,9 @@ export function isWhitelisted(url: string) {
     'https://appqa.fromdoppler.com/',
     'https://goemms.com/',
     'http://goemms.com/',
+    'https://app.fromdoppler.com/',
+    'https://webappqa.fromdoppler.net/',
+    'https://webappint.fromdoppler.net/',
   ];
   return !!url && loginWhitelist.some((element) => url.startsWith(element));
 }


### PR DESCRIPTION
Hi team!

I need to redirect from the Editor WebApp after the login. Example: `https://app.fromdoppler.com/login?redirect=https://app.fromdoppler.com/editors/templates/1234`

What do you think about this approach?