### PR TITLE
fix: assume 'direct' when URL does not contain UTM_Source

### DIFF
--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -51,14 +51,6 @@ function getParameter(location, parameter) {
   return extractParameter(location, queryString.parse, parameter);
 }
 
-function getSource(location) {
-  let utmSource = getParameter(location, 'utm_source');
-  if (!utmSource) {
-    utmSource = document.referrer || 'direct';
-  }
-  return utmSource;
-}
-
 /**
  * Signup Page
  * @param { Object } props
@@ -77,7 +69,7 @@ const Signup = function ({
   const [alreadyExistentAddresses, setAlreadyExistentAddresses] = useState([]);
   const [blockedDomains, setBlockedDomains] = useState([]);
 
-  const utmSource = getSource(location);
+  const utmSource = getParameter(location, 'utm_source') || 'direct';
   const utmCampaign = getParameter(location, 'utm_campaign');
   const utmMedium = getParameter(location, 'utm_medium');
   const utmTerm = getParameter(location, 'utm_term');


### PR DESCRIPTION
The value of the parameter `UTM_Source` during registration exceeds DB file length, [see Level2's chat](https://makingsense.slack.com/archives/GGW4H4YRL/p1659539173629839?thread_ts=1659467569.669719&cid=GGW4H4YRL).

It is because we receive a URL when we should receive a simple word (`facebook`, `instagram`, `linkedin`, `youtube`, `twitter`, `newsletter`, `mailing`, etc., see [documentation](https://makingsense.atlassian.net/wiki/spaces/DopplerMKT/pages/1329889281/Lineamientos+Tracking+UTMs#UTM-Source-(utm_source))).

The current code tries to read the value from the current URL and if it is not defined it uses the full _referrer_ value (an URL), [the code is ancient](https://github.com/FromDoppler/doppler-webapp/pull/1339/files#diff-97729f1090c23546a0ddc2b5198c7ce68403f05d48ae9e85035e02ec4d6818d2R56), and probably it is buggy from the beginning.

@MatiasRoy-Rodriguez confirms that [using `direct` when the parameter is not present in the current URL makes sense](https://makingsense.slack.com/archives/C030BR6PK2P/p1659545138855039?thread_ts=1659540441.159659&cid=C030BR6PK2P), so, here is the fix.

Thoughts?