### PR TITLE
feat: add typeform for free users

### DIFF
--- a/src/components/Dashboard/Dashboard.test.js
+++ b/src/components/Dashboard/Dashboard.test.js
@@ -26,11 +26,20 @@ describe('Dashboard component', () => {
         userData: {
           user: {
             fullname: 'Cecilia Bernat',
+            plan: {
+              isFreeAccount: true,
+            },
           },
         },
       },
     },
     reportClient: reportClientDouble(),
+    dopplerLegacyClient: {
+      getSurveyFormStatus: async () => ({
+        success: true,
+        value: { surveyFormCompleted: true },
+      }),
+    },
   };
 
   it('should show the hero-banner with personal welcome message', async () => {

--- a/src/components/TypeformSurvey/index.js
+++ b/src/components/TypeformSurvey/index.js
@@ -24,7 +24,9 @@ export const TypeformSurvey = InjectAppServices(
       fetchData();
     }, [dopplerLegacyClient]);
 
-    if (loading || surveyFormCompleted) {
+    const { isFreeAccount: isTrial } = appSessionRef.current.userData.user.plan;
+
+    if (loading || surveyFormCompleted || !isTrial) {
       return <div data-testid="empty-fragment" />;
     }
 

--- a/src/components/TypeformSurvey/index.test.js
+++ b/src/components/TypeformSurvey/index.test.js
@@ -18,6 +18,9 @@ describe('TypeformSurvey', () => {
               lang: 'es',
               fullname: 'Junior Campos',
               email: 'jcampos@makingsense.com',
+              plan: {
+                isFreeAccount: true,
+              },
             },
           },
         },
@@ -55,6 +58,9 @@ describe('TypeformSurvey', () => {
               lang: 'es',
               fullname: 'Junior Campos',
               email: 'jcampos@makingsense.com',
+              plan: {
+                isFreeAccount: true,
+              },
             },
           },
         },
@@ -76,5 +82,45 @@ describe('TypeformSurvey', () => {
     await waitForElementToBeRemoved(screen.getByTestId('empty-fragment'));
     expect(getSurveyFormStatusMock).toHaveBeenCalled();
     expect(await screen.findByTestId('iframe')).toBeInTheDocument();
+  });
+
+  it('should not render TypeformSurvey component when the user does not have a trial account', async () => {
+    // Arrange
+    const getSurveyFormStatusMock = jest.fn(async () => ({
+      success: true,
+      value: { surveyFormCompleted: true },
+    }));
+    const forcedServices = {
+      appSessionRef: {
+        current: {
+          userData: {
+            user: {
+              lang: 'es',
+              fullname: 'Junior Campos',
+              email: 'jcampos@makingsense.com',
+              plan: {
+                isFreeAccount: false,
+              },
+            },
+          },
+        },
+      },
+      dopplerLegacyClient: {
+        getSurveyFormStatus: getSurveyFormStatusMock,
+      },
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={forcedServices}>
+        <TypeformSurvey />
+      </AppServicesProvider>,
+    );
+
+    // Assert
+    expect(screen.getByTestId('empty-fragment')).toBeInTheDocument();
+
+    expect(getSurveyFormStatusMock).toHaveBeenCalled();
+    expect(await screen.findByTestId('empty-fragment')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## **Add typeform for free users**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-866
**CDN**:  https://cdn.fromdoppler.com/doppler-webapp/qa-build4488/#/login

**Scenaries**: 

###  The users navigates to `/dashboard` with a paid account 

<img width="1415" alt="Captura de Pantalla 2022-03-31 a la(s) 7 40 49 a  m" src="https://user-images.githubusercontent.com/84402180/161056910-13f70064-fceb-4182-a259-ded173cedd22.png">


### The user navigates to `/dashboard` with a free account

<img width="1439" alt="Captura de Pantalla 2022-03-31 a la(s) 7 38 36 a  m" src="https://user-images.githubusercontent.com/84402180/161056544-402abc7a-3a50-4e62-a050-3c3db9c0d675.png">
