### PR TITLE
feat: use the new loader

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,7 @@
       }
     </style>
     <!-- Manifest Style Guide -->
-    <script src="https://cdn.fromdoppler.com/loader/v1/loader.js"></script>
+    <script src="https://cdn.fromdoppler.com/mfe-loader/loader-v1.1.1.js"></script>
       <script type="text/javascript">
         window["style-guide-configuration"] = {
         autoInitialize: true,


### PR DESCRIPTION
Hi team!

We created a new project with CI/CD for the loader.

With this change, I am testing it: https://github.com/FromDoppler/mfe-loader/pull/1

![image](https://user-images.githubusercontent.com/1157864/172916743-2f8a4c9e-cc0a-4ce5-98c5-08ac0f5b261f.png)

~What do you think? how should we update this project?~

* ~Should we create a new URL like (`https://cdn.fromdoppler.com/loader/v1.1.0/loader.js`)?~
* ~Should we use the URL with the hash (`https://cdn.fromdoppler.com/mfe-loader/static/js/main.a58832ef.js`)?~
* ~Should update the same URL with the new content (`https://cdn.fromdoppler.com/loader/v1/loader.js`)?~

The chosen option was copying manually the final version file to `https://cdn.fromdoppler.com/mfe-loader/loader-v#.#.#.js` was see more details in https://github.com/FromDoppler/mfe-loader/#how-to-contribute