### PR TITLE
[DAT-876] - Add new endpoints to use in the Mexico transfer

### DIFF
--- a/src/services/static-data-client.double.ts
+++ b/src/services/static-data-client.double.ts
@@ -52,6 +52,22 @@ export const fakeConsumerTypes = [
   { key: 'NC', value: 'No Categorizado' },
 ];
 
+export const fakeCfdi = [
+  { key: 'G03', value: 'G03' },
+  { key: 'P01', value: 'P01' },
+];
+
+export const fakePaymentWays = [
+  { key: 'CASH', value: 'CASH' },
+  { key: 'CHECK', value: 'CHECK' },
+  { key: 'TRANSFER', value: 'TRANSFER' },
+];
+
+export const fakePaymentTypes = [
+  { key: 'PPD', value: 'PPD' },
+  { key: 'PUE', value: 'PUE' },
+];
+
 export class HardcodedStaticDataClient implements StaticDataClient {
   public async getIndustriesData(language: string): Promise<any> {
     await timeout(1500);
@@ -81,6 +97,30 @@ export class HardcodedStaticDataClient implements StaticDataClient {
     await timeout(1500);
     return {
       value: fakeConsumerTypes,
+      success: true,
+    };
+  }
+
+  public async getUseCfdiData(language: string): Promise<any> {
+    await timeout(1500);
+    return {
+      value: fakeCfdi,
+      success: true,
+    };
+  }
+
+  public async getPaymentWaysData(language: string): Promise<any> {
+    await timeout(1500);
+    return {
+      value: fakePaymentWays,
+      success: true,
+    };
+  }
+
+  public async getPaymentTypesData(language: string): Promise<any> {
+    await timeout(1500);
+    return {
+      value: fakePaymentTypes,
       success: true,
     };
   }

--- a/src/services/static-data-client.test.ts
+++ b/src/services/static-data-client.test.ts
@@ -91,4 +91,118 @@ describe('HttpStaticDataClient', () => {
     expect(result.success).toBe(false);
     expect(result.error).not.toBe(undefined);
   });
+
+  it('should get cfdi', async () => {
+    // Arrange
+    const fakeResponse = {
+      data: fakeStates,
+      status: 200,
+    };
+
+    const request = jest.fn(async () => fakeResponse);
+    const staticDataClient = createHttpStaticDataClient({ request });
+
+    // Act
+    const result = await staticDataClient.getUseCfdiData('es');
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('should set error when the connecting fail trying to get the cfdi information ', async () => {
+    // Arrange
+    const request = jest.fn(async () => {});
+    request.mockImplementation(() => {
+      throw new Error();
+    });
+    const staticDataClient = createHttpStaticDataClient({ request });
+
+    console.error = jest.fn(); // silence console error for this test run only
+
+    // Act
+    const result = await staticDataClient.getUseCfdiData('es');
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(false);
+    expect(result.error).not.toBe(undefined);
+  });
+
+  it('should get payment types', async () => {
+    // Arrange
+    const fakeResponse = {
+      data: fakeStates,
+      status: 200,
+    };
+
+    const request = jest.fn(async () => fakeResponse);
+    const staticDataClient = createHttpStaticDataClient({ request });
+
+    // Act
+    const result = await staticDataClient.getPaymentTypesData('es');
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('should set error when the connecting fail trying to get the payment types information ', async () => {
+    // Arrange
+    const request = jest.fn(async () => {});
+    request.mockImplementation(() => {
+      throw new Error();
+    });
+    const staticDataClient = createHttpStaticDataClient({ request });
+
+    console.error = jest.fn(); // silence console error for this test run only
+
+    // Act
+    const result = await staticDataClient.getPaymentTypesData('es');
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(false);
+    expect(result.error).not.toBe(undefined);
+  });
+
+  it('should get payment ways', async () => {
+    // Arrange
+    const fakeResponse = {
+      data: fakeStates,
+      status: 200,
+    };
+
+    const request = jest.fn(async () => fakeResponse);
+    const staticDataClient = createHttpStaticDataClient({ request });
+
+    // Act
+    const result = await staticDataClient.getPaymentWaysData('es');
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('should set error when the connecting fail trying to get the payment ways information ', async () => {
+    // Arrange
+    const request = jest.fn(async () => {});
+    request.mockImplementation(() => {
+      throw new Error();
+    });
+    const staticDataClient = createHttpStaticDataClient({ request });
+
+    console.error = jest.fn(); // silence console error for this test run only
+
+    // Act
+    const result = await staticDataClient.getPaymentWaysData('es');
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(false);
+    expect(result.error).not.toBe(undefined);
+  });
 });

--- a/src/services/static-data-client.ts
+++ b/src/services/static-data-client.ts
@@ -5,6 +5,9 @@ export interface StaticDataClient {
   getStatesData(country: string, language: string): Promise<any>;
   getSecurityQuestionsData(language: string): Promise<any>;
   getConsumerTypesData(country: string, language: string): Promise<any>;
+  getUseCfdiData(language: string): Promise<any>;
+  getPaymentWaysData(language: string): Promise<any>;
+  getPaymentTypesData(language: string): Promise<any>;
 }
 
 export class HttpStaticDataClient implements StaticDataClient {
@@ -97,6 +100,45 @@ export class HttpStaticDataClient implements StaticDataClient {
       return { success: true, value: consumerTypesOrdered };
     } catch (error) {
       console.error('States file not accesible');
+      return { success: false, error: error };
+    }
+  }
+
+  public async getUseCfdiData(language: string): Promise<any> {
+    try {
+      const response = await this.axios.request({
+        method: 'GET',
+        url: this.baseUrl + `/'cfdi-${language}'.json`,
+      });
+      return { success: true, value: response.data };
+    } catch (error) {
+      console.error('CFDI file not accesible');
+      return { success: false, error: error };
+    }
+  }
+
+  public async getPaymentWaysData(language: string): Promise<any> {
+    try {
+      const response = await this.axios.request({
+        method: 'GET',
+        url: this.baseUrl + `/'payment-ways-${language}'.json`,
+      });
+      return { success: true, value: response.data };
+    } catch (error) {
+      console.error('Payment ways file not accesible');
+      return { success: false, error: error };
+    }
+  }
+
+  public async getPaymentTypesData(language: string): Promise<any> {
+    try {
+      const response = await this.axios.request({
+        method: 'GET',
+        url: this.baseUrl + `/'payment-types-${language}'.json`,
+      });
+      return { success: true, value: response.data };
+    } catch (error) {
+      console.error('Payment types file not accesible');
       return { success: false, error: error };
     }
   }


### PR DESCRIPTION
Add new endpoints to use in the México transfer:

- Get CFDI.
- Get Payment ways.
- Get Payment types

**Task:** [DAT-876](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-876)