### PR TITLE
fix: fix language in useBannerData

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -35,7 +35,7 @@ const ForgotPassword = ({
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
   const [sentEmail, setSentEmail] = useState(null);
-  const bannerDataState = useGetBannerData({ dopplerSitesClient, intl, type: 'login' });
+  const bannerDataState = useGetBannerData({ dopplerSitesClient, type: 'login' });
 
   /** Prepare empty values for all fields
    * It is required because in another way, the fields are not marked as touched.

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -239,7 +239,6 @@ const Login = ({
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
   const bannerDataState = useGetBannerData({
     dopplerSitesClient,
-    intl,
     type: 'login',
     page: extractPage(location),
   });

--- a/src/components/Signup/Signup.js
+++ b/src/components/Signup/Signup.js
@@ -63,7 +63,7 @@ const Signup = function ({
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
   const query = useQueryParams();
   const page = query.get('page') || query.get('Page');
-  const bannerDataState = useGetBannerData({ dopplerSitesClient, intl, type: 'signup', page });
+  const bannerDataState = useGetBannerData({ dopplerSitesClient, type: 'signup', page });
   const navigate = useNavigate();
   useLinkedinInsightTag();
 

--- a/src/hooks/useGetBannerData/index.test.js
+++ b/src/hooks/useGetBannerData/index.test.js
@@ -1,6 +1,20 @@
 import '@testing-library/jest-dom/extend-expect';
 import { renderHook } from '@testing-library/react-hooks';
 import { useGetBannerData } from '.';
+import IntlProvider from '../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+import { MemoryRouter as Router } from 'react-router-dom';
+
+const createWrapper = (Wrapper) => {
+  return function CreatedWrapper({ children }) {
+    return <Wrapper>{children}</Wrapper>;
+  };
+};
+
+const Wrapper = ({ children }) => (
+  <IntlProvider>
+    <Router>{children}</Router>
+  </IntlProvider>
+);
 
 describe('useGetBannerData', () => {
   it('should complete getBannerData with success', async () => {
@@ -18,13 +32,14 @@ describe('useGetBannerData', () => {
     };
     const props = {
       dopplerSitesClient: dopplerSitesClientFake,
-      intl: jest.fn(),
       type: 'signup',
       page: 'dts',
     };
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useGetBannerData(props));
+    const { result, waitForNextUpdate } = renderHook(() => useGetBannerData(props), {
+      wrapper: createWrapper(Wrapper),
+    });
 
     // Assert
     expect(result.current.loading).toBe(true);
@@ -41,15 +56,14 @@ describe('useGetBannerData', () => {
     };
     const props = {
       dopplerSitesClient: dopplerSitesClientFake,
-      intl: {
-        formatMessage: jest.fn(({ id }) => id),
-      },
       type: 'signup',
       page: 'dts',
     };
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useGetBannerData(props));
+    const { result, waitForNextUpdate } = renderHook(() => useGetBannerData(props), {
+      wrapper: createWrapper(Wrapper),
+    });
 
     // Assert
     expect(result.current.loading).toBe(true);


### PR DESCRIPTION
### **Fix language in useBannerData**
**Jira Ticket:** https://makingsense.atlassian.net/browse/DAT-1238

**Description**

When the user enters to `/signup?lang=es`  `/login?lang=es`  or `/login/reset-password?lang=es` with the navigator configured in english, sites api was called with `lang=en` as query param instead of `lang=es`