### PR TITLE
Dat 1201 get content activation

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -17,6 +17,7 @@ import { connect } from 'formik';
 import Promotions from '../shared/Promotions/Promotions';
 import * as S from './ForgotPassword.styles';
 import { getFormInitialValues } from '../../utils';
+import { useGetBannerData } from '../../hooks/useGetBannerData';
 
 const fieldNames = {
   email: 'email',
@@ -28,10 +29,14 @@ const fieldNames = {
  * @param { import('react-intl').InjectedIntl } props.intl
  * @param { import('../../services/pure-di').AppServices } props.dependencies
  */
-const ForgotPassword = ({ location, dependencies: { dopplerLegacyClient } }) => {
+const ForgotPassword = ({
+  location,
+  dependencies: { dopplerLegacyClient, dopplerSitesClient },
+}) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
   const [sentEmail, setSentEmail] = useState(null);
+  const bannerDataState = useGetBannerData({ dopplerSitesClient, intl, type: 'login' });
 
   /** Prepare empty values for all fields
    * It is required because in another way, the fields are not marked as touched.
@@ -161,7 +166,7 @@ const ForgotPassword = ({ location, dependencies: { dopplerLegacyClient } }) => 
             </small>
           </footer>
         </article>
-        <Promotions type="login" />
+        <Promotions {...bannerDataState} />
       </main>
     </div>
   );

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -27,6 +27,7 @@ import {
   openZendeskChatWithMessage,
 } from '../../utils';
 import { useLinkedinInsightTag } from '../../hooks/useLinkedingInsightTag';
+import { useGetBannerData } from '../../hooks/useGetBannerData';
 
 const fieldNames = {
   user: 'email',
@@ -113,11 +114,20 @@ const LoginErrorBasedOnCustomerSupport = ({ messages }) => {
  * @param { import('history').Location } props.location - location
  * @param { import('../../services/pure-di').AppServices } props.dependencies
  */
-const Login = ({ location, dependencies: { dopplerLegacyClient, sessionManager, window } }) => {
+const Login = ({
+  location,
+  dependencies: { dopplerLegacyClient, dopplerSitesClient, sessionManager, window },
+}) => {
   const intl = useIntl();
   const [redirectAfterLogin, setRedirectAfterLogin] = useState(false);
   const [redirectToUrl, setRedirectToUrl] = useState(false);
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const bannerDataState = useGetBannerData({
+    dopplerSitesClient,
+    intl,
+    type: 'login',
+    page: extractPage(location),
+  });
 
   /** Prepare empty values for all fields
    * It is required because in another way, the fields are not marked as touched.
@@ -354,7 +364,7 @@ const Login = ({ location, dependencies: { dopplerLegacyClient, sessionManager, 
             </small>
           </footer>
         </article>
-        <Promotions type="login" page={extractPage(location)} />
+        <Promotions {...bannerDataState} />
       </main>
     </div>
   );

--- a/src/components/Signup/ConfirmationContent/index.js
+++ b/src/components/Signup/ConfirmationContent/index.js
@@ -1,0 +1,23 @@
+import { useIntl } from 'react-intl';
+
+export const ConfirmationContent = ({ contentActivation }) => {
+  const intl = useIntl();
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  if (contentActivation) {
+    return (
+      <div data-testid="dinamic-content" dangerouslySetInnerHTML={{ __html: contentActivation }} />
+    );
+  }
+
+  return (
+    <article className="confirmation-article">
+      <h1>{_('signup.thanks_for_registering')}</h1>
+      <p>{_('signup.check_inbox')}</p>
+      <span className="icon-registration m-bottom--lv6">
+        {_('signup.check_inbox_icon_description')}
+      </span>
+      <p className="text-italic">{_('signup.activate_account_instructions')}</p>
+    </article>
+  );
+};

--- a/src/components/Signup/ConfirmationContent/index.test.js
+++ b/src/components/Signup/ConfirmationContent/index.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { ConfirmationContent } from '.';
+import DopplerIntlProvider from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+
+describe('ConfirmationContent', () => {
+  it('should render default content when has not contentAction', async () => {
+    // Arrange
+    const contentActivation = null;
+
+    // Act
+    render(
+      <DopplerIntlProvider>
+        <ConfirmationContent contentActivation={contentActivation} />
+      </DopplerIntlProvider>,
+    );
+
+    // Assert
+    expect(screen.queryByTestId('dinamic-content')).not.toBeInTheDocument();
+    screen.getByRole('article');
+    screen.getByRole('heading', { level: 1, name: 'signup.thanks_for_registering' });
+  });
+});

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -142,6 +142,7 @@ const Signup = function ({
       navigate(`/signup/confirmation${hasQueryParams ? location.search : ''}`, {
         state: {
           registeredUser,
+          contentActivation: bannerDataState.bannerData.contentActivation,
         },
       });
     } else if (result.expectedError && result.expectedError.emailAlreadyExists) {

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -21,6 +21,7 @@ import { isWhitelisted, addLogEntry, getFormInitialValues } from './../../utils'
 import * as S from './Signup.styles';
 import { useLinkedinInsightTag } from '../../hooks/useLinkedingInsightTag';
 import { useQueryParams } from '../../hooks/useQueryParams';
+import { useGetBannerData } from '../../hooks/useGetBannerData';
 
 const fieldNames = {
   firstname: 'firstname',
@@ -54,12 +55,17 @@ function getReferrerHostname() {
  * @param { import('react-intl').InjectedIntl } props.intl
  * @param { import('../../services/pure-di').AppServices } props.dependencies
  */
-const Signup = function ({ location, dependencies: { dopplerLegacyClient, utmCookiesManager } }) {
-  useLinkedinInsightTag();
-  const query = useQueryParams();
-  const navigate = useNavigate();
+const Signup = function ({
+  location,
+  dependencies: { dopplerLegacyClient, dopplerSitesClient, utmCookiesManager },
+}) {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const query = useQueryParams();
+  const page = query.get('page') || query.get('Page');
+  const bannerDataState = useGetBannerData({ dopplerSitesClient, intl, type: 'signup', page });
+  const navigate = useNavigate();
+  useLinkedinInsightTag();
 
   const [alreadyExistentAddresses, setAlreadyExistentAddresses] = useState([]);
   const [blockedDomains, setBlockedDomains] = useState([]);
@@ -74,8 +80,6 @@ const Signup = function ({ location, dependencies: { dopplerLegacyClient, utmCoo
     Origin_Inbound: query.get('origin_inbound'),
   };
   utmCookiesManager.setCookieEntry(utmParams);
-
-  const page = query.get('page') || query.get('Page');
 
   const addExistentEmailAddress = (email) => {
     setAlreadyExistentAddresses((x) => [...x, email]);
@@ -293,7 +297,7 @@ const Signup = function ({ location, dependencies: { dopplerLegacyClient, utmCoo
             </small>
           </footer>
         </S.MainPanel>
-        <Promotions type="signup" page={page} />
+        <Promotions {...bannerDataState} />
       </main>
     </div>
   );

--- a/src/components/Signup/SignupConfirmation.js
+++ b/src/components/Signup/SignupConfirmation.js
@@ -3,6 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 import { Navigate, useLocation } from 'react-router-dom';
 import { InjectAppServices } from '../../services/pure-di';
+import { ConfirmationContent } from './ConfirmationContent';
 
 /**
  * Signup Confirmation Page
@@ -16,6 +17,7 @@ const SignupConfirmation = function ({
 }) {
   const location = useLocation();
   const registeredUser = location.state?.registeredUser;
+  const contentActivation = location.state?.contentActivation;
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
   const [resentTimes, setResentTimes] = useState(0);
@@ -50,14 +52,7 @@ const SignupConfirmation = function ({
             </a>
           </h1>
         </header>
-        <article className="confirmation-article">
-          <h1>{_('signup.thanks_for_registering')}</h1>
-          <p>{_('signup.check_inbox')}</p>
-          <span className="icon-registration m-bottom--lv6">
-            {_('signup.check_inbox_icon_description')}
-          </span>
-          <p className="text-italic">{_('signup.activate_account_instructions')}</p>
-        </article>
+        <ConfirmationContent contentActivation={contentActivation} />
         {resentTimes === 0 ? (
           <>
             <Captcha />

--- a/src/components/shared/Promotions/Promotions.js
+++ b/src/components/shared/Promotions/Promotions.js
@@ -1,64 +1,30 @@
-import React, { useState, useEffect } from 'react';
-import { useIntl } from 'react-intl';
-import { InjectAppServices } from '../../../services/pure-di';
+import React from 'react';
 import { Loading } from '../../Loading/Loading';
-
-const getDefaultBannerData = (intl) => {
-  const _ = (id, values) => intl.formatMessage({ id: id }, values);
-
-  return {
-    title: _('default_banner_data.title'),
-    description: _('default_banner_data.description'),
-    backgroundUrl: _('default_banner_data.background_url'),
-    imageUrl: _('default_banner_data.image_url'),
-    functionality: _('default_banner_data.functionality'),
-    fontColor: '#FFF',
-  };
-};
 
 /**
  * Promotions
  * @param { Object } props
- * @param { import('react-intl').InjectedIntl } props.intl
- * @param { import('../../services/pure-di').AppServices } props.dependencies
  */
-const Promotions = function ({ type, page, dependencies: { dopplerSitesClient } }) {
-  const intl = useIntl();
-  const [state, setState] = useState({ loading: true });
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setState({ loading: true });
-      const bannerData = await dopplerSitesClient.getBannerData(intl.locale, type, page || '');
-      if (!bannerData || !bannerData.success) {
-        setState({ loading: false, bannerData: getDefaultBannerData(intl) });
-      } else {
-        setState({ loading: false, bannerData: bannerData.value });
-      }
-    };
-
-    fetchData();
-  }, [dopplerSitesClient, page, intl, type]);
-
+const Promotions = function ({ loading, bannerData }) {
   return (
     <section className="feature-panel" style={{ position: 'relative' }}>
-      {state.loading ? (
+      {loading ? (
         <Loading />
       ) : (
         <div
           className="feature-panel--bg"
           style={{
-            backgroundImage: `url(${state.bannerData.backgroundUrl})`,
-            color: state.bannerData.fontColor,
+            backgroundImage: `url(${bannerData.backgroundUrl})`,
+            color: bannerData.fontColor,
           }}
         >
           <article className="feature-content">
-            <h6>{state.bannerData.functionality}</h6>
-            <h1>{state.bannerData.title}</h1>
-            <div dangerouslySetInnerHTML={{ __html: state.bannerData.description }} />
+            <h6>{bannerData.functionality}</h6>
+            <h1>{bannerData.title}</h1>
+            <div dangerouslySetInnerHTML={{ __html: bannerData.description }} />
           </article>
           <figure className="content-img">
-            <img src={state.bannerData.imageUrl} alt="" />
+            <img src={bannerData.imageUrl} alt="" />
           </figure>
         </div>
       )}
@@ -66,4 +32,4 @@ const Promotions = function ({ type, page, dependencies: { dopplerSitesClient } 
   );
 };
 
-export default InjectAppServices(Promotions);
+export default Promotions;

--- a/src/components/shared/Promotions/Promotions.test.js
+++ b/src/components/shared/Promotions/Promotions.test.js
@@ -1,82 +1,43 @@
 import React from 'react';
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Promotions from './Promotions';
-import DopplerIntlProvider from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
-import { AppServicesProvider } from '../../../services/pure-di';
-
-const emptyResponse = { success: false, error: new Error('Dummy error') };
-const fullResponse = {
-  success: true,
-  value: {
-    title: 'default_banner_data.title',
-    description: 'default_banner_data.description',
-    backgroundUrl: 'default_banner_data.background_url',
-    imageUrl: 'default_banner_data.image_url',
-    functionality: 'default_banner_data.functionality',
-    color: '#fff',
-  },
-};
 
 describe('Promotions Component', () => {
-  afterEach(cleanup);
-  it('should sites response fail', async () => {
-    const dopplerSitesClientDouble = {
-      getBannerData: async () => emptyResponse,
+  it('should render loading component', async () => {
+    // arrange
+    const props = {
+      loading: true,
+      bannerData: null,
     };
 
-    const { container, getByText } = render(
-      <AppServicesProvider
-        forcedServices={{
-          dopplerSitesClient: dopplerSitesClientDouble,
-        }}
-      >
-        <DopplerIntlProvider locale="es">
-          <Promotions type="signup" page="example" />
-        </DopplerIntlProvider>
-      </AppServicesProvider>,
-    );
-    expect(container.querySelector('.loading-box')).toBeInTheDocument();
-    await waitFor(() => expect(getByText('default_banner_data.title')));
+    // act
+    render(<Promotions {...props} />);
+
+    // assert
+    screen.getByTestId('loading-box');
+    expect(screen.queryByRole('heading', { lavel: 1 })).not.toBeInTheDocument();
   });
 
-  it('should has full data from service', async () => {
-    const dopplerSitesClientDouble = {
-      getBannerData: async () => fullResponse,
+  it('should render Promotion component when has bannerData', async () => {
+    // arrange
+    const props = {
+      loading: false,
+      bannerData: {
+        title: 'default_banner_data.title',
+        description: 'default_banner_data.description',
+        backgroundUrl: 'default_banner_data.background_url',
+        imageUrl: 'default_banner_data.image_url',
+        functionality: 'default_banner_data.functionality',
+        fontColor: '#FFF',
+      },
     };
 
-    const { container, getByText } = render(
-      <AppServicesProvider
-        forcedServices={{
-          dopplerSitesClient: dopplerSitesClientDouble,
-        }}
-      >
-        <DopplerIntlProvider locale="es">
-          <Promotions type="signup" page="example" />
-        </DopplerIntlProvider>
-      </AppServicesProvider>,
-    );
-    expect(container.querySelector('.loading-box')).toBeInTheDocument();
-    await waitFor(() => expect(getByText(fullResponse.value.title)));
-  });
+    // act
+    render(<Promotions {...props} />);
 
-  it('should has full default data from service when dont have page in parameters', async () => {
-    const dopplerSitesClientDouble = {
-      getBannerData: async () => fullResponse,
-    };
-
-    const { container, getByText } = render(
-      <AppServicesProvider
-        forcedServices={{
-          dopplerSitesClient: dopplerSitesClientDouble,
-        }}
-      >
-        <DopplerIntlProvider locale="es">
-          <Promotions type="signup" />
-        </DopplerIntlProvider>
-      </AppServicesProvider>,
-    );
-    expect(container.querySelector('.loading-box')).toBeInTheDocument();
-    await waitFor(() => expect(getByText(fullResponse.value.title)));
+    // assert
+    expect(screen.queryByTestId('loading-box')).not.toBeInTheDocument();
+    screen.getByRole('heading', { level: 1, name: props.bannerData.title });
   });
 });

--- a/src/hooks/useGetBannerData/bannerDataReducer/index.js
+++ b/src/hooks/useGetBannerData/bannerDataReducer/index.js
@@ -1,0 +1,39 @@
+export const INITIAL_STATE_BANNER_DATA = {
+  bannerData: null,
+  loading: true,
+  hasError: false,
+};
+
+export const BANNER_DATA_ACTIONS = {
+  START_FETCH: 'START_FETCH',
+  FINISH_FETCH: 'FINISH_FETCH',
+  FAIL_FETCH: 'FAIL_FETCH',
+};
+
+export const bannerDataReducer = (state, action) => {
+  switch (action.type) {
+    case BANNER_DATA_ACTIONS.START_FETCH:
+      return {
+        ...state,
+        loading: true,
+        hasError: false,
+      };
+    case BANNER_DATA_ACTIONS.FINISH_FETCH:
+      const { payload } = action;
+
+      return {
+        ...state,
+        bannerData: payload,
+        loading: false,
+        hasError: false,
+      };
+    case BANNER_DATA_ACTIONS.FAIL_FETCH:
+      return {
+        ...state,
+        loading: false,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/hooks/useGetBannerData/bannerDataReducer/index.test.js
+++ b/src/hooks/useGetBannerData/bannerDataReducer/index.test.js
@@ -1,0 +1,72 @@
+import { bannerDataReducer, BANNER_DATA_ACTIONS } from '.';
+import { INITIAL_STATE_BANNER_DATA } from '..';
+
+describe('bannerDataReducer', () => {
+  it(`${BANNER_DATA_ACTIONS.START_FETCH} action`, () => {
+    // Arrange
+    const action = { type: BANNER_DATA_ACTIONS.START_FETCH };
+
+    // Act
+    const newState = bannerDataReducer(INITIAL_STATE_BANNER_DATA, action);
+
+    // Assert
+    expect(newState).toEqual({
+      ...INITIAL_STATE_BANNER_DATA,
+      loading: true,
+      hasError: false,
+    });
+  });
+
+  it(`${BANNER_DATA_ACTIONS.FINISH_FETCH} action`, () => {
+    // Arrange
+    const action = {
+      type: BANNER_DATA_ACTIONS.FINISH_FETCH,
+      payload: {
+        title: 'fake title',
+        description: 'fake description',
+        backgroundUrl: 'fake background',
+        imageUrl: 'fake image',
+        functionality: 'fake functionality',
+        fontColor: '#000',
+      },
+    };
+
+    // Act
+    const newState = bannerDataReducer(INITIAL_STATE_BANNER_DATA, action);
+
+    // Assert
+    expect(newState).toEqual({
+      loading: false,
+      hasError: false,
+      bannerData: action.payload,
+    });
+  });
+
+  it(`${BANNER_DATA_ACTIONS.FAIL_FETCH} action`, () => {
+    // Arrange
+    const action = { type: BANNER_DATA_ACTIONS.FAIL_FETCH };
+
+    // Act
+    const newState = bannerDataReducer(INITIAL_STATE_BANNER_DATA, action);
+
+    // Assert
+    expect(newState).toEqual({
+      ...INITIAL_STATE_BANNER_DATA,
+      loading: false,
+      hasError: true,
+    });
+  });
+
+  it('should return initialState when the action is not defined', () => {
+    // Arrange
+    const action = {
+      type: 'my-action',
+    };
+
+    // Act
+    const newState = bannerDataReducer(INITIAL_STATE_BANNER_DATA, action);
+
+    // Assert
+    expect(newState).toEqual(INITIAL_STATE_BANNER_DATA);
+  });
+});

--- a/src/hooks/useGetBannerData/index.js
+++ b/src/hooks/useGetBannerData/index.js
@@ -1,0 +1,46 @@
+import { useEffect, useReducer, useRef } from 'react';
+import {
+  bannerDataReducer,
+  BANNER_DATA_ACTIONS,
+  INITIAL_STATE_BANNER_DATA,
+} from './bannerDataReducer';
+
+export const getDefaultBannerData = (intl) => {
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  return {
+    title: _('default_banner_data.title'),
+    description: _('default_banner_data.description'),
+    backgroundUrl: _('default_banner_data.background_url'),
+    imageUrl: _('default_banner_data.image_url'),
+    functionality: _('default_banner_data.functionality'),
+    fontColor: '#FFF',
+  };
+};
+
+export const useGetBannerData = ({ dopplerSitesClient, intl, type, page }) => {
+  const intlRef = useRef(intl);
+  const [state, dispatch] = useReducer(bannerDataReducer, INITIAL_STATE_BANNER_DATA);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      dispatch({ type: BANNER_DATA_ACTIONS.START_FETCH });
+      const bannerData = await dopplerSitesClient.getBannerData(
+        intlRef.current.locale,
+        type,
+        page ?? '',
+      );
+      dispatch({
+        type: BANNER_DATA_ACTIONS.FINISH_FETCH,
+        payload:
+          !bannerData || !bannerData.success
+            ? getDefaultBannerData(intlRef.current)
+            : bannerData.value,
+      });
+    };
+
+    fetchData();
+  }, [dopplerSitesClient, intlRef, page, type]);
+
+  return state;
+};

--- a/src/hooks/useGetBannerData/index.test.js
+++ b/src/hooks/useGetBannerData/index.test.js
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom/extend-expect';
+import { renderHook } from '@testing-library/react-hooks';
+import { useGetBannerData } from '.';
+
+describe('useGetBannerData', () => {
+  it('should complete getBannerData with success', async () => {
+    // Arrange
+    const bannerData = {
+      title: 'fake title',
+      description: 'fake description',
+      backgroundUrl: 'fake background',
+      imageUrl: 'fake image',
+      functionality: 'fake functionality',
+      fontColor: '#000',
+    };
+    const dopplerSitesClientFake = {
+      getBannerData: jest.fn().mockResolvedValue({ success: true, value: bannerData }),
+    };
+    const props = {
+      dopplerSitesClient: dopplerSitesClientFake,
+      intl: jest.fn(),
+      type: 'signup',
+      page: 'dts',
+    };
+
+    // Act
+    const { result, waitForNextUpdate } = renderHook(() => useGetBannerData(props));
+
+    // Assert
+    expect(result.current.loading).toBe(true);
+
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.bannerData).toBe(bannerData);
+  });
+});

--- a/src/hooks/useGetBannerData/index.test.js
+++ b/src/hooks/useGetBannerData/index.test.js
@@ -33,4 +33,36 @@ describe('useGetBannerData', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.bannerData).toBe(bannerData);
   });
+
+  it('should complete getBannerData with banner data by default', async () => {
+    // Arrange
+    const dopplerSitesClientFake = {
+      getBannerData: jest.fn().mockResolvedValue({ success: false, value: null }),
+    };
+    const props = {
+      dopplerSitesClient: dopplerSitesClientFake,
+      intl: {
+        formatMessage: jest.fn(({ id }) => id),
+      },
+      type: 'signup',
+      page: 'dts',
+    };
+
+    // Act
+    const { result, waitForNextUpdate } = renderHook(() => useGetBannerData(props));
+
+    // Assert
+    expect(result.current.loading).toBe(true);
+
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.bannerData).toEqual({
+      title: 'default_banner_data.title',
+      description: 'default_banner_data.description',
+      backgroundUrl: 'default_banner_data.background_url',
+      imageUrl: 'default_banner_data.image_url',
+      functionality: 'default_banner_data.functionality',
+      fontColor: '#FFF',
+    });
+  });
 });

--- a/src/services/doppler-sites-client.ts
+++ b/src/services/doppler-sites-client.ts
@@ -12,6 +12,7 @@ export interface Promotions {
   imageUrl: string;
   backgroundUrl: string;
   fontColor: string;
+  contentActivation: string;
 }
 
 export type PromotionsResult = ResultWithoutExpectedErrors<Promotions>;
@@ -52,6 +53,7 @@ export class HttpDopplerSitesClient implements DopplerSitesClient {
           imageUrl: response.data.image_url,
           backgroundUrl: response.data.background_url,
           fontColor: response.data.font_color,
+          contentActivation: response.data.content_activation,
         },
       };
     } catch (error) {


### PR DESCRIPTION
### **Get activation content**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-1201

**Description**

- The user enters to `Signup` page
- `getBannerData` is executed. Return a new `contentActivation` property
- The user creates an account (`contentActivation` is sent)
- The user is redirected to `/signup/confirmation `
- If there is `contentActivation` then is used as content instead of content by default