### PR TITLE
feat: add support for plans by contacts

### DIFF
--- a/src/components/Plans/PlanCalculator/index.js
+++ b/src/components/Plans/PlanCalculator/index.js
@@ -145,7 +145,11 @@ export const PlanCalculator = InjectAppServices(
     };
 
     useEffect(() => {
-      const { isFreeAccount: isTrial, planType } = appSessionRef.current.userData.user.plan;
+      const {
+        isFreeAccount: isTrial,
+        planType,
+        planSubscription,
+      } = appSessionRef.current.userData.user.plan;
       if (!isTrial) {
         switch (planType) {
           case PLAN_TYPE.byEmail:
@@ -155,6 +159,21 @@ export const PlanCalculator = InjectAppServices(
                   history.location.search
                 }`,
               );
+            }
+            break;
+          case PLAN_TYPE.byContact:
+            if (planTypeUrlSegment !== URL_PLAN_TYPE[PLAN_TYPE.byContact]) {
+              const isMonthlySubscription = planSubscription === 1;
+              if (
+                !isMonthlySubscription ||
+                (isMonthlySubscription && planTypeUrlSegment !== URL_PLAN_TYPE[PLAN_TYPE.byEmail])
+              ) {
+                history.push(
+                  `/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byContact]}${
+                    history.location.search
+                  }`,
+                );
+              }
             }
             break;
           default:

--- a/src/components/Plans/PlanCalculator/index.test.js
+++ b/src/components/Plans/PlanCalculator/index.test.js
@@ -310,4 +310,71 @@ describe('PlanCalculator component', () => {
     );
     expect(byCreditsTab).not.toBeInTheDocument();
   });
+
+  it('should make redirect to by contacts tab when the current plan is by contacts', async () => {
+    // Arrange
+    const planTypes = [PLAN_TYPE.byContact];
+    const forcedServices = {
+      appSessionRef: {
+        current: {
+          userData: {
+            user: {
+              plan: {
+                idPlan: 3,
+                planType: PLAN_TYPE.byContact,
+              },
+            },
+          },
+        },
+      },
+      planService: {
+        getPlanTypes: async () => planTypes,
+        getPlansByType: async () => plansByContacts,
+      },
+      experimentalFeatures: {
+        getFeature: () => false,
+      },
+      ipinfoClient: {
+        getCountryCode: () => 'CL',
+      },
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={forcedServices}>
+        <IntlProvider>
+          <Router
+            initialEntries={[`/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byContact]}`]}
+          >
+            <Route path="/plan-selection/premium/:planType?">
+              <PlanCalculator />
+            </Route>
+          </Router>
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    // Assert
+    const loader = screen.getByTestId('wrapper-loading');
+    await waitForElementToBeRemoved(loader);
+
+    const listTabs = screen.getByRole('list', { name: 'navigator tabs' });
+    expect(listTabs.children.length).toBe(planTypes.length);
+    const byContactsTab = getByText(
+      listTabs,
+      `plan_calculator.plan_type_${PLAN_TYPE.byContact.replace('-', '_')}`,
+    );
+    expect(byContactsTab).toBeInTheDocument();
+
+    const byCreditsTab = queryByText(
+      listTabs,
+      `plan_calculator.plan_type_${PLAN_TYPE.byCredit.replace('-', '_')}`,
+    );
+    expect(byCreditsTab).not.toBeInTheDocument();
+    const byEmailsTab = queryByText(
+      listTabs,
+      `plan_calculator.plan_type_${PLAN_TYPE.byEmail.replace('-', '_')}`,
+    );
+    expect(byEmailsTab).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### **Plans by emails**
**Jira ticket:** https://makingsense.atlassian.net/browse/DAT-835

When an user enters to /plan-selection/premium/by-emails or /plan-selection/premium/by-credits with a contact plan, the user will be redirect to /plan-selection/premium/by-contact because only is visible the Contacts Tag