### PR TITLE
Set menu item for subscriber pages

### DIFF
--- a/src/components/Reports/Subscribers/Subscribers.js
+++ b/src/components/Reports/Subscribers/Subscribers.js
@@ -94,6 +94,7 @@ const Subscribers = ({ dependencies: { dopplerApiClient } }) => {
           </Breadcrumb>
           <h2>{currentSection.title}</h2>
           <p>{currentSection.description}</p>
+          <meta name="doppler-menu-mfe:default-active-item" content="listMasterSubscriberMenu" />
         </div>
       </HeaderSection>
 


### PR DESCRIPTION
I think that we missed marking the menu item for these sections.

<img width="1836" alt="image" src="https://user-images.githubusercontent.com/1157864/194319481-4b8a5084-ca8e-40c3-8e7b-e13986cb8dcb.png">

Pending:

- [ ] Confirm change in [#doppler-producto](https://makingsense.slack.com/archives/C023YV1B7B6/p1665061400106659)