### PR TITLE
fix: avoid to try to translate control panel URLs

### DIFF
--- a/src/components/ControlPanel/ControlPanelBox/ControlPanelBox.js
+++ b/src/components/ControlPanel/ControlPanelBox/ControlPanelBox.js
@@ -45,7 +45,7 @@ export const ControlPanelBox = ({ box }) => {
             <S.Link
               target={box.targetBlank ? '_blank' : '_self'}
               className="dp-white"
-              href={_(box.linkUrl)}
+              href={box.linkUrl}
             >
               <div>
                 <S.Image src={box.imgSrc} alt={_(box.imgAlt)} />


### PR DESCRIPTION
It fixes these errors:

![image](https://user-images.githubusercontent.com/1157864/195178460-534e1ec9-95f6-46c4-8bc4-df6c9214484a.png)
