### PR TITLE
[DAT-735] - Add thousand separator number

### DIFF
--- a/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.js
+++ b/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.js
@@ -3,7 +3,7 @@ import { useRouteMatch } from 'react-router-dom';
 import { InjectAppServices } from '../../../../services/pure-di';
 import { Loading } from '../../../Loading/Loading';
 import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
-import { extractParameter } from '../../../../utils';
+import { extractParameter, thousandSeparatorNumber } from '../../../../utils';
 import { useLocation } from 'react-router';
 import queryString from 'query-string';
 import useTimeout from '../../../../hooks/useTimeout';
@@ -41,7 +41,7 @@ export const PlanInformation = ({ plan, planType }) => {
     <>
       <span>
         {_(`checkoutProcessForm.purchase_summary.plan_type_${planType.replace('-', '_')}_label`)}
-        <strong> {getQuantity()}</strong>
+        <strong> {thousandSeparatorNumber(intl.defaultLocale, getQuantity())}</strong>
       </span>
       <span>
         {dollarSymbol} <FormattedNumber value={plan?.fee} {...numberFormatOptions} />
@@ -134,7 +134,7 @@ export const CreditsPromocode = ({ extraCredits }) => {
     <>
       <span>
         {_(`checkoutProcessForm.purchase_summary.credits_for_promocode`)}{' '}
-        <strong>{extraCredits}</strong>
+        <strong>{thousandSeparatorNumber(intl.defaultLocale, extraCredits)}</strong>
       </span>
       <span>
         {dollarSymbol} <FormattedNumber value={0} {...numberFormatOptions} />

--- a/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.test.js
+++ b/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.test.js
@@ -198,7 +198,7 @@ describe('PurchaseSummary component', () => {
     const loader = screen.getByTestId('loading-box');
     await waitForElementToBeRemoved(loader);
 
-    expect(screen.getByRole('listitem', { name: 'units' })).toHaveTextContent(1500);
+    expect(screen.getByRole('listitem', { name: 'units' })).toHaveTextContent('1,500');
     expect(screen.getByRole('listitem', { name: 'units' })).toHaveTextContent('US$ 55.00');
   });
 


### PR DESCRIPTION
Add thousand separator number in the PurchaseSummary section

**Before:**

![image](https://user-images.githubusercontent.com/70591946/148535330-44f1627d-cc9b-405c-8015-385e9aaeda0e.png)

**After:**

![image](https://user-images.githubusercontent.com/70591946/148535373-7b54f592-ec36-46cc-9f6e-3ce872b007b6.png)

Task: [DAT-735](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-735)
