### PR TITLE
feat: add icon at mercado pago summary

### DIFF
--- a/src/components/Plans/Checkout/CheckoutSummary/CheckoutSummary.js
+++ b/src/components/Plans/Checkout/CheckoutSummary/CheckoutSummary.js
@@ -56,7 +56,8 @@ const PlanInformation = ({
               src={_('common.ui_library_image', {
                 imageUrl: `${
                   paymentMethod === paymentType.creditCard ||
-                  (paymentMethod === paymentType.transfer && discountPromocode === MAX_PERCENTAGE)
+                  ([paymentType.transfer, paymentType.mercadoPago].includes(paymentMethod) &&
+                    discountPromocode === MAX_PERCENTAGE)
                     ? 'checkout-success.svg'
                     : 'three-points.svg'
                 }`,


### PR DESCRIPTION
### **Add icon when the promocode is equal to 100% at Mercado Pago Summary**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-931

**Description**

When the user buy a plan with a promocode 100%, the user sees the check success icon

**Result**
<img width="1040" alt="Captura de Pantalla 2022-05-11 a la(s) 2 42 53 p  m" src="https://user-images.githubusercontent.com/84402180/167932665-10fe2837-d50d-44a6-92a3-aea0507fc322.png">

