### PR TITLE
[DOI-831] Add spinning icon when waiting for status fetch

### DIFF
--- a/src/components/Integrations/index.js
+++ b/src/components/Integrations/index.js
@@ -42,7 +42,7 @@ export const IntegrationsSection = InjectAppServices(
   ({ dependencies: { controlPanelService, dopplerUserApiClient } }) => {
     const intl = useIntl();
     const _ = useCallback((id, values) => intl.formatMessage({ id }, values), [intl]);
-    const [{ integrationSection, loading, loadingStatus }, dispatch] = useReducer(
+    const [{ integrationSection, loadingPage, loadingNativeIntegrations }, dispatch] = useReducer(
       IntegrationReducer,
       INITIAL_STATE,
     );
@@ -77,7 +77,7 @@ export const IntegrationsSection = InjectAppServices(
 
     useHashScrollHandler();
 
-    if (loading) {
+    if (loadingPage) {
       return <Loading page />;
     }
 
@@ -99,7 +99,7 @@ export const IntegrationsSection = InjectAppServices(
                     <h3 className="m-b-24" id={section.anchorLink}>
                       {section.title}
                     </h3>
-                    {section.showStatus && !loadingStatus ? (
+                    {section.showStatus && !loadingNativeIntegrations ? (
                       <S.StatusBoxContainer className="m-b-24">
                         <S.StatusIcon src={connection_alert} alt="connection alert icon" />
                         <span className="yellow-color">{_('integrations.status_alert')}</span>
@@ -116,7 +116,7 @@ export const IntegrationsSection = InjectAppServices(
                       <></>
                     )}
                   </S.TitleContainer>
-                  {section.showStatus && loadingStatus ? (
+                  {section.showStatus && loadingNativeIntegrations ? (
                     <Loading page />
                   ) : (
                     <div className="dp-rowflex" aria-label="Boxes Container">

--- a/src/components/Integrations/index.js
+++ b/src/components/Integrations/index.js
@@ -42,7 +42,7 @@ export const IntegrationsSection = InjectAppServices(
   ({ dependencies: { controlPanelService, dopplerUserApiClient } }) => {
     const intl = useIntl();
     const _ = useCallback((id, values) => intl.formatMessage({ id }, values), [intl]);
-    const [{ integrationSection, loading }, dispatch] = useReducer(
+    const [{ integrationSection, loading, loadingStatus }, dispatch] = useReducer(
       IntegrationReducer,
       INITIAL_STATE,
     );
@@ -64,6 +64,10 @@ export const IntegrationsSection = InjectAppServices(
           dispatch({
             type: INTEGRATION_SECTION_ACTIONS.GET_INTEGRATIONS_STATUS,
             payload: integrationsStatusResult.value,
+          });
+        } else {
+          dispatch({
+            type: INTEGRATION_SECTION_ACTIONS.GET_INTEGRATIONS_STATUS_FAILED,
           });
         }
       };
@@ -95,7 +99,7 @@ export const IntegrationsSection = InjectAppServices(
                     <h3 className="m-b-24" id={section.anchorLink}>
                       {section.title}
                     </h3>
-                    {section.showStatus ? (
+                    {section.showStatus && !loadingStatus ? (
                       <S.StatusBoxContainer className="m-b-24">
                         <S.StatusIcon src={connection_alert} alt="connection alert icon" />
                         <span className="yellow-color">{_('integrations.status_alert')}</span>
@@ -112,13 +116,17 @@ export const IntegrationsSection = InjectAppServices(
                       <></>
                     )}
                   </S.TitleContainer>
-                  <div className="dp-rowflex" aria-label="Boxes Container">
-                    {integrationSection[indexSection].boxes
-                      .sort(sortByStatus)
-                      .map((box, indexBox) => (
-                        <ControlPanelBox box={box} key={`box-${indexBox}`} />
-                      ))}
-                  </div>
+                  {section.showStatus && loadingStatus ? (
+                    <Loading page />
+                  ) : (
+                    <div className="dp-rowflex" aria-label="Boxes Container">
+                      {integrationSection[indexSection].boxes
+                        .sort(sortByStatus)
+                        .map((box, indexBox) => (
+                          <ControlPanelBox box={box} key={`box-${indexBox}`} />
+                        ))}
+                    </div>
+                  )}
                 </div>
               </div>
             ))}

--- a/src/components/Integrations/index.test.js
+++ b/src/components/Integrations/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import '@testing-library/jest-dom/extend-expect';
 import { IntegrationsSection } from '.';
 import DopplerIntlProvider from '../../i18n/DopplerIntlProvider.double-with-ids-as-values';
@@ -54,7 +55,9 @@ describe('Integration Section component', () => {
 
   it('should render sections and boxes', async () => {
     // Act
-    render(<IntegrationsSectionComponent />);
+    await act(async () => {
+      render(<IntegrationsSectionComponent />);
+    });
 
     // Assert
     expect(screen.getByRole('heading', { name: 'integrations.native_integrations.title' }));
@@ -65,7 +68,9 @@ describe('Integration Section component', () => {
 
   it('should render status description title', async () => {
     // Act
-    render(<IntegrationsSectionComponent showStatus={true} />);
+    await act(async () => {
+      render(<IntegrationsSectionComponent showStatus={true} />);
+    });
 
     // Assert
     expect(screen.getByText('integrations.status_alert')).toBeInTheDocument();
@@ -75,7 +80,9 @@ describe('Integration Section component', () => {
 
   it('should not render status description title', async () => {
     // Act
-    render(<IntegrationsSectionComponent />);
+    await act(async () => {
+      render(<IntegrationsSectionComponent />);
+    });
 
     // Assert
     expect(screen.queryByText('integrations.status_alert')).not.toBeInTheDocument();
@@ -85,7 +92,9 @@ describe('Integration Section component', () => {
 
   it('should render boxes ordered by status', async () => {
     // Act
-    render(<IntegrationsSectionComponent />);
+    await act(async () => {
+      render(<IntegrationsSectionComponent />);
+    });
 
     // Assert
     const boxesList = screen.getByLabelText('Boxes Container').childNodes;

--- a/src/components/Integrations/reducers/IntegrationReducer.js
+++ b/src/components/Integrations/reducers/IntegrationReducer.js
@@ -3,6 +3,7 @@ import { objectKeystoLowerCase } from '../../../utils';
 export const INITIAL_STATE = {
   integrationSection: [],
   loading: false,
+  loadingStatus: false,
 };
 
 const addConnectionStatusToBoxes = (integrationsStatus, integrationSection) => {
@@ -31,6 +32,7 @@ export const INTEGRATION_SECTION_ACTIONS = {
   START_FETCH: 'START_FETCH',
   GET_SECTIONS: 'GET_SECTIONS',
   GET_INTEGRATIONS_STATUS: 'GET_INTEGRATIONS_STATUS',
+  GET_INTEGRATIONS_STATUS_FAILED: 'GET_INTEGRATIONS_STATUS_FAILED',
 };
 
 export const IntegrationReducer = (state, action) => {
@@ -45,6 +47,7 @@ export const IntegrationReducer = (state, action) => {
       return {
         loading: false,
         integrationSection,
+        loadingStatus: true,
       };
 
     case INTEGRATION_SECTION_ACTIONS.GET_INTEGRATIONS_STATUS:
@@ -53,6 +56,14 @@ export const IntegrationReducer = (state, action) => {
       return {
         integrationSection: addConnectionStatusToBoxes(lowercaseObj, state.integrationSection),
         loading: false,
+        loadingStatus: false,
+      };
+
+    case INTEGRATION_SECTION_ACTIONS.GET_INTEGRATIONS_STATUS_FAILED:
+      return {
+        loading: false,
+        integrationSection: state.integrationSection,
+        loadingStatus: false,
       };
 
     default:

--- a/src/components/Integrations/reducers/IntegrationReducer.js
+++ b/src/components/Integrations/reducers/IntegrationReducer.js
@@ -2,8 +2,8 @@ import { objectKeystoLowerCase } from '../../../utils';
 
 export const INITIAL_STATE = {
   integrationSection: [],
-  loading: false,
-  loadingStatus: false,
+  loadingPage: false,
+  loadingNativeIntegrations: false,
 };
 
 const addConnectionStatusToBoxes = (integrationsStatus, integrationSection) => {
@@ -39,15 +39,15 @@ export const IntegrationReducer = (state, action) => {
   switch (action.type) {
     case INTEGRATION_SECTION_ACTIONS.START_FETCH:
       return {
-        loading: true,
+        loadingPage: true,
       };
 
     case INTEGRATION_SECTION_ACTIONS.GET_SECTIONS:
       const { payload: integrationSection } = action;
       return {
-        loading: false,
+        loadingPage: false,
         integrationSection,
-        loadingStatus: true,
+        loadingNativeIntegrations: true,
       };
 
     case INTEGRATION_SECTION_ACTIONS.GET_INTEGRATIONS_STATUS:
@@ -55,15 +55,15 @@ export const IntegrationReducer = (state, action) => {
       const lowercaseObj = objectKeystoLowerCase(integrationsStatusResult);
       return {
         integrationSection: addConnectionStatusToBoxes(lowercaseObj, state.integrationSection),
-        loading: false,
-        loadingStatus: false,
+        loadingPage: false,
+        loadingNativeIntegrations: false,
       };
 
     case INTEGRATION_SECTION_ACTIONS.GET_INTEGRATIONS_STATUS_FAILED:
       return {
-        loading: false,
+        loadingPage: false,
         integrationSection: state.integrationSection,
-        loadingStatus: false,
+        loadingNativeIntegrations: false,
       };
 
     default:

--- a/src/components/Integrations/reducers/IntegrationReducer.test.js
+++ b/src/components/Integrations/reducers/IntegrationReducer.test.js
@@ -42,9 +42,9 @@ describe('IntegrationReducer', () => {
 
     // Assert
     expect(newState).toEqual({
-      loading: false,
+      loadingPage: false,
       integrationSection: fakeIntegrationSection,
-      loadingStatus: true,
+      loadingNativeIntegrations: true,
     });
   });
 
@@ -146,8 +146,8 @@ describe('IntegrationReducer', () => {
     // Assert
     expect(newState).toEqual({
       ...expectedState,
-      loading: false,
-      loadingStatus: false,
+      loadingPage: false,
+      loadingNativeIntegrations: false,
     });
   });
 
@@ -174,7 +174,7 @@ describe('IntegrationReducer', () => {
     const newState = IntegrationReducer(INITIAL_STATE, action);
 
     // Assert
-    expect(newState).toEqual({ loading: true });
+    expect(newState).toEqual({ loadingPage: true });
   });
 
   it('should set loadingStatus false and keep integrationSection unchanged for GET_INTEGRATIONS_STATUS_FAILED action', () => {
@@ -184,7 +184,7 @@ describe('IntegrationReducer', () => {
     };
 
     const fakeState = {
-      loading: false,
+      loadingPage: false,
       integrationSection: [
         {
           title: 'title',
@@ -208,7 +208,7 @@ describe('IntegrationReducer', () => {
     // Assert
     expect(newState).toEqual({
       ...fakeState,
-      loadingStatus: false,
+      loadingNativeIntegrations: false,
     });
   });
 });

--- a/src/components/Integrations/reducers/IntegrationReducer.test.js
+++ b/src/components/Integrations/reducers/IntegrationReducer.test.js
@@ -44,6 +44,7 @@ describe('IntegrationReducer', () => {
     expect(newState).toEqual({
       loading: false,
       integrationSection: fakeIntegrationSection,
+      loadingStatus: true,
     });
   });
 
@@ -146,6 +147,7 @@ describe('IntegrationReducer', () => {
     expect(newState).toEqual({
       ...expectedState,
       loading: false,
+      loadingStatus: false,
     });
   });
 
@@ -173,5 +175,40 @@ describe('IntegrationReducer', () => {
 
     // Assert
     expect(newState).toEqual({ loading: true });
+  });
+
+  it('should set loadingStatus false and keep integrationSection unchanged for GET_INTEGRATIONS_STATUS_FAILED action', () => {
+    // Arrange
+    const action = {
+      type: INTEGRATION_SECTION_ACTIONS.GET_INTEGRATIONS_STATUS_FAILED,
+    };
+
+    const fakeState = {
+      loading: false,
+      integrationSection: [
+        {
+          title: 'title',
+          showStatus: true,
+          boxes: [
+            {
+              name: 'Box1',
+              linkUrl: 'link1',
+              imgSrc: 'imagen1',
+              imgAlt: 'imagen1',
+              iconName: 'boxName1',
+            },
+          ],
+        },
+      ],
+    };
+
+    // Act
+    const newState = IntegrationReducer(fakeState, action);
+
+    // Assert
+    expect(newState).toEqual({
+      ...fakeState,
+      loadingStatus: false,
+    });
   });
 });


### PR DESCRIPTION
When fetching for the integrations status there is a delay between the rendering of the boxes and the re-ordering by status of them. This already happened in the control panel but since you had to scroll down to get to the integrations sections it wasn't visible.
If the request fails it should show the boxes without the connection icon.

**BEFORE:**
![before](https://user-images.githubusercontent.com/34007887/207329258-ce999dd9-2c41-45a9-b565-9fb98d58608e.gif)

**AFTER**
![after](https://user-images.githubusercontent.com/34007887/207329710-8e4c9bdc-966c-4446-845b-01f22c5e4452.gif)
