### PR TITLE
[DAT-734] - Add thousand separator number in the 'CheckoutSummary' page

### DIFF
--- a/src/components/Plans/Checkout/CheckoutSummary.js
+++ b/src/components/Plans/Checkout/CheckoutSummary.js
@@ -16,6 +16,7 @@ import {
 } from './Reducers/checkoutSummaryReducer';
 import { exception } from 'react-ga';
 import { UnexpectedError } from '../PlanCalculator/UnexpectedError';
+import { thousandSeparatorNumber } from '../../../utils';
 
 const arCountry = 'ar';
 
@@ -57,18 +58,18 @@ const PlanInformation = ({
         </li>
         <li>
           <span>{_(`checkoutProcessSuccess.plan_type_${planType ?? ''}`)}</span>
-          <h3>{quantity}</h3>
+          <h3>{thousandSeparatorNumber(intl.defaultLocale, quantity)}</h3>
         </li>
         {extraCredits > 0 ? (
           <li>
             <span>{_(`checkoutProcessSuccess.plan_type_prepaid_promocode`)}</span>
-            <h3>{extraCredits}</h3>
+            <h3>{thousandSeparatorNumber(intl.defaultLocale, extraCredits)}</h3>
           </li>
         ) : null}
         {planType === PLAN_TYPE.byCredit ? (
           <li>
             <span>{_(`checkoutProcessSuccess.plan_type_prepaid_total`)}</span>
-            <h3>{remainingCredits}</h3>
+            <h3>{thousandSeparatorNumber(intl.defaultLocale, remainingCredits)}</h3>
           </li>
         ) : null}
         <li>

--- a/src/components/Plans/Checkout/CheckoutSummary.test.js
+++ b/src/components/Plans/Checkout/CheckoutSummary.test.js
@@ -146,7 +146,7 @@ describe('CheckoutSummary component', () => {
     expect(
       screen.getByText(`checkoutProcessSuccess.plan_type_${currentUserFake.plan.planType}`),
     ).toBeInTheDocument();
-    expect(screen.getByText(`${fakePrepaidPlan.emailQty}`)).toBeInTheDocument();
+    expect(screen.getByText('1,500')).toBeInTheDocument();
     expect(
       screen.queryByText(`checkoutProcessSuccess.plan_type_prepaid_promocode`),
     ).not.toBeInTheDocument();
@@ -229,7 +229,7 @@ describe('CheckoutSummary component', () => {
       expect(
         screen.getByText(`checkoutProcessSuccess.plan_type_${currentUserFake.plan.planType}`),
       ).toBeInTheDocument();
-      expect(screen.getByText(`${fakePrepaidPlan.emailQty}`)).toBeInTheDocument();
+      expect(screen.getByText(`1,500`)).toBeInTheDocument();
 
       if (context.showPromocodeSection) {
         expect(


### PR DESCRIPTION
Add thousand separator number in the 'CheckoutSummary' page

**Before:**

![image](https://user-images.githubusercontent.com/70591946/148583627-05e58b99-bc50-4d7c-84ad-cccab4b83370.png)

**After:**

![image](https://user-images.githubusercontent.com/70591946/148583680-3ee9b018-d8df-413c-8e64-40a04589c479.png)

**Task:** [DAT-734](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-734)