### PR TITLE
refactor: remove use of "/features" endpoint

### DIFF
--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -488,7 +488,9 @@ function parsePlan(json: any) {
   json.CancelCampaignEnabled && features.push('cancelCampaign');
   json.SiteTrackingLicensed && features.push('siteTracking');
   json.SmartCampaignsEnabled && features.push('smartCampaigns');
-  json.ShippingLimitEnabled && features.push('shippingLimit');
+  // TODO: the features are available for all users.
+  // Analyze the treatment to clean the code related with them.
+  features.push('shippingLimit');
 
   const billingCycleDetails = json.DiscountXPlan.length
     ? json.DiscountXPlan.filter(

--- a/src/services/doppler-user-api-client.ts
+++ b/src/services/doppler-user-api-client.ts
@@ -142,6 +142,8 @@ export class HttpDopplerUserApiClient implements DopplerUserApiClient {
     }
   }
 
+  // TODO: it should be removed, the features are available for all users.
+  // [Related ticket](https://makingsense.atlassian.net/browse/DOP-1097)
   public async getFeatures(): Promise<ResultWithoutExpectedErrors<Features>> {
     try {
       const { email, jwtToken } = this.getDopplerUserApiConnectionData();


### PR DESCRIPTION
It's not necessary to use this endpoint anymore because now the features are assumed like true for all users.
[A ticket](https://makingsense.atlassian.net/browse/DOP-1097) was created and associated with the related code.

related to [DOP-1080](https://makingsense.atlassian.net/browse/DOP-1080)