### PR TITLE
fix: enable button when change the suscription type user

### DIFF
--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
@@ -8,12 +8,14 @@ import { useLocation, useParams } from 'react-router-dom';
 import { PLAN_TYPE } from '../../../../doppler-types';
 
 export const PlanCalculatorButtons = InjectAppServices(
-  ({ selectedPlanId, selectedDiscountId, selectedMonthPlan, dependencies: { appSessionRef } }) => {
+  ({ selectedPlanId, selectedDiscount, selectedMonthPlan, dependencies: { appSessionRef } }) => {
     const intl = useIntl();
     const _ = (id, values) => intl.formatMessage({ id: id }, values);
     const { search } = useLocation();
 
     const sessionPlan = appSessionRef.current.userData.user;
+    const isEqualSubscription =
+      sessionPlan.plan.planSubscription === selectedDiscount?.numberMonths;
     const isEqualPlan = sessionPlan.plan.idPlan === selectedPlanId;
     const { planType: planTypeUrlSegment } = useParams();
     const selectedPlanType = getPlanTypeFromUrlSegment(planTypeUrlSegment);
@@ -32,17 +34,19 @@ export const PlanCalculatorButtons = InjectAppServices(
               {_('plan_calculator.button_back')}
             </button>
             <TooltipContainer
-              visible={isEqualPlan}
+              visible={isEqualPlan && isEqualSubscription}
               content={_('plan_calculator.button_purchase_tooltip')}
               orientation="top"
             >
               <S.PurchaseLink
-                className={`dp-button button-medium primary-green ${isEqualPlan ? 'disabled' : ''}`}
+                className={`dp-button button-medium primary-green ${
+                  isEqualPlan && isEqualSubscription ? 'disabled' : ''
+                }`}
                 href={getBuyPurchaseUrl({
                   controlPanelUrl: _('common.control_panel_section_url'),
                   planType: selectedPlanType,
                   planId: selectedPlanId,
-                  discountId: selectedDiscountId,
+                  discountId: selectedDiscount?.id,
                   monthPlan: selectedMonthPlan,
                   newCheckoutEnabled: redirectNewCheckout,
                   search,

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
@@ -16,6 +16,7 @@ describe('PlanCalculator component', () => {
             plan: {
               idPlan: 3,
               planType: PLAN_TYPE.free,
+              planSubscription: 1,
             },
           },
         },
@@ -32,7 +33,10 @@ describe('PlanCalculator component', () => {
   it('should render PlanCalculatorButtons when the user is free', async () => {
     // Arrange
     const selectedPlanId = 2;
-    const selectedDiscountId = 1;
+    const selectedDiscount = {
+      id: 1,
+      numberMonths: 1,
+    };
 
     // Act
     render(
@@ -48,7 +52,7 @@ describe('PlanCalculator component', () => {
             <Route path="/plan-selection/premium/:planType?">
               <PlanCalculatorButtons
                 selectedPlanId={selectedPlanId}
-                selectedDiscountId={selectedDiscountId}
+                selectedDiscount={selectedDiscount}
               />
             </Route>
           </Router>
@@ -62,7 +66,7 @@ describe('PlanCalculator component', () => {
     expect(purchaseLink).toHaveAttribute(
       'href',
       `/checkout/premium/${PLAN_TYPE.byContact}?selected-plan=${selectedPlanId}` +
-        `&discountId=${selectedDiscountId}` +
+        `&discountId=${selectedDiscount.id}` +
         `&PromoCode=fake-promo-code&origin_inbound=fake`,
     );
   });
@@ -70,7 +74,10 @@ describe('PlanCalculator component', () => {
   it('should render PlanCalculatorButtons when the user is not free', async () => {
     // Arrange
     const selectedPlanId = 2;
-    const selectedDiscountId = 1;
+    const selectedDiscount = {
+      id: 1,
+      numberMonths: 1,
+    };
 
     const fakeForcedServices = {
       appSessionRef: {
@@ -80,6 +87,7 @@ describe('PlanCalculator component', () => {
               plan: {
                 idPlan: 3,
                 planType: PLAN_TYPE.byContact,
+                planSubscription: 1,
               },
             },
           },
@@ -101,7 +109,7 @@ describe('PlanCalculator component', () => {
             <Route path="/plan-selection/premium/:planType?">
               <PlanCalculatorButtons
                 selectedPlanId={selectedPlanId}
-                selectedDiscountId={selectedDiscountId}
+                selectedDiscount={selectedDiscount}
               />
             </Route>
           </Router>
@@ -116,7 +124,7 @@ describe('PlanCalculator component', () => {
       'href',
       'common.control_panel_section_url' +
         `/AccountPreferences/UpgradeAccountStep2?IdUserTypePlan=${selectedPlanId}&fromStep1=True` +
-        `&IdDiscountPlan=${selectedDiscountId}` +
+        `&IdDiscountPlan=${selectedDiscount.id}` +
         `&PromoCode=fake-promo-code&origin_inbound=fake`,
     );
   });
@@ -124,7 +132,10 @@ describe('PlanCalculator component', () => {
   it('should render PlanCalculatorButtons when selected plan is equal to user current plan', async () => {
     // Arrange
     const selectedPlanId = 3;
-    const selectedDiscountId = 1;
+    const selectedDiscount = {
+      id: 1,
+      numberMonths: 1,
+    };
 
     // Act
     render(
@@ -140,7 +151,58 @@ describe('PlanCalculator component', () => {
             <Route path="/plan-selection/premium/:planType?">
               <PlanCalculatorButtons
                 selectedPlanId={selectedPlanId}
-                selectedDiscountId={selectedDiscountId}
+                selectedDiscount={selectedDiscount}
+              />
+            </Route>
+          </Router>
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    // Assert
+    const purchaseLink = screen.getByText('plan_calculator.button_purchase');
+    expect(purchaseLink).toHaveClass('disabled');
+  });
+
+  it('The buy button shoud be disabled when user has plan y discount equal to selected', async () => {
+    // Arrange
+    const selectedPlanId = 2;
+    const selectedDiscount = {
+      id: 1,
+      numberMonths: 3,
+    };
+
+    const fakeForcedServices = {
+      appSessionRef: {
+        current: {
+          userData: {
+            user: {
+              plan: {
+                idPlan: 2,
+                planType: PLAN_TYPE.byContact,
+                planSubscription: 3,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={fakeForcedServices}>
+        <IntlProvider>
+          <Router
+            initialEntries={[
+              `/plan-selection/premium/${
+                URL_PLAN_TYPE[PLAN_TYPE.byContact]
+              }?promo-code=fake-promo-code&origin_inbound=fake`,
+            ]}
+          >
+            <Route path="/plan-selection/premium/:planType?">
+              <PlanCalculatorButtons
+                selectedPlanId={selectedPlanId}
+                selectedDiscount={selectedDiscount}
               />
             </Route>
           </Router>

--- a/src/components/Plans/PlanCalculator/index.js
+++ b/src/components/Plans/PlanCalculator/index.js
@@ -249,7 +249,7 @@ export const PlanCalculator = InjectAppServices(
                 </S.PlanTabContainer>
                 <PlanCalculatorButtons
                   selectedPlanId={selectedPlan?.id}
-                  selectedDiscountId={selectedDiscount?.id}
+                  selectedDiscount={selectedDiscount}
                   selectedMonthPlan={selectedDiscount?.numberMonths}
                 />
               </div>


### PR DESCRIPTION
### **Enable buy button when change the suscription type user**
**Jira Ticket**: https://makingsense.atlassian.net/browse/DAT-1019

**Description**
When the user has a monthly subscription type and he wants a trimestral subscription type, the buy continue button is enabled.

**The Bug**
![Grabación de pantalla 2022-07-11 a la(s) 8 32 14 a](https://user-images.githubusercontent.com/84402180/178265331-f7a173f4-7196-4371-b96a-7d367aad774c.gif)

