### PR TITLE
fix: fix not a number ui error on the purchase summary component

### DIFF
--- a/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.js
+++ b/src/components/Plans/Checkout/PurchaseSummary/PurchaseSummary.js
@@ -264,7 +264,7 @@ export const InvoiceInformation = ({
   );
 };
 
-export const TotalPurchase = ({ totalPlan, priceToPay, state, isFree, currentMonthTotal }) => {
+export const TotalPurchase = ({ totalPlan, priceToPay, state, isFree, currentMonthTotal = 0 }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
 


### PR DESCRIPTION
When the purchase summary component was loading it showed: "NaN" on the total tag. Now when is loading it shows 0

Before:
![image](https://user-images.githubusercontent.com/113532222/200032478-661f5cdb-94ad-4e9c-ae0a-e729703d7418.png)
After:
![image](https://user-images.githubusercontent.com/113532222/200031440-724e53a1-7793-49af-a256-9f4445ce0d22.png)
