### PR TITLE
Dop 1445 improve contact policy errors messages

### DIFF
--- a/src/components/ContactPolicy/ContactPolicy.js
+++ b/src/components/ContactPolicy/ContactPolicy.js
@@ -127,46 +127,70 @@ export const ContactPolicy = InjectAppServices(
       }
     };
 
-    const validate = (values) => {
+    const validateShipmentsQuantitySwitch = (values) => {
       const errors = {};
 
       const amountIsEmpty = values.emailsAmountByInterval === '';
       const intervalIsEmpty = values.intervalInDays === '';
-      const hourFromEmpty = values.timeRestriction.hourFrom === '';
-      const hourToEmpty = values.timeRestriction.hourTo === '';
 
-      if (amountIsEmpty || intervalIsEmpty || hourFromEmpty || hourToEmpty) {
+      if (amountIsEmpty || intervalIsEmpty) {
         errors.emailsAmountByInterval = amountIsEmpty;
         errors.intervalInDays = intervalIsEmpty;
-        errors.timeRestrictionHourFrom = hourFromEmpty;
-        errors.timeRestrictionHourTo = hourToEmpty;
-        errors.message = <FormattedMessageMarkdown id="validation_messages.error_required_field" />;
+        errors.messageForShipmentsQuantity = (
+          <FormattedMessageMarkdown id="validation_messages.error_required_field" />
+        );
       } else {
         const amountOutOfRange =
           values.emailsAmountByInterval < 1 || values.emailsAmountByInterval > 999;
         const intervalOutOfRange = values.intervalInDays < 1 || values.intervalInDays > 30;
 
+        if (amountOutOfRange || intervalOutOfRange) {
+          errors.emailsAmountByInterval = amountOutOfRange;
+          errors.intervalInDays = intervalOutOfRange;
+          errors.messageForShipmentsQuantity = (
+            <FormattedMessageMarkdown id="contact_policy.error_invalid_range_msg_MD" />
+          );
+        }
+      }
+
+      return errors;
+    };
+
+    const validateTimeSlotSwitch = (values) => {
+      const errors = {};
+
+      const hourFromEmpty = values.timeRestriction.hourFrom === '';
+      const hourToEmpty = values.timeRestriction.hourTo === '';
+
+      if (hourFromEmpty || hourToEmpty) {
+        errors.timeRestrictionHourFrom = hourFromEmpty;
+        errors.timeRestrictionHourTo = hourToEmpty;
+        errors.messageForTimeSlot = (
+          <FormattedMessageMarkdown id="validation_messages.error_required_field" />
+        );
+      } else {
         const hourFromOutOfRange =
           values.timeRestriction.hourFrom < 0 || values.timeRestriction.hourFrom > 23;
         const hourToOutOfRange =
           values.timeRestriction.hourTo < 0 || values.timeRestriction.hourTo > 23;
 
-        if (amountOutOfRange || intervalOutOfRange) {
-          errors.emailsAmountByInterval = amountOutOfRange;
-          errors.intervalInDays = intervalOutOfRange;
-          errors.message = (
-            <FormattedMessageMarkdown id="contact_policy.error_invalid_range_msg_MD" />
-          );
-        } else if (hourFromOutOfRange || hourToOutOfRange) {
+        if (hourFromOutOfRange || hourToOutOfRange) {
           errors.timeRestrictionHourFrom = hourFromOutOfRange;
           errors.timeRestrictionHourTo = hourToOutOfRange;
-          errors.message = (
+          errors.messageForTimeSlot = (
             <FormattedMessageMarkdown id="contact_policy.time_restriction.error_invalid_range_of_hours_msg" />
           );
         }
       }
 
       return errors;
+    };
+
+    const validate = (values) => {
+      const errorsShipmentsQuantitySwitch = validateShipmentsQuantitySwitch(values);
+      const errorsTimeSlotSwitch = validateTimeSlotSwitch(values);
+
+      return { ...errorsShipmentsQuantitySwitch, ...errorsTimeSlotSwitch };
     };
 
     const hideMessage = () => {
@@ -300,6 +324,7 @@ export const ContactPolicy = InjectAppServices(
                                   onChangeValue={() => hideMessage()}
                                 />
                                 <span>{_('contact_policy.interval_unit')}</span>
+
                                 <div
                                   className={`dp-textmessage ${
                                     errors.emailsAmountByInterval || errors.intervalInDays
@@ -307,7 +332,7 @@ export const ContactPolicy = InjectAppServices(
                                       : ''
                                   }`}
                                 >
-                                  {errors.message}
+                                  {errors.messageForShipmentsQuantity}
                                 </div>
                               </label>
                             </div>
@@ -380,16 +405,20 @@ export const ContactPolicy = InjectAppServices(
                                 />
                               </li>
                               <li className="field-item">
-                                <div className="dp-item-block">
-                                  <div>
+                                <div className="dp-item-block awa-form">
+                                  <label
+                                    className="labelcontrol"
+                                    data-required="false"
+                                    aria-disabled={!values['timeRestriction']['timeSlotEnabled']}
+                                  >
                                     <span>
                                       {_(
                                         'contact_policy.time_restriction.time_slot_hour_from_label',
                                       )}
                                     </span>
                                     <NumberField
-                                      className={
-                                        errors.timeRestrictionHourFrom ? 'dp-error-input' : ''
+                                      aria-invalid={
+                                        errors.timeRestrictionHourFrom ? 'true' : 'false'
                                       }
                                       name={fieldNames.timeRestrictionHourFrom}
                                       id="time-restriction-time-slot-from"
@@ -401,15 +430,12 @@ export const ContactPolicy = InjectAppServices(
                                       onChangeValue={() => hideMessage()}
                                     />
                                     <span className="m-r-30">{_('common.hours_abbreviation')}</span>
-                                  </div>
-                                  <div>
+
                                     <span>
                                       {_('contact_policy.time_restriction.time_slot_hour_to_label')}
                                     </span>
                                     <NumberField
-                                      className={
-                                        errors.timeRestrictionHourTo ? 'dp-error-input' : ''
-                                      }
+                                      aria-invalid={errors.timeRestrictionHourTo ? 'true' : 'false'}
                                       name={fieldNames.timeRestrictionHourTo}
                                       id="time-restriction-time-slot-to"
                                       disabled={!values['timeRestriction']['timeSlotEnabled']}
@@ -420,7 +446,18 @@ export const ContactPolicy = InjectAppServices(
                                       onChangeValue={() => hideMessage()}
                                     />
                                     <span>{_('common.hours_abbreviation')}</span>
-                                  </div>
+
+                                    <div
+                                      className={`dp-textmessage ${
+                                        errors.timeRestrictionHourFrom ||
+                                        errors.timeRestrictionHourTo
+                                          ? 'show'
+                                          : ''
+                                      }`}
+                                    >
+                                      {errors.messageForTimeSlot}
+                                    </div>
+                                  </label>
                                 </div>
                               </li>
 

--- a/src/components/ContactPolicy/ContactPolicy.js
+++ b/src/components/ContactPolicy/ContactPolicy.js
@@ -63,10 +63,7 @@ export const ContactPolicy = InjectAppServices(
 
     const FieldItemMessage = ({ errors }) => {
       let message = {};
-      if (errors.message) {
-        message.text = errors.message;
-        message.type = 'cancel';
-      } else if (errors[fieldNames.excludedSubscribersLists]) {
+      if (errors[fieldNames.excludedSubscribersLists]) {
         message.text = errors[fieldNames.excludedSubscribersLists];
         message.type = 'cancel';
       } else if (error) {
@@ -143,7 +140,7 @@ export const ContactPolicy = InjectAppServices(
         errors.intervalInDays = intervalIsEmpty;
         errors.timeRestrictionHourFrom = hourFromEmpty;
         errors.timeRestrictionHourTo = hourToEmpty;
-        errors.message = 'validation_messages.error_required_field';
+        errors.message = <FormattedMessageMarkdown id="validation_messages.error_required_field" />;
       } else {
         const amountOutOfRange =
           values.emailsAmountByInterval < 1 || values.emailsAmountByInterval > 999;
@@ -236,7 +233,7 @@ export const ContactPolicy = InjectAppServices(
         </HeaderSection>
         <section className="dp-container">
           <div className="dp-rowflex">
-            <div className="col-lg-6 col-md-12 col-sm-12 m-b-24">
+            <div className="col-lg-8 col-md-12 col-sm-12 m-b-24">
               <Formik
                 onSubmit={submitContactPolicyForm}
                 initialValues={{
@@ -274,11 +271,15 @@ export const ContactPolicy = InjectAppServices(
                             />
                           </li>
                           <li className="field-item">
-                            <div className="dp-item-block">
-                              <div>
+                            <div className="dp-item-block awa-form">
+                              <label
+                                className="labelcontrol"
+                                data-required="false"
+                                aria-disabled={!values[fieldNames.active]}
+                              >
                                 <span>{_('contact_policy.amount_description')}</span>
                                 <NumberField
-                                  className={errors.emailsAmountByInterval ? 'dp-error-input' : ''}
+                                  aria-invalid={errors.emailsAmountByInterval ? 'true' : 'false'}
                                   name={fieldNames.emailsAmountByInterval}
                                   id="contact-policy-input-amount"
                                   disabled={!values[fieldNames.active]}
@@ -287,11 +288,10 @@ export const ContactPolicy = InjectAppServices(
                                   onChangeValue={() => hideMessage()}
                                 />
                                 <span className="m-r-6">{_('common.emails')}</span>
-                              </div>
-                              <div>
+
                                 <span>{_('contact_policy.interval_description')}</span>
                                 <NumberField
-                                  className={errors.intervalInDays ? 'dp-error-input' : ''}
+                                  aria-invalid={errors.intervalInDays ? 'true' : 'false'}
                                   name={fieldNames.intervalInDays}
                                   id="contact-policy-input-interval"
                                   disabled={!values[fieldNames.active]}
@@ -300,7 +300,16 @@ export const ContactPolicy = InjectAppServices(
                                   onChangeValue={() => hideMessage()}
                                 />
                                 <span>{_('contact_policy.interval_unit')}</span>
-                              </div>
+                                <div
+                                  className={`dp-textmessage ${
+                                    errors.emailsAmountByInterval || errors.intervalInDays
+                                      ? 'show'
+                                      : ''
+                                  }`}
+                                >
+                                  {errors.message}
+                                </div>
+                              </label>
                             </div>
                           </li>
 

--- a/src/components/ContactPolicy/ContactPolicy.test.js
+++ b/src/components/ContactPolicy/ContactPolicy.test.js
@@ -1224,7 +1224,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Interval field should be highlighted and error message should be displayed
-    expect(inputHourFrom).toHaveClass('dp-error-input');
+    expect(inputHourFrom).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('validation_messages.error_required_field')).toBeInTheDocument();
   });
 
@@ -1268,7 +1268,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Interval field should be highlighted and error message should be displayed
-    expect(inputHourTo).toHaveClass('dp-error-input');
+    expect(inputHourTo).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('validation_messages.error_required_field')).toBeInTheDocument();
   });
 
@@ -1387,7 +1387,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Interval field should be highlighted and error message should be displayed
-    expect(inputHourFrom).toHaveClass('dp-error-input');
+    expect(inputHourFrom).toHaveAttribute('aria-invalid', 'true');
     expect(
       screen.getByText('contact_policy.time_restriction.error_invalid_range_of_hours_msg'),
     ).toBeInTheDocument();
@@ -1434,7 +1434,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Interval field should be highlighted and error message should be displayed
-    expect(inputHourTo).toHaveClass('dp-error-input');
+    expect(inputHourTo).toHaveAttribute('aria-invalid', 'true');
     expect(
       screen.getByText('contact_policy.time_restriction.error_invalid_range_of_hours_msg'),
     ).toBeInTheDocument();

--- a/src/components/ContactPolicy/ContactPolicy.test.js
+++ b/src/components/ContactPolicy/ContactPolicy.test.js
@@ -1144,7 +1144,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Emails amount field should be highlighted and error message should be displayed
-    expect(inputAmount).toHaveClass('dp-error-input');
+    expect(inputAmount).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('validation_messages.error_required_field')).toBeInTheDocument();
   });
 
@@ -1180,7 +1180,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Interval field should be highlighted and error message should be displayed
-    expect(inputInterval).toHaveClass('dp-error-input');
+    expect(inputInterval).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('validation_messages.error_required_field')).toBeInTheDocument();
   });
 
@@ -1305,7 +1305,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Emails amount field should be highlighted and error message should be displayed
-    expect(inputAmount).toHaveClass('dp-error-input');
+    expect(inputAmount).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('contact_policy.error_invalid_range_msg_MD')).toBeInTheDocument();
   });
 
@@ -1342,7 +1342,7 @@ describe('ContactPolicy component', () => {
     expect(submitButton).toBeDisabled();
 
     // Interval field should be highlighted and error message should be displayed
-    expect(inputInterval).toHaveClass('dp-error-input');
+    expect(inputInterval).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('contact_policy.error_invalid_range_msg_MD')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
**Before**, the error messages related to the input changes was displayed on the bottom, and one message for time to each section:
![chrome_yd93OaiTT8](https://github.com/FromDoppler/doppler-webapp/assets/1985175/01bfbad6-88c6-42ad-a190-7268c8968224)

**Now**, the error messages are displayed near the related inputs, and the messages for each section are displayed simultaneously:
![chrome_W45g7u7HKt](https://github.com/FromDoppler/doppler-webapp/assets/1985175/42d82463-0cce-4370-b887-5efd09dbcd59)
