### PR TITLE
fix: fix suscription message when account type is free

### DIFF
--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -426,7 +426,7 @@ function mapPlanEntry(json: any): PlanEntry {
     planType: planTypeByIdUserType[json.planType],
     idPlan: json.idUserTypePlan ? json.idUserTypePlan : 0,
     planDiscount: json.planDiscount,
-    planSubscription: json.monthPlan,
+    planSubscription: json.monthPlan ? json.monthPlan : 1,
     subscribersCount: json.subscribersCount,
     planFee: json.planFee,
     trialExpired: json.trialExpired,


### PR DESCRIPTION
### **Fix subscription message**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-1005

**Description**

- The user enters to /plan-selection/premium/by-contacts with a free
- The user does not see the subscription type message