### PR TITLE
Dat 1027 add enable upgrade between plans by contacts - ⚠️⚠️⚠️ don't merge before of 10/08/2022

### DIFF
--- a/src/components/Plans/PlanCalculator/GoToUpgrade/index.js
+++ b/src/components/Plans/PlanCalculator/GoToUpgrade/index.js
@@ -10,34 +10,14 @@ export const GoToUpgrade = InjectAppServices(({ dependencies: { appSessionRef } 
   const { isFreeAccount: isTrial, planType } = appSessionRef.current.userData.user.plan;
   const location = useLocation();
 
-  if (!isTrial) {
-    if (planType === PLAN_TYPE.byCredit) {
-      // Redirect to buy credits with all query parameters
-      return (
-        <>
-          <Loading />
-          <SafeRedirect to={`/ControlPanel/AccountPreferences/BuyCreditsStep1${location.search}`} />
-        </>
-      );
-    } else if (planType !== PLAN_TYPE.byEmail) {
-      const queryParams = new URLSearchParams(location.search);
-      if (queryParams.has('PromoCode')) {
-        // Delete PromoCode query parameter: https://docs.google.com/spreadsheets/d/1CSXmsVqZTwIhzPRH8_tcPohHmvDXffLTQ-veF-53698/edit#gid=0
-        queryParams.delete('PromoCode');
-      }
-      const restQueryParams = queryParams.toString();
-      // Redirect to upgrade page with popup (without promocode query parameter)
-      return (
-        <>
-          <Loading />
-          <SafeRedirect
-            to={`/ControlPanel/AccountPreferences/GetAccountInformation${
-              restQueryParams ? `?${restQueryParams}` : ''
-            }`}
-          />
-        </>
-      );
-    }
+  if (!isTrial && planType === PLAN_TYPE.byCredit) {
+    // Redirect to buy credits with all query parameters
+    return (
+      <>
+        <Loading />
+        <SafeRedirect to={`/ControlPanel/AccountPreferences/BuyCreditsStep1${location.search}`} />
+      </>
+    );
   }
 
   return <PlanCalculator />;

--- a/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
+++ b/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
@@ -102,46 +102,6 @@ describe('GoToUpgrade Component', () => {
     expect(window.location.href).toBe(`${process.env.REACT_APP_DOPPLER_LEGACY_URL}${partialUrl}`);
   });
 
-  it('should go to upgrade plan when is a contacts account', async () => {
-    //Arrange
-    const dependencies = getDependencies(
-      {
-        isFreeAccount: false,
-        planType: PLAN_TYPE.byContact,
-      },
-      [PLAN_TYPE.byContact],
-    );
-
-    //Act
-    render(
-      <IntlProvider>
-        <Router
-          initialEntries={[
-            `/plan-selection/premium/${
-              URL_PLAN_TYPE[PLAN_TYPE.byContact]
-            }?PromoCode=S4NV4L3NT1N&origin_inbound=fake`,
-          ]}
-        >
-          <Route path="/plan-selection/premium/:planType?">
-            <AppServicesProvider forcedServices={dependencies}>
-              <GoToUpgrade />
-            </AppServicesProvider>
-          </Route>
-        </Router>
-      </IntlProvider>,
-    );
-
-    //Assert
-    const planCalculatorTitle = screen.queryByText('plan_calculator.plan_premium_title');
-    expect(planCalculatorTitle).not.toBeInTheDocument();
-
-    const loader = screen.getByTestId('loading-box');
-    expect(loader).toBeInTheDocument();
-
-    const partialUrl = `/ControlPanel/AccountPreferences/GetAccountInformation?origin_inbound=fake`;
-    expect(window.location.href).toBe(`${process.env.REACT_APP_DOPPLER_LEGACY_URL}${partialUrl}`);
-  });
-
   it('should go to plan calculator when is a emails account', async () => {
     //Arrange
     const dependencies = getDependencies(
@@ -157,6 +117,66 @@ describe('GoToUpgrade Component', () => {
     render(
       <IntlProvider>
         <Router initialEntries={[`/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byEmail]}`]}>
+          <Route path="/plan-selection/premium/:planType?">
+            <AppServicesProvider forcedServices={dependencies}>
+              <GoToUpgrade />
+            </AppServicesProvider>
+          </Route>
+        </Router>
+      </IntlProvider>,
+    );
+
+    //Assert
+    const planCalculatorTitle = await screen.findByText('plan_calculator.plan_premium_title');
+    expect(planCalculatorTitle).toBeInTheDocument();
+  });
+
+  it('should go to plan calculator when is a monthly contacts account', async () => {
+    //Arrange
+    const dependencies = getDependencies(
+      {
+        idPlan: 3,
+        isFreeAccount: false,
+        planType: PLAN_TYPE.byContact,
+        planSubscription: 1,
+      },
+      [PLAN_TYPE.byContact, PLAN_TYPE.byEmail],
+    );
+
+    //Act
+    render(
+      <IntlProvider>
+        <Router initialEntries={[`/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byContact]}`]}>
+          <Route path="/plan-selection/premium/:planType?">
+            <AppServicesProvider forcedServices={dependencies}>
+              <GoToUpgrade />
+            </AppServicesProvider>
+          </Route>
+        </Router>
+      </IntlProvider>,
+    );
+
+    //Assert
+    const planCalculatorTitle = await screen.findByText('plan_calculator.plan_premium_title');
+    expect(planCalculatorTitle).toBeInTheDocument();
+  });
+
+  it('should go to plan calculator when is a semestral contacts account', async () => {
+    //Arrange
+    const dependencies = getDependencies(
+      {
+        idPlan: 3,
+        isFreeAccount: false,
+        planType: PLAN_TYPE.byContact,
+        planSubscription: 6,
+      },
+      [PLAN_TYPE.byContact],
+    );
+
+    //Act
+    render(
+      <IntlProvider>
+        <Router initialEntries={[`/plan-selection/premium/${URL_PLAN_TYPE[PLAN_TYPE.byContact]}`]}>
           <Route path="/plan-selection/premium/:planType?">
             <AppServicesProvider forcedServices={dependencies}>
               <GoToUpgrade />

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
@@ -20,7 +20,9 @@ export const PlanCalculatorButtons = InjectAppServices(
     const { planType: planTypeUrlSegment } = useParams();
     const selectedPlanType = getPlanTypeFromUrlSegment(planTypeUrlSegment);
     const sessionPlanType = sessionPlan.plan.planType;
-    const redirectNewCheckout = [PLAN_TYPE.free, PLAN_TYPE.byEmail].includes(sessionPlanType);
+    const redirectNewCheckout = [PLAN_TYPE.free, PLAN_TYPE.byEmail, PLAN_TYPE.byContact].includes(
+      sessionPlanType,
+    );
 
     return (
       <div className="dp-container">

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
@@ -71,7 +71,7 @@ describe('PlanCalculator component', () => {
     );
   });
 
-  it('should render PlanCalculatorButtons when the user is not free', async () => {
+  it('should render PlanCalculatorButtons when the user is by credit', async () => {
     // Arrange
     const selectedPlanId = 2;
     const selectedDiscount = {
@@ -86,7 +86,7 @@ describe('PlanCalculator component', () => {
             user: {
               plan: {
                 idPlan: 3,
-                planType: PLAN_TYPE.byContact,
+                planType: PLAN_TYPE.byCredit,
                 planSubscription: 1,
               },
             },
@@ -102,7 +102,7 @@ describe('PlanCalculator component', () => {
           <Router
             initialEntries={[
               `/plan-selection/premium/${
-                URL_PLAN_TYPE[PLAN_TYPE.byContact]
+                URL_PLAN_TYPE[PLAN_TYPE.byCredit]
               }?promo-code=fake-promo-code&origin_inbound=fake`,
             ]}
           >
@@ -258,6 +258,53 @@ describe('PlanCalculator component', () => {
     expect(purchaseLink).toHaveAttribute(
       'href',
       `/checkout/premium/${PLAN_TYPE.byEmail}?selected-plan=${selectedPlanId}` +
+        `&PromoCode=fake-promo-code&origin_inbound=fake`,
+    );
+  });
+
+  it('should go to new checkout when the account type is by contacts', async () => {
+    // Arrange
+    const selectedPlanId = 2;
+    const fakeForcedServices = {
+      appSessionRef: {
+        current: {
+          userData: {
+            user: {
+              plan: {
+                idPlan: 3,
+                planType: PLAN_TYPE.byContact,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={fakeForcedServices}>
+        <IntlProvider>
+          <Router
+            initialEntries={[
+              `/plan-selection/premium/${
+                URL_PLAN_TYPE[PLAN_TYPE.byContact]
+              }?promo-code=fake-promo-code&origin_inbound=fake`,
+            ]}
+          >
+            <Route path="/plan-selection/premium/:planType?">
+              <PlanCalculatorButtons selectedPlanId={selectedPlanId} />
+            </Route>
+          </Router>
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    // Assert
+    const purchaseLink = screen.getByText('plan_calculator.button_purchase');
+    expect(purchaseLink).not.toHaveClass('disabled');
+    expect(purchaseLink).toHaveAttribute(
+      'href',
+      `/checkout/premium/${PLAN_TYPE.byContact}?selected-plan=${selectedPlanId}` +
         `&PromoCode=fake-promo-code&origin_inbound=fake`,
     );
   });


### PR DESCRIPTION
### **Enable plans by contacts**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-1027
⚠️⚠️ **Note:** Don't merge before of 10/08/2022

**Scenario**

- The user navigates to /plan-selection/premium/by-contacts with a account type by contacts
- The user sees Plan Calculator
- The user selects a new plan
- The user click continue button
- The user sees new checkout