### PR TITLE
[DAT-1082] - Add enable upgrade between plans by credits

### DIFF
--- a/src/components/Plans/PlanCalculator/GoToUpgrade/index.js
+++ b/src/components/Plans/PlanCalculator/GoToUpgrade/index.js
@@ -1,24 +1,8 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 import { PlanCalculator } from '..';
-import { PLAN_TYPE } from '../../../../doppler-types';
 import { InjectAppServices } from '../../../../services/pure-di';
-import { Loading } from '../../../Loading/Loading';
-import SafeRedirect from '../../../SafeRedirect';
 
-export const GoToUpgrade = InjectAppServices(({ dependencies: { appSessionRef } }) => {
-  const { isFreeAccount: isTrial, planType } = appSessionRef.current.userData.user.plan;
-  const location = useLocation();
-
-  if (!isTrial && planType === PLAN_TYPE.byCredit) {
-    // Redirect to buy credits with all query parameters
-    return (
-      <>
-        <Loading />
-        <SafeRedirect to={`/ControlPanel/AccountPreferences/BuyCreditsStep1${location.search}`} />
-      </>
-    );
-  }
-
+//TODO: In the future, this component should be replaced to PlanCalculator component.
+export const GoToUpgrade = InjectAppServices(() => {
   return <PlanCalculator />;
 });

--- a/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
+++ b/src/components/Plans/PlanCalculator/GoToUpgrade/index.test.js
@@ -62,14 +62,14 @@ describe('GoToUpgrade Component', () => {
     expect(planCalculatorTitle).toBeInTheDocument();
   });
 
-  it('should go to buy credits page when is a credits account', async () => {
+  it('should go to plan calculator when is a credits account', async () => {
     //Arrange
     const dependencies = getDependencies(
       {
         isFreeAccount: false,
         planType: PLAN_TYPE.byCredit,
       },
-      [PLAN_TYPE.byCredit],
+      [PLAN_TYPE.byContact, PLAN_TYPE.byEmail, PLAN_TYPE.byCredit],
     );
 
     //Act
@@ -78,7 +78,7 @@ describe('GoToUpgrade Component', () => {
         <Router
           initialEntries={[
             `/plan-selection/premium/${
-              URL_PLAN_TYPE[PLAN_TYPE.byContact]
+              URL_PLAN_TYPE[PLAN_TYPE.byCredit]
             }?PromoCode=S4NV4L3NT1N&origin_inbound=fake`,
           ]}
         >
@@ -92,14 +92,8 @@ describe('GoToUpgrade Component', () => {
     );
 
     //Assert
-    const planCalculatorTitle = screen.queryByText('plan_calculator.plan_premium_title');
-    expect(planCalculatorTitle).not.toBeInTheDocument();
-
-    const loader = screen.getByTestId('loading-box');
-    expect(loader).toBeInTheDocument();
-
-    const partialUrl = `/ControlPanel/AccountPreferences/BuyCreditsStep1?PromoCode=S4NV4L3NT1N&origin_inbound=fake`;
-    expect(window.location.href).toBe(`${process.env.REACT_APP_DOPPLER_LEGACY_URL}${partialUrl}`);
+    const planCalculatorTitle = await screen.findByText('plan_calculator.plan_premium_title');
+    expect(planCalculatorTitle).toBeInTheDocument();
   });
 
   it('should go to plan calculator when is a emails account', async () => {

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.js
@@ -21,9 +21,12 @@ export const PlanCalculatorButtons = InjectAppServices(
     const { planType: planTypeUrlSegment } = useParams();
     const selectedPlanType = getPlanTypeFromUrlSegment(planTypeUrlSegment);
     const sessionPlanType = sessionPlan.plan.planType;
-    const redirectNewCheckout = [PLAN_TYPE.free, PLAN_TYPE.byEmail, PLAN_TYPE.byContact].includes(
-      sessionPlanType,
-    );
+    const redirectNewCheckout = [
+      PLAN_TYPE.free,
+      PLAN_TYPE.byEmail,
+      PLAN_TYPE.byContact,
+      PLAN_TYPE.byCredit,
+    ].includes(sessionPlanType);
 
     return (
       <div className="dp-container">

--- a/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
+++ b/src/components/Plans/PlanCalculator/PlanCalculatorButtons/index.test.js
@@ -122,9 +122,8 @@ describe('PlanCalculator component', () => {
     expect(purchaseLink).not.toHaveClass('disabled');
     expect(purchaseLink).toHaveAttribute(
       'href',
-      'common.control_panel_section_url' +
-        `/AccountPreferences/UpgradeAccountStep2?IdUserTypePlan=${selectedPlanId}&fromStep1=True` +
-        `&IdDiscountPlan=${selectedDiscount.id}` +
+      `/checkout/premium/${PLAN_TYPE.byCredit}?selected-plan=${selectedPlanId}` +
+        `&discountId=${selectedDiscount.id}` +
         `&PromoCode=fake-promo-code&origin_inbound=fake`,
     );
   });
@@ -349,5 +348,52 @@ describe('PlanCalculator component', () => {
     // Assert
     const purchaseLink = screen.getByText('plan_calculator.button_purchase');
     expect(purchaseLink).toHaveClass('disabled');
+  });
+
+  it('should go to new checkout when the account type is by credits', async () => {
+    // Arrange
+    const selectedPlanId = 2;
+    const fakeForcedServices = {
+      appSessionRef: {
+        current: {
+          userData: {
+            user: {
+              plan: {
+                idPlan: 3,
+                planType: PLAN_TYPE.byCredit,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    render(
+      <AppServicesProvider forcedServices={fakeForcedServices}>
+        <IntlProvider>
+          <Router
+            initialEntries={[
+              `/plan-selection/premium/${
+                URL_PLAN_TYPE[PLAN_TYPE.byCredit]
+              }?promo-code=fake-promo-code&origin_inbound=fake`,
+            ]}
+          >
+            <Route path="/plan-selection/premium/:planType?">
+              <PlanCalculatorButtons selectedPlanId={selectedPlanId} />
+            </Route>
+          </Router>
+        </IntlProvider>
+      </AppServicesProvider>,
+    );
+
+    // Assert
+    const purchaseLink = screen.getByText('plan_calculator.button_purchase');
+    expect(purchaseLink).not.toHaveClass('disabled');
+    expect(purchaseLink).toHaveAttribute(
+      'href',
+      `/checkout/premium/${PLAN_TYPE.byCredit}?selected-plan=${selectedPlanId}` +
+        `&PromoCode=fake-promo-code&origin_inbound=fake`,
+    );
   });
 });


### PR DESCRIPTION
Add enable upgrade between plans by credits.

**Task:** [DAT-1082](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-1082)

**Scenario**

- The user navigates to /plan-selection/premium/by-credits with a account type by credits
- The user sees Plan Calculator
- The user selects a new plan
- The user click continue button
- The user sees new checkout