### PR TITLE
feat: redirect user to /upgrade-sueestion-form when has exclusive plan

### DIFF
--- a/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
+++ b/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
@@ -4,9 +4,10 @@ import { MemoryRouter as Router, Route } from 'react-router-dom';
 import { GoToUpgrade } from '.';
 import { PLAN_TYPE, URL_PLAN_TYPE } from '../../../../doppler-types';
 import IntlProvider from '../../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+import { allPlans } from '../../../../services/doppler-legacy-client.doubles';
 import { AppServicesProvider } from '../../../../services/pure-di';
 
-const getDependencies = (planData) => {
+const getDependencies = (planData, planTypes) => {
   return {
     appSessionRef: {
       current: {
@@ -18,8 +19,8 @@ const getDependencies = (planData) => {
       },
     },
     planService: {
-      getPlanTypes: async () => [],
-      getPlansByType: async () => [],
+      getPlanTypes: async () => planTypes,
+      getPlansByType: async () => allPlans,
     },
   };
 };
@@ -34,11 +35,14 @@ describe('GoToUpgrade Component', () => {
 
   it('should go to plan calculator when is a trial account', async () => {
     //Arrange
-    const dependencies = getDependencies({
-      idPlan: 3,
-      isFreeAccount: true,
-      planType: PLAN_TYPE.free,
-    });
+    const dependencies = getDependencies(
+      {
+        idPlan: 3,
+        isFreeAccount: true,
+        planType: PLAN_TYPE.free,
+      },
+      [PLAN_TYPE.byContact, PLAN_TYPE.byEmail, PLAN_TYPE.byCredit],
+    );
 
     //Act
     render(
@@ -60,10 +64,13 @@ describe('GoToUpgrade Component', () => {
 
   it('should go to buy credits page when is a credits account', async () => {
     //Arrange
-    const dependencies = getDependencies({
-      isFreeAccount: false,
-      planType: PLAN_TYPE.byCredit,
-    });
+    const dependencies = getDependencies(
+      {
+        isFreeAccount: false,
+        planType: PLAN_TYPE.byCredit,
+      },
+      [PLAN_TYPE.byCredit],
+    );
 
     //Act
     render(
@@ -101,10 +108,13 @@ describe('GoToUpgrade Component', () => {
   ])('paid accounts with monthly subscription', (testName, planType) => {
     it(testName, async () => {
       //Arrange
-      const dependencies = getDependencies({
-        isFreeAccount: false,
-        planType: planType,
-      });
+      const dependencies = getDependencies(
+        {
+          isFreeAccount: false,
+          planType: planType,
+        },
+        [planType],
+      );
 
       //Act
       render(

--- a/src/components/Plans/PlanCalculator/index.js
+++ b/src/components/Plans/PlanCalculator/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useHistory, useParams } from 'react-router-dom';
+import { Redirect, useHistory, useParams } from 'react-router-dom';
 import { PLAN_TYPE, URL_PLAN_TYPE } from '../../../doppler-types';
 import { useQueryParams } from '../../../hooks/useQueryParams';
 import useTimeout from '../../../hooks/useTimeout';
@@ -154,6 +154,10 @@ export const PlanCalculator = InjectAppServices(
         history.push(urlToRedirect);
       }
     }, [appSessionRef, planTypeUrlSegment, history]);
+
+    if (!hasError && !loading && planTypes.length === 0) {
+      return <Redirect to="/upgrade-suggestion-form" />;
+    }
 
     if (loading) {
       return <Loading page />;


### PR DESCRIPTION
### **Redirect to suggestion form when the uses has an exclusive plan**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-986

**scenarios:**
- The user navigates to `/plan-selection/premium/by-emails` with an exclusive plan by email 
- The user is redirected to `/upgrade-suggestion-form`

**NOTE:** this functionality has not yet been released