### PR TITLE
[DAT-1097] - Fix issue in the dashboard in the stepper.

### DIFF
--- a/src/components/Dashboard/FirstSteps/index.js
+++ b/src/components/Dashboard/FirstSteps/index.js
@@ -105,10 +105,10 @@ const getDomainsReadyStep = (hasDomainsReady) => ({
   link: 'dashboard.first_steps.has_domains_ready_url',
 });
 
-const getCampaingsCreatedStep = (hasCampaingsCreated) => ({
-  status: hasCampaingsCreated
+const getCampaingsCreatedAndSentStep = (hasCampaingsCreatedAndSent) => ({
+  status: hasCampaingsCreatedAndSent
     ? COMPLETED_STATUS
-    : hasCampaingsCreated === false
+    : hasCampaingsCreatedAndSent === false
     ? PENDING_STATUS
     : UNKNOWN_STATUS,
   titleId: `dashboard.first_steps.has_campaings_created_title`,
@@ -141,7 +141,7 @@ export const mapSystemUsageSummary = (systemUsageSummary) => {
     firstSteps: [
       getListCreatedStep(hasListsCreated),
       getDomainsReadyStep(hasDomainsReady),
-      getCampaingsCreatedStep(hasCampaingsCreated),
+      getCampaingsCreatedAndSentStep(hasCampaingsCreated && hasCampaingsSent),
       getCampaingsSentStep(hasCampaingsSent),
     ],
   };


### PR DESCRIPTION
El paso "Crea tu primer campaña" aparece tachado sin que le campaña se haya enviado. 

Este paso debería estar tachado cuando la campaña y enviada.

Bug: [DAT-1097](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-1097)