### PR TITLE
Disable Renovate auto-rebase

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":enableVulnerabilityAlerts",
     ":semanticCommits"
   ],
+  "rebaseWhen": "never",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
It is to avoid CI consumption because we have a lot of unmergeable dependencies.

![image](https://user-images.githubusercontent.com/1157864/191073393-2e504d39-059d-4636-88a9-fe363bb21ef4.png)

See documentation at https://docs.renovatebot.com/configuration-options/#rebasewhen

I think that we can rebase [by adding the tag `rebase`](https://docs.renovatebot.com/configuration-options/#rebaselabel) and also using the [Dependency Dashboard](https://github.com/FromDoppler/doppler-webapp/issues/2110).