### PR TITLE
Dat 1013 enabled plans by emails - ⚠️⚠️⚠️ don't merge before of DAT-998

### DIFF
--- a/src/components/Plans/PlanCalculator/GoToUpgrade/index.js
+++ b/src/components/Plans/PlanCalculator/GoToUpgrade/index.js
@@ -19,7 +19,7 @@ export const GoToUpgrade = InjectAppServices(({ dependencies: { appSessionRef } 
           <SafeRedirect to={`/ControlPanel/AccountPreferences/BuyCreditsStep1${location.search}`} />
         </>
       );
-    } else {
+    } else if (planType !== PLAN_TYPE.byEmail) {
       const queryParams = new URLSearchParams(location.search);
       if (queryParams.has('PromoCode')) {
         // Delete PromoCode query parameter: https://docs.google.com/spreadsheets/d/1CSXmsVqZTwIhzPRH8_tcPohHmvDXffLTQ-veF-53698/edit#gid=0

--- a/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
+++ b/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
@@ -102,48 +102,72 @@ describe('GoToUpgrade Component', () => {
     expect(window.location.href).toBe(`${process.env.REACT_APP_DOPPLER_LEGACY_URL}${partialUrl}`);
   });
 
-  describe.each([
-    ['should go to upgrade plan when is a contacts account', PLAN_TYPE.byContact],
-    ['should go to upgrade plan when is a emails account', PLAN_TYPE.byEmail],
-  ])('paid accounts with monthly subscription', (testName, planType) => {
-    it(testName, async () => {
-      //Arrange
-      const dependencies = getDependencies(
-        {
-          isFreeAccount: false,
-          planType: planType,
-        },
-        [planType],
-      );
+  it('should go to upgrade plan when is a contacts account', async () => {
+    //Arrange
+    const dependencies = getDependencies(
+      {
+        isFreeAccount: false,
+        planType: PLAN_TYPE.byContact,
+      },
+      [PLAN_TYPE.byContact],
+    );
 
-      //Act
-      render(
-        <IntlProvider>
-          <Router
-            initialEntries={[
-              `/plan-selection/premium/${
-                URL_PLAN_TYPE[PLAN_TYPE.byContact]
-              }?PromoCode=S4NV4L3NT1N&origin_inbound=fake`,
-            ]}
-          >
-            <Route path="/plan-selection/premium/:planType?">
-              <AppServicesProvider forcedServices={dependencies}>
-                <GoToUpgrade />
-              </AppServicesProvider>
-            </Route>
-          </Router>
-        </IntlProvider>,
-      );
+    //Act
+    render(
+      <IntlProvider>
+        <Router
+          initialEntries={[
+            `/plan-selection/premium/${
+              URL_PLAN_TYPE[PLAN_TYPE.byContact]
+            }?PromoCode=S4NV4L3NT1N&origin_inbound=fake`,
+          ]}
+        >
+          <Route path="/plan-selection/premium/:planType?">
+            <AppServicesProvider forcedServices={dependencies}>
+              <GoToUpgrade />
+            </AppServicesProvider>
+          </Route>
+        </Router>
+      </IntlProvider>,
+    );
 
-      //Assert
-      const planCalculatorTitle = screen.queryByText('plan_calculator.plan_premium_title');
-      expect(planCalculatorTitle).not.toBeInTheDocument();
+    //Assert
+    const planCalculatorTitle = screen.queryByText('plan_calculator.plan_premium_title');
+    expect(planCalculatorTitle).not.toBeInTheDocument();
 
-      const loader = screen.getByTestId('loading-box');
-      expect(loader).toBeInTheDocument();
+    const loader = screen.getByTestId('loading-box');
+    expect(loader).toBeInTheDocument();
 
-      const partialUrl = `/ControlPanel/AccountPreferences/GetAccountInformation?origin_inbound=fake`;
-      expect(window.location.href).toBe(`${process.env.REACT_APP_DOPPLER_LEGACY_URL}${partialUrl}`);
-    });
+    const partialUrl = `/ControlPanel/AccountPreferences/GetAccountInformation?origin_inbound=fake`;
+    expect(window.location.href).toBe(`${process.env.REACT_APP_DOPPLER_LEGACY_URL}${partialUrl}`);
+  });
+
+  it('should go to plan calculator when is a emails account', async () => {
+    //Arrange
+    const dependencies = getDependencies(
+      {
+        idPlan: 3,
+        isFreeAccount: true,
+        planType: PLAN_TYPE.byCredit,
+      },
+      [PLAN_TYPE.byEmail],
+    );
+
+    //Act
+    render(
+      <IntlProvider>
+        <Router initialEntries={[`/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byEmail]}`]}>
+          <Route path="/plan-selection/premium/:planType?">
+            <AppServicesProvider forcedServices={dependencies}>
+              <GoToUpgrade />
+            </AppServicesProvider>
+          </Route>
+        </Router>
+      </IntlProvider>,
+    );
+
+    //Assert
+    const planCalculatorTitle = await screen.findByText('plan_calculator.plan_premium_title');
+    expect(planCalculatorTitle).toBeInTheDocument();
   });
 });

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
@@ -20,7 +20,7 @@ export const PlanCalculatorButtons = InjectAppServices(
     const { planType: planTypeUrlSegment } = useParams();
     const selectedPlanType = getPlanTypeFromUrlSegment(planTypeUrlSegment);
     const sessionPlanType = sessionPlan.plan.planType;
-    const redirectNewCheckout = sessionPlanType === PLAN_TYPE.free;
+    const redirectNewCheckout = [PLAN_TYPE.free, PLAN_TYPE.byEmail].includes(sessionPlanType);
 
     return (
       <div className="dp-container">

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
@@ -214,4 +214,51 @@ describe('PlanCalculator component', () => {
     const purchaseLink = screen.getByText('plan_calculator.button_purchase');
     expect(purchaseLink).toHaveClass('disabled');
   });
+
+  it('should go to new checkout when the account type is by emails', async () => {
+    // Arrange
+    const selectedPlanId = 2;
+    const fakeForcedServices = {
+      appSessionRef: {
+        current: {
+          userData: {
+            user: {
+              plan: {
+                idPlan: 3,
+                planType: PLAN_TYPE.byEmail,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={fakeForcedServices}>
+        <IntlProvider>
+          <Router
+            initialEntries={[
+              `/plan-selection/premium/${
+                URL_PLAN_TYPE[PLAN_TYPE.byEmail]
+              }?promo-code=fake-promo-code&origin_inbound=fake`,
+            ]}
+          >
+            <Route path="/plan-selection/premium/:planType?">
+              <PlanCalculatorButtons selectedPlanId={selectedPlanId} />
+            </Route>
+          </Router>
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    // Assert
+    const purchaseLink = screen.getByText('plan_calculator.button_purchase');
+    expect(purchaseLink).not.toHaveClass('disabled');
+    expect(purchaseLink).toHaveAttribute(
+      'href',
+      `/checkout/premium/${PLAN_TYPE.byEmail}?selected-plan=${selectedPlanId}` +
+        `&PromoCode=fake-promo-code&origin_inbound=fake`,
+    );
+  });
 });


### PR DESCRIPTION
### **Enable plans by emails**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-1013
⚠️⚠️ **Note:** Don't merge before of [DAT-998](https://github.com/FromDoppler/doppler-webapp/pull/2024)

**Scenario**

- The user navigates to /plan-selection/premium/by-emails with a account type by emails
- The user sees Plan Calculator
- The user selects a new plan
- The user click continue button
- The user sees new checkout

![Grabación de pantalla 2022-07-05 a la(s) 11 18 37 a](https://user-images.githubusercontent.com/84402180/177362048-1e3a9977-2332-4f51-a208-15c6f91e5c77.gif)

