### PR TITLE
fix: add reports to login redirection white list

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,6 +201,9 @@ export function isWhitelisted(url: string) {
     'https://app.fromdoppler.com/',
     'https://webappqa.fromdoppler.net/',
     'https://webappint.fromdoppler.net/',
+    'https://reports2.fromdoppler.com/',
+    'https://reportsqa.fromdoppler.net:400/',
+    'https://reportsint.fromdoppler.net:400/',
   ];
   return !!url && loginWhitelist.some((element) => url.startsWith(element));
 }


### PR DESCRIPTION
I will use it to redirect back to the same page when the session is expired in reports.