### PR TITLE
Dop 1445 get restriction time values from doppler api

### DIFF
--- a/src/services/doppler-contact-policy-api-client.double.ts
+++ b/src/services/doppler-contact-policy-api-client.double.ts
@@ -25,6 +25,7 @@ export class HardcodedDopplerContactPolicyApiClient implements DopplerContactPol
       emailsAmountByInterval: 20,
       intervalInDays: 7,
       excludedSubscribersLists: this.mapSubscriberList(subscriberListCollection(5)),
+      timeRestriction: null,
     };
 
     return {

--- a/src/services/doppler-contact-policy-api-client.double.ts
+++ b/src/services/doppler-contact-policy-api-client.double.ts
@@ -25,7 +25,12 @@ export class HardcodedDopplerContactPolicyApiClient implements DopplerContactPol
       emailsAmountByInterval: 20,
       intervalInDays: 7,
       excludedSubscribersLists: this.mapSubscriberList(subscriberListCollection(5)),
-      timeRestriction: null,
+      timeRestriction: {
+        timeSlotEnabled: false,
+        hourFrom: 1,
+        hourTo: 2,
+        weekdaysEnabled: false,
+      },
     };
 
     return {

--- a/src/services/doppler-contact-policy-api-client.test.ts
+++ b/src/services/doppler-contact-policy-api-client.test.ts
@@ -12,6 +12,12 @@ const accountSettings = {
   emailsAmountByInterval: 20,
   intervalInDays: 7,
   excludedSubscribersLists: subscriberListCollection(2),
+  timeRestriction: {
+    timeSlotEnabled: true,
+    hourFrom: 5,
+    hourTo: 10,
+    weekdaysEnabled: false,
+  },
 };
 
 function createHttpDopplerContactPolicyApiClient(axios: any) {
@@ -56,6 +62,11 @@ describe('Doppler Contact Policy Api Client', () => {
     expect(result.value.intervalInDays).toBe(7);
     expect(result.value.excludedSubscribersLists).not.toBe(undefined);
     expect(result.value.excludedSubscribersLists).toHaveLength(2);
+    expect(result.value.timeRestriction).not.toBe(null);
+    expect(result.value.timeRestriction.timeSlotEnabled).toBe(true);
+    expect(result.value.timeRestriction.hourFrom).toBe(5);
+    expect(result.value.timeRestriction.hourTo).toBe(10);
+    expect(result.value.timeRestriction.weekdaysEnabled).toBe(false);
   });
 
   it('should get an error when requesting account settings', async () => {

--- a/src/services/doppler-contact-policy-api-client.test.ts
+++ b/src/services/doppler-contact-policy-api-client.test.ts
@@ -19,6 +19,19 @@ const accountSettings = {
     weekdaysEnabled: false,
   },
 };
+const accountSettingsWithEmptyValues = {
+  accountName: emailAccount,
+  active: true,
+  emailsAmountByInterval: null,
+  intervalInDays: null,
+  excludedSubscribersLists: subscriberListCollection(2),
+  timeRestriction: {
+    timeSlotEnabled: true,
+    hourFrom: null,
+    hourTo: null,
+    weekdaysEnabled: false,
+  },
+};
 
 function createHttpDopplerContactPolicyApiClient(axios: any) {
   const axiosStatic = {
@@ -66,6 +79,39 @@ describe('Doppler Contact Policy Api Client', () => {
     expect(result.value.timeRestriction.timeSlotEnabled).toBe(true);
     expect(result.value.timeRestriction.hourFrom).toBe(5);
     expect(result.value.timeRestriction.hourTo).toBe(10);
+    expect(result.value.timeRestriction.weekdaysEnabled).toBe(false);
+  });
+
+  it('should consider default values for a response with empty values', async () => {
+    // Arrange
+    const response = {
+      data: accountSettingsWithEmptyValues,
+      status: 200,
+    };
+    const request = jest.fn(async () => response);
+    const dopplerContactPolicyApiClient = createHttpDopplerContactPolicyApiClient({ request });
+
+    const emailsAmountByIntervalDefault = 1;
+    const intervalInDaysDefault = 1;
+    const hourFromDefault = 0;
+    const hourToDefault = 0;
+
+    // Act
+    const result = await dopplerContactPolicyApiClient.getAccountSettings();
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
+    expect(result.value.active).toBe(true);
+    expect(result.value.emailsAmountByInterval).toBe(emailsAmountByIntervalDefault);
+    expect(result.value.intervalInDays).toBe(intervalInDaysDefault);
+    expect(result.value.excludedSubscribersLists).not.toBe(undefined);
+    expect(result.value.excludedSubscribersLists).toHaveLength(2);
+    expect(result.value.timeRestriction).not.toBe(null);
+    expect(result.value.timeRestriction.timeSlotEnabled).toBe(true);
+    expect(result.value.timeRestriction.hourFrom).toBe(hourFromDefault);
+    expect(result.value.timeRestriction.hourTo).toBe(hourToDefault);
     expect(result.value.timeRestriction.weekdaysEnabled).toBe(false);
   });
 

--- a/src/services/doppler-contact-policy-api-client.test.ts
+++ b/src/services/doppler-contact-policy-api-client.test.ts
@@ -26,10 +26,10 @@ const accountSettingsWithEmptyValues = {
   intervalInDays: null,
   excludedSubscribersLists: subscriberListCollection(2),
   timeRestriction: {
-    timeSlotEnabled: true,
+    timeSlotEnabled: null,
     hourFrom: null,
     hourTo: null,
-    weekdaysEnabled: false,
+    weekdaysEnabled: null,
   },
 };
 
@@ -93,8 +93,10 @@ describe('Doppler Contact Policy Api Client', () => {
 
     const emailsAmountByIntervalDefault = 1;
     const intervalInDaysDefault = 1;
+    const timeSlotEnabledDefault = false;
     const hourFromDefault = 0;
     const hourToDefault = 0;
+    const weekdaysEnabledDefault = false;
 
     // Act
     const result = await dopplerContactPolicyApiClient.getAccountSettings();
@@ -109,10 +111,10 @@ describe('Doppler Contact Policy Api Client', () => {
     expect(result.value.excludedSubscribersLists).not.toBe(undefined);
     expect(result.value.excludedSubscribersLists).toHaveLength(2);
     expect(result.value.timeRestriction).not.toBe(null);
-    expect(result.value.timeRestriction.timeSlotEnabled).toBe(true);
+    expect(result.value.timeRestriction.timeSlotEnabled).toBe(timeSlotEnabledDefault);
     expect(result.value.timeRestriction.hourFrom).toBe(hourFromDefault);
     expect(result.value.timeRestriction.hourTo).toBe(hourToDefault);
-    expect(result.value.timeRestriction.weekdaysEnabled).toBe(false);
+    expect(result.value.timeRestriction.weekdaysEnabled).toBe(weekdaysEnabledDefault);
   });
 
   it('should get an error when requesting account settings', async () => {

--- a/src/services/doppler-contact-policy-api-client.ts
+++ b/src/services/doppler-contact-policy-api-client.ts
@@ -78,6 +78,15 @@ export class HttpDopplerContactPolicyApiClient implements DopplerContactPolicyAp
     }));
   }
 
+  private mapTimeRestriction(data: any): TimeRestriction {
+    return {
+      timeSlotEnabled: data.timeSlotEnabled,
+      hourFrom: data.hourFrom || 0,
+      hourTo: data.hourTo || 0,
+      weekdaysEnabled: data.weekdaysEnabled,
+    };
+  }
+
   async getAccountSettings(): Promise<ResultWithoutExpectedErrors<AccountSettings>> {
     try {
       const { email, jwtToken } = this.getDopplerContactPolicyApiConnectionData();
@@ -96,7 +105,9 @@ export class HttpDopplerContactPolicyApiClient implements DopplerContactPolicyAp
           excludedSubscribersLists: response.data.excludedSubscribersLists
             ? this.mapSubscriberList(response.data.excludedSubscribersLists)
             : [],
-          timeRestriction: null,
+          timeRestriction: response.data.timeRestriction
+            ? this.mapTimeRestriction(response.data.timeRestriction)
+            : null,
         };
 
         return {

--- a/src/services/doppler-contact-policy-api-client.ts
+++ b/src/services/doppler-contact-policy-api-client.ts
@@ -28,10 +28,10 @@ export interface SubscriberList {
 }
 
 export interface TimeRestriction {
-  timeSlotEnabled: boolean | null;
-  hourFrom: number | null;
-  hourTo: number | null;
-  weekdaysEnabled: boolean | null;
+  timeSlotEnabled: boolean;
+  hourFrom: number;
+  hourTo: number;
+  weekdaysEnabled: boolean;
 }
 
 export class HttpDopplerContactPolicyApiClient implements DopplerContactPolicyApiClient {
@@ -80,10 +80,10 @@ export class HttpDopplerContactPolicyApiClient implements DopplerContactPolicyAp
 
   private mapTimeRestriction(data: any): TimeRestriction {
     return {
-      timeSlotEnabled: data.timeSlotEnabled,
+      timeSlotEnabled: data.timeSlotEnabled || false,
       hourFrom: data.hourFrom || 0,
       hourTo: data.hourTo || 0,
-      weekdaysEnabled: data.weekdaysEnabled,
+      weekdaysEnabled: data.weekdaysEnabled || false,
     };
   }
 

--- a/src/services/doppler-contact-policy-api-client.ts
+++ b/src/services/doppler-contact-policy-api-client.ts
@@ -19,11 +19,19 @@ export interface AccountSettings {
   emailsAmountByInterval: number | null;
   intervalInDays: number | null;
   excludedSubscribersLists: SubscriberList[] | null;
+  timeRestriction: TimeRestriction | null;
 }
 
 export interface SubscriberList {
   id: number;
   name: string;
+}
+
+export interface TimeRestriction {
+  timeSlotEnabled: boolean | null;
+  hourFrom: number | null;
+  hourTo: number | null;
+  weekdaysEnabled: boolean | null;
 }
 
 export class HttpDopplerContactPolicyApiClient implements DopplerContactPolicyApiClient {
@@ -88,6 +96,7 @@ export class HttpDopplerContactPolicyApiClient implements DopplerContactPolicyAp
           excludedSubscribersLists: response.data.excludedSubscribersLists
             ? this.mapSubscriberList(response.data.excludedSubscribersLists)
             : [],
+          timeRestriction: null,
         };
 
         return {


### PR DESCRIPTION
Obtain values from the Doppler api to complete the restriction time section:
![image](https://github.com/FromDoppler/doppler-webapp/assets/1985175/a6e198fa-6f46-4040-8847-f686c9f68989)

@mmosquera the endpoint to be requested is: `https://apisqa.fromdoppler.net/contact-policies/accounts/{email}/settings`, 
and the new fields to be added in the response should be:
```
timeRestriction: {
	timeSlotEnabled: boolean,
        hourFrom: number,
        hourTo: number,
        weekdaysEnabled: boolean,
},
```

