### PR TITLE
feat: add target attribute to link for open at a new tab

### DIFF
--- a/src/components/Dashboard/LearnWithDoppler/TextPreviewPost/TextPreviewPost.js
+++ b/src/components/Dashboard/LearnWithDoppler/TextPreviewPost/TextPreviewPost.js
@@ -10,7 +10,7 @@ export const TextPreviewPost = ({ post }) => {
     <>
       <h3>{_(title)}</h3>
       <p>{_(description)}</p>
-      <a href={_(link)}>
+      <a href={_(link)} target="_blank">
         <span className="ms-icon icon-arrow-next"></span>
         {_(linkDescription)}
       </a>


### PR DESCRIPTION
### **Add target attribute to link in Learn With Doppler Section**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-801

**Scenaries:**

- The user navigates to `/dashboard`
- The user clicks in Learn With Doppler Section
- The page is opening at a new tab 