### PR TITLE
feat: add support for plans by contacts to plan calculator

### DIFF
--- a/src/components/Plans/PlanCalculator/index.js
+++ b/src/components/Plans/PlanCalculator/index.js
@@ -88,7 +88,10 @@ export const PlanCalculator = InjectAppServices(
           );
           dispatchPlansByType({
             type: PLANS_BY_TYPE_ACTIONS.FINISH_FETCH,
-            payload: _plansByType,
+            payload: {
+              plansByType: _plansByType,
+              currentSubscriptionUser: appSessionRef.current.userData.user.plan.planSubscription,
+            },
           });
         } catch (error) {
           dispatchPlansByType({ type: PLANS_BY_TYPE_ACTIONS.FAIL_FETCH });
@@ -98,7 +101,7 @@ export const PlanCalculator = InjectAppServices(
       if (planTypes.length > 0) {
         fetchPlansByType();
       }
-    }, [planService, planTypeUrlSegment, planTypes]);
+    }, [planService, appSessionRef, planTypeUrlSegment, planTypes]);
 
     useEffect(() => {
       setActiveClass('');

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.js
@@ -29,10 +29,13 @@ export const plansByTypeReducer = (state, action) => {
         hasError: false,
       };
     case PLANS_BY_TYPE_ACTIONS.FINISH_FETCH:
-      const { payload: plansByType } = action;
+      const { plansByType, currentSubscriptionUser } = action.payload;
       const sliderValuesRange = plansByType.map(amountByPlanType);
       const discounts =
         plansByType[0].billingCycleDetails?.map(mapDiscount).sort(orderDiscount) ?? [];
+      const selectDiscountIndexByDefault = discounts.findIndex(
+        (discount) => discount.numberMonths === currentSubscriptionUser,
+      );
       return {
         ...state,
         selectedPlanIndex: 0,
@@ -41,8 +44,8 @@ export const plansByTypeReducer = (state, action) => {
         plansByType,
         sliderValuesRange,
         discounts,
-        selectedDiscount: discounts[0],
-        selectedDiscountIndex: 0,
+        selectedDiscount: discounts[selectDiscountIndexByDefault],
+        selectedDiscountIndex: selectDiscountIndexByDefault,
       };
     case PLANS_BY_TYPE_ACTIONS.FAIL_FETCH:
       return {

--- a/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
+++ b/src/components/Plans/PlanCalculator/reducers/plansByTypeReducer.test.js
@@ -25,8 +25,9 @@ describe('plansByTypeReducer', () => {
     );
   });
 
-  it(`${PLANS_BY_TYPE_ACTIONS.FINISH_FETCH} action`, () => {
+  it(`${PLANS_BY_TYPE_ACTIONS.FINISH_FETCH} action with plan subscription equal to 1 month`, () => {
     // Arrange
+    const planSubscription = 1;
     const plansByType = allPlans.filter((plan) => plan.type === PLAN_TYPE.byContact);
     const initialState = {
       ...INITIAL_STATE_PLANS_BY_TYPE,
@@ -34,7 +35,10 @@ describe('plansByTypeReducer', () => {
     };
     const action = {
       type: PLANS_BY_TYPE_ACTIONS.FINISH_FETCH,
-      payload: plansByType,
+      payload: {
+        plansByType,
+        currentSubscriptionUser: planSubscription,
+      },
     };
 
     // Act
@@ -52,6 +56,41 @@ describe('plansByTypeReducer', () => {
         sliderValuesRange: plansByType.map(amountByPlanType),
         discounts,
         selectedDiscount: discounts[0],
+      }),
+    );
+  });
+
+  it(`${PLANS_BY_TYPE_ACTIONS.FINISH_FETCH} action with plan subscription equal to 3 months`, () => {
+    // Arrange
+    const planSubscription = 3;
+    const plansByType = allPlans.filter((plan) => plan.type === PLAN_TYPE.byContact);
+    const initialState = {
+      ...INITIAL_STATE_PLANS_BY_TYPE,
+      selectedPlanIndex: 15, // An arbitrary plan
+    };
+    const action = {
+      type: PLANS_BY_TYPE_ACTIONS.FINISH_FETCH,
+      payload: {
+        plansByType,
+        currentSubscriptionUser: planSubscription,
+      },
+    };
+
+    // Act
+    const newState = plansByTypeReducer(initialState, action);
+
+    // Assert
+    const discounts =
+      plansByType[0].billingCycleDetails?.map(mapDiscount).sort(orderDiscount) ?? [];
+    expect(newState).toEqual(
+      expect.objectContaining({
+        loading: false,
+        selectedPlanIndex: 0,
+        selectedPlan: plansByType[0],
+        plansByType,
+        sliderValuesRange: plansByType.map(amountByPlanType),
+        discounts,
+        selectedDiscount: discounts[1],
       }),
     );
   });


### PR DESCRIPTION
### **Add plans by contactos in Plan Calculator**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-987

**Description**

When a user enters the plan calculator with a contact plan with a 3-month subscription, the calculator is initialized 