### PR TITLE
feat: remove experimental features

### DIFF
--- a/src/components/TypeformSurvey/index.js
+++ b/src/components/TypeformSurvey/index.js
@@ -4,7 +4,7 @@ import { InjectAppServices } from '../../services/pure-di';
 import { INITIAL_STATE_SURVEY, surveyReducer, SURVEY_ACTIONS } from './reducers/surveyReducer';
 
 export const TypeformSurvey = InjectAppServices(
-  ({ dependencies: { appSessionRef, surveyClient, experimentalFeatures } }) => {
+  ({ dependencies: { appSessionRef, surveyClient } }) => {
     const [{ surveyFormCompleted, loading }, dispatch] = useReducer(
       surveyReducer,
       INITIAL_STATE_SURVEY,
@@ -14,19 +14,18 @@ export const TypeformSurvey = InjectAppServices(
       const fetchData = async () => {
         dispatch({ type: SURVEY_ACTIONS.START_FETCH });
         const response = await surveyClient.getSurveyFormStatus();
-        console.log('response', response);
         if (response.success) {
-          dispatch({ type: SURVEY_ACTIONS.FINISH_FETCH, payload: response.value });
+          dispatch({
+            type: SURVEY_ACTIONS.FINISH_FETCH,
+            payload: { surveyFormCompleted: response.value },
+          });
         } else {
           dispatch({ type: SURVEY_ACTIONS.FAIL_FETCH });
         }
       };
 
-      const typeformEnabled = experimentalFeatures.getFeature('typeformEnabled');
-      if (typeformEnabled) {
-        fetchData();
-      }
-    }, [surveyClient, experimentalFeatures]);
+      fetchData();
+    }, [surveyClient]);
 
     if (loading || surveyFormCompleted) {
       return <div data-testid="empty-fragment" />;

--- a/src/components/TypeformSurvey/index.test.js
+++ b/src/components/TypeformSurvey/index.test.js
@@ -4,34 +4,10 @@ import { TypeformSurvey } from '.';
 import { AppServicesProvider } from '../../services/pure-di';
 
 describe('TypeformSurvey', () => {
-  it('should render TypeformSurvey component when typeformEnabled is false', async () => {
-    // Arrange
-    const typeformEnabled = false;
-    const forcedServices = {
-      experimentalFeatures: {
-        getFeature: () => typeformEnabled,
-      },
-    };
-
-    // Act
-    render(
-      <AppServicesProvider forcedServices={forcedServices}>
-        <TypeformSurvey />
-      </AppServicesProvider>,
-    );
-
-    // Assert
-    expect(screen.queryByTestId('tf-v1-popup')).not.toBeInTheDocument();
-  });
-
-  it('should render TypeformSurvey component when typeformEnabled is true', async () => {
+  it('should render TypeformSurvey component when the user completes the survey', async () => {
     // Arrange
     const getSurveyFormStatusMock = jest.fn(async () => ({ success: true, value: true }));
-    const typeformEnabled = true;
     const forcedServices = {
-      experimentalFeatures: {
-        getFeature: () => typeformEnabled,
-      },
       appSessionRef: {
         current: {
           userData: {
@@ -56,9 +32,43 @@ describe('TypeformSurvey', () => {
     );
 
     // Assert
-    await waitForElementToBeRemoved(screen.getByTestId('empty-fragment'));
+    expect(screen.getByTestId('empty-fragment')).toBeInTheDocument();
 
     expect(getSurveyFormStatusMock).toHaveBeenCalled();
-    expect(screen.getByTestId('iframe')).toBeInTheDocument();
+    expect(await screen.findByTestId('empty-fragment')).toBeInTheDocument();
+  });
+
+  it('should render TypeformSurvey component when the user do not complete the survey', async () => {
+    // Arrange
+    const getSurveyFormStatusMock = jest.fn(async () => ({ success: true, value: false }));
+    const forcedServices = {
+      appSessionRef: {
+        current: {
+          userData: {
+            user: {
+              lang: 'es',
+              fullname: 'Junior Campos',
+              email: 'jcampos@makingsense.com',
+            },
+          },
+        },
+      },
+      surveyClient: {
+        getSurveyFormStatus: getSurveyFormStatusMock,
+      },
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={forcedServices}>
+        <TypeformSurvey />
+      </AppServicesProvider>,
+    );
+
+    // Assert
+
+    await waitForElementToBeRemoved(screen.getByTestId('empty-fragment'));
+    expect(getSurveyFormStatusMock).toHaveBeenCalled();
+    expect(await screen.findByTestId('iframe')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### **Remove experimental features**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-841

**Description**

When the users navigates to `/dashboard`, now don't use experimental features to know if the user has the typeform complete or not. Only is used the `/Integration/Integration/GetSurveyFormStatus`