### PR TITLE
[DAT-1133] - Integrate app with provisory token

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -128,7 +128,7 @@ const BlockedAccountNotPayed = ({ messages }) => {
               button: (chunk) => (
                 <button
                   type="button"
-                  class="dp-message-link"
+                  className="dp-message-link"
                   onClick={() => openZendeskChatWithMessage(messages.msgZohoChat)}
                 >
                   {chunk}
@@ -307,6 +307,11 @@ const Login = ({
           setRedirectAfterLogin(true);
         }
       } else if (result.expectedError && result.expectedError.blockedAccountNotPayed) {
+        sessionManager.initialzeSessionWithBlockedUser({
+          status: 'non-authenticated-blocked-user',
+          provisoryToken: result.provisoryToken,
+          email: values[fieldNames.user].trim(),
+        });
         setErrors({
           _error: <BlockedAccountNotPayed messages={errorMessages.blockedAccountNotPayed} />,
         });

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -9,6 +9,7 @@ import RedirectToLogin from './RedirectToLogin';
 import { Loading } from './Loading/Loading';
 import { InjectAppServices } from '../services/pure-di';
 import MenuDemo from './MenuDemo/MenuDemo';
+import { nonAuthenticatedBlockedUser } from '../doppler-types';
 
 export default InjectAppServices(
   /**
@@ -49,6 +50,10 @@ export default InjectAppServices(
           <Footer />
         </div>
       );
+    }
+
+    if (dopplerSession.status === nonAuthenticatedBlockedUser) {
+      return children;
     }
 
     if (dopplerSession.status === 'unknown') {

--- a/src/doppler-types.ts
+++ b/src/doppler-types.ts
@@ -152,3 +152,5 @@ export const MercadoPagoError = {
 };
 
 export const OnlySupportUpSelling = 'Invalid selected plan. Only supports upselling.';
+
+export const nonAuthenticatedBlockedUser = 'non-authenticated-blocked-user';

--- a/src/services/app-session.ts
+++ b/src/services/app-session.ts
@@ -7,6 +7,12 @@ interface AuthenticatedAppSession {
   jwtToken: string;
 }
 
+interface BlockedUserAppSession {
+  status: 'non-authenticated-blocked-user';
+  provisoryToken: string;
+  email: string;
+}
+
 interface AuthenticatedAppSessionWithoutDatahub extends AuthenticatedAppSession {
   datahubCustomerId?: null;
 }
@@ -27,6 +33,7 @@ interface AuthenticatedAppSessionWithDatahub
 export type AppSession =
   | { status: 'unknown' }
   | { status: 'non-authenticated' }
+  | BlockedUserAppSession
   | AuthenticatedAppSessionWithoutDatahub
   | AuthenticatedAppSessionWithDatahub;
 

--- a/src/services/doppler-legacy-client.ts
+++ b/src/services/doppler-legacy-client.ts
@@ -181,7 +181,10 @@ export type LoginErrorResult =
       errorMessage: string;
     };
 
-export type LoginResult = Result<{ redirectUrl?: string }, LoginErrorResult>;
+export type LoginResult = Result<
+  { redirectUrl?: string; provisoryToken?: string },
+  LoginErrorResult
+>;
 
 export interface LoginModel extends PayloadWithCaptchaToken {
   username: string;
@@ -750,7 +753,10 @@ export class HttpDopplerLegacyClient implements DopplerLegacyClient {
       if (!response.data.success) {
         switch (response.data.error) {
           case 'BlockedAccountNotPayed': {
-            return { expectedError: { blockedAccountNotPayed: true } };
+            return {
+              expectedError: { blockedAccountNotPayed: true },
+              provisoryToken: response.data.provisoryToken,
+            };
           }
           case 'AccountNotValidated': {
             return { expectedError: { accountNotValidated: true } };


### PR DESCRIPTION
Integrate app with provisional token. 

The idea about this functionality is that when the user is blocked. The user can access the update payment information page with a provisional token.