### PR TITLE
Disable status icons

### DIFF
--- a/src/services/control-panel-service.ts
+++ b/src/services/control-panel-service.ts
@@ -261,7 +261,7 @@ export class ControlPanelService implements ControlPanelService {
       },
       {
         title: 'control_panel.native_integrations.title',
-        showStatus: true,
+        showStatus: false,
         boxes: [
           {
             name: 'GoogleAnaliytic',


### PR DESCRIPTION
The users API is not returning the correct values for some users. I'm disabling the control panel status untill it's fixed