### PR TITLE
[DAT-1684] - Integrate canceled account with mercado pago

### DIFF
--- a/src/components/Plans/UpdatePaymentInformation/Reducers/updatePaymentInformationReducer.js
+++ b/src/components/Plans/UpdatePaymentInformation/Reducers/updatePaymentInformationReducer.js
@@ -20,13 +20,14 @@ export const updatePaymentInformationReducer = (state, action) => {
       };
     case UPDATE_PAYMENT_INFORMATION_ACTIONS.FINISH_FETCH:
       const {
-        payload: { paymentMethod },
+        payload: { paymentMethod, billingCountry },
       } = action;
 
       return {
         loading: false,
         hasError: false,
         paymentMethod,
+        billingCountry,
       };
 
     case UPDATE_PAYMENT_INFORMATION_ACTIONS.FAIL_FETCH:

--- a/src/components/Plans/UpdatePaymentInformation/Reprocess/index.js
+++ b/src/components/Plans/UpdatePaymentInformation/Reprocess/index.js
@@ -68,6 +68,7 @@ export const Reprocess = InjectAppServices(
             'failed',
             'clientFailed',
             'doNotHonor',
+            'mercadopagoException',
           ]);
 
           dispatch({

--- a/src/components/Plans/UpdatePaymentInformation/UpdatePaymentInformationSummary/index.js
+++ b/src/components/Plans/UpdatePaymentInformation/UpdatePaymentInformationSummary/index.js
@@ -132,6 +132,7 @@ export const PaymentInformationSummary = InjectAppServices(
             'failed',
             'clientFailed',
             'doNotHonor',
+            'mercadopagoException',
           ]);
 
           dispatch({

--- a/src/components/Plans/UpdatePaymentInformation/UpdatePaymentMethod/index.js
+++ b/src/components/Plans/UpdatePaymentInformation/UpdatePaymentMethod/index.js
@@ -1,13 +1,13 @@
 import React, { useEffect, useState, useReducer } from 'react';
 import { InjectAppServices } from '../../../../services/pure-di';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { CreditCard, getCreditCardBrand } from '../../Checkout/PaymentMethod/CreditCard';
 import { StatusMessage } from '../../Checkout/PurchaseSummary/PlanPurchase/index';
 import { MercadoPagoArgentina } from '../../Checkout/PaymentMethod/MercadoPagoArgentina';
 import { actionPage } from '../../Checkout/Checkout';
 import { getFormInitialValues } from '../../../../utils';
 import { Loading } from '../../../Loading/Loading';
-import { Form, Formik } from 'formik';
+import { Form, Formik, Field } from 'formik';
 import { FieldGroup, FieldItem, SubmitButton } from '../../../form-helpers/form-helpers';
 import { PaymentMethodType } from '../.././../../doppler-types';
 import { handleMessage } from '../index';
@@ -19,6 +19,22 @@ import {
 import { UnexpectedError } from '../../../shared/UnexpectedError/index';
 import { useNavigate } from 'react-router-dom';
 import useTimeout from '../../../../hooks/useTimeout';
+
+const considerationNoteStyle = {
+  fontSize: '13px',
+  lineHeight: '18px',
+};
+
+const FormatMessageWithBoldWords = ({ id }) => {
+  return (
+    <FormattedMessage
+      id={id}
+      values={{
+        bold: (chunks) => <b>{chunks}</b>,
+      }}
+    />
+  );
+};
 
 const fieldNames = {
   paymentMethodName: 'paymentMethodName',
@@ -37,9 +53,24 @@ const fieldNames = {
   cfdi: 'cfdi',
 };
 
+const none = 'NONE';
 const HAS_ERROR = 'HAS_ERROR';
 const SAVED = 'SAVED';
 export const DELAY_BEFORE_REDIRECT_TO_SUMMARY = 3000;
+
+const paymentMethods = [
+  {
+    value: PaymentMethodType.creditCard,
+    description: 'checkoutProcessForm.payment_method.credit_card_option',
+  },
+  {
+    value: PaymentMethodType.mercadoPago,
+    description: 'checkoutProcessForm.payment_method.mercado_pago',
+  },
+];
+
+const countriesAvailableTransfer = ['ar', 'co', 'mx'];
+const countriesAvailableMercadoPago = ['ar'];
 
 const PaymentType = ({ paymentMethodType, optionView, paymentMethod }) => {
   return (
@@ -58,9 +89,117 @@ const PaymentType = ({ paymentMethodType, optionView, paymentMethod }) => {
   );
 };
 
+const PaymentMethodField = ({ billingCountry, currentPaymentMethod, optionView, handleChange }) => {
+  const intl = useIntl();
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  const allowTransfer = countriesAvailableTransfer.find((c) => c === billingCountry);
+  const allowMercadoPago = countriesAvailableMercadoPago.find((c) => c === billingCountry);
+
+  return (
+    <Field name="paymentMethodName">
+      {({ field }) => (
+        <ul role="group" aria-labelledby="checkbox-group" className="dp-radio-input">
+          {paymentMethods.map((paymentMethod) =>
+            (paymentMethod.value === PaymentMethodType.transfer && allowTransfer) ||
+            (paymentMethod.value === PaymentMethodType.mercadoPago && allowMercadoPago) ||
+            paymentMethod.value === PaymentMethodType.creditCard ? (
+              <li key={paymentMethod.value}>
+                <div className="dp-volume-option">
+                  <label>
+                    <input
+                      aria-label={paymentMethod.description}
+                      id={paymentMethod.value}
+                      type="radio"
+                      name={fieldNames.paymentMethodName}
+                      {...field}
+                      value={paymentMethod.value}
+                      checked={field.value === paymentMethod.value}
+                      disabled={
+                        (optionView === actionPage.READONLY &&
+                          field.value !== paymentMethod.value) ||
+                        (optionView === actionPage.UPDATE &&
+                          paymentMethod.value === PaymentMethodType.transfer &&
+                          currentPaymentMethod !== PaymentMethodType.transfer &&
+                          currentPaymentMethod !== none)
+                      }
+                      onChange={handleChange}
+                    />
+                    {paymentMethod.value !== PaymentMethodType.mercadoPago ? (
+                      <span>{_(paymentMethod.description)}</span>
+                    ) : (
+                      <span>
+                        <img
+                          src={_('common.ui_library_image', {
+                            imageUrl: 'mercado-pago.svg',
+                          })}
+                          alt="Mercado pago"
+                        ></img>
+                      </span>
+                    )}
+                  </label>
+                </div>
+              </li>
+            ) : null,
+          )}
+        </ul>
+      )}
+    </Field>
+  );
+};
+
+const PaymentNotes = ({ paymentMethodType }) => {
+  const intl = useIntl();
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  switch (paymentMethodType) {
+    case PaymentMethodType.creditCard:
+      return (
+        <FieldGroup>
+          <li className="field-item">
+            <div className="dp-considerations">
+              <label>{_('checkoutProcessForm.payment_method.considerations')}</label>
+              <p style={considerationNoteStyle}>
+                <FormatMessageWithBoldWords id="checkoutProcessForm.payment_method.considerations_credit_card_note_1" />
+              </p>
+              <br />
+              <p style={considerationNoteStyle}>
+                <FormatMessageWithBoldWords id="checkoutProcessForm.payment_method.considerations_credit_card_note_2" />
+              </p>
+            </div>
+          </li>
+        </FieldGroup>
+      );
+
+    case PaymentMethodType.mercadoPago:
+      return (
+        <FieldGroup>
+          <li className="field-item">
+            <div className="dp-considerations">
+              <label>{_('checkoutProcessForm.payment_method.considerations')}</label>
+              <p className="m-t-12" style={considerationNoteStyle}>
+                <FormatMessageWithBoldWords id="checkoutProcessForm.payment_method.considerations_mercado_pago_note_1" />
+              </p>
+              <br />
+              <p style={considerationNoteStyle}>
+                <FormatMessageWithBoldWords id="checkoutProcessForm.payment_method.considerations_mercado_pago_note_2" />
+              </p>
+              <br />
+              <p style={considerationNoteStyle}>
+                <FormatMessageWithBoldWords id="checkoutProcessForm.payment_method.considerations_mercado_pago_note_3" />
+              </p>
+            </div>
+          </li>
+        </FieldGroup>
+      );
+    default:
+      return null;
+  }
+};
+
 export const UpdatePaymentMethod = InjectAppServices(
   ({ dependencies: { dopplerBillingUserApiClient }, optionView, handleSaveAndContinue }) => {
-    const [{ loading, paymentMethod, hasError }, dispatch] = useReducer(
+    const [{ loading, paymentMethod, billingCountry, hasError }, dispatch] = useReducer(
       updatePaymentInformationReducer,
       INITIAL_STATE_UPDATE_PAYMENT_INFORMATION,
     );
@@ -68,6 +207,7 @@ export const UpdatePaymentMethod = InjectAppServices(
     const intl = useIntl();
     const createTimeout = useTimeout();
     const navigate = useNavigate();
+    const [paymentMethodType, setPaymentMethodType] = useState('');
     const [status, setStatus] = useState('');
     const [errorMessageId, setErrorMessageId] = useState('');
     const _ = (id, values) => intl.formatMessage({ id: id }, values);
@@ -77,13 +217,18 @@ export const UpdatePaymentMethod = InjectAppServices(
         try {
           dispatch({ type: UPDATE_PAYMENT_INFORMATION_ACTIONS.START_FETCH });
           const paymentMethodData = await dopplerBillingUserApiClient.getPaymentMethodData();
+          const billingInformationResult =
+            await dopplerBillingUserApiClient.getBillingInformationData();
 
           dispatch({
             type: UPDATE_PAYMENT_INFORMATION_ACTIONS.FINISH_FETCH,
             payload: {
               paymentMethod: paymentMethodData.value,
+              billingCountry: billingInformationResult.value.country,
             },
           });
+
+          setPaymentMethodType(paymentMethodData.value.paymentMethodName);
         } catch (error) {
           dispatch({ type: UPDATE_PAYMENT_INFORMATION_ACTIONS.FAIL_FETCH });
         }
@@ -91,7 +236,15 @@ export const UpdatePaymentMethod = InjectAppServices(
       fetchData();
     }, [dopplerBillingUserApiClient]);
 
+    const handleChange = (e, setFieldValue) => {
+      const { value } = e.target;
+      setFieldValue(fieldNames.paymentMethodName, value);
+      setPaymentMethodType(value);
+    };
+
     const submitPaymentMethodForm = async (values) => {
+      setStatus('');
+
       const result = await dopplerBillingUserApiClient.updatePaymentMethod({
         ...values,
         idSelectedPlan: 0,
@@ -140,16 +293,25 @@ export const UpdatePaymentMethod = InjectAppServices(
     return (
       <>
         <Formik initialValues={_getFormInitialValues()} onSubmit={submitPaymentMethodForm}>
-          {() => (
+          {({ setFieldValue }) => (
             <Form className="dp-form-payment-method m-l-24 m-b-12 m-r-24">
               <legend>{_('updatePaymentMethod.payment_method.title')}</legend>
               <fieldset>
                 <FieldGroup>
+                  <FieldItem className="field-item m-b-24">
+                    <PaymentMethodField
+                      billingCountry={billingCountry}
+                      currentPaymentMethod={paymentMethodType}
+                      optionView={optionView}
+                      handleChange={(e) => handleChange(e, setFieldValue)}
+                    />
+                  </FieldItem>
                   <PaymentType
-                    paymentMethodType={paymentMethod.paymentMethodName}
+                    paymentMethodType={paymentMethodType}
                     optionView={optionView}
                     paymentMethod={paymentMethod}
                   />
+                  <PaymentNotes paymentMethodType={paymentMethodType} />
                   {showMessage && (
                     <StatusMessage
                       type={status === SAVED ? 'success' : 'cancel'}

--- a/src/components/Plans/UpdatePaymentInformation/UpdatePaymentMethod/index.test.js
+++ b/src/components/Plans/UpdatePaymentInformation/UpdatePaymentMethod/index.test.js
@@ -11,7 +11,10 @@ import user from '@testing-library/user-event';
 import IntlProvider from '../../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
 import { AppServicesProvider } from '../../../../services/pure-di';
 import { BrowserRouter } from 'react-router-dom';
-import { fakePaymentMethodInformation } from '../../../../services/doppler-billing-user-api-client.double';
+import {
+  fakeBillingInformation,
+  fakePaymentMethodInformation,
+} from '../../../../services/doppler-billing-user-api-client.double';
 import { actionPage } from '../../Checkout/Checkout';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -22,6 +25,14 @@ const dependencies = (withError, paymentMethodData, withFirstDataError, firstDat
         ? {
             success: true,
             value: paymentMethodData,
+          }
+        : { success: false };
+    },
+    getBillingInformationData: async () => {
+      return !withError
+        ? {
+            success: true,
+            value: fakeBillingInformation,
           }
         : { success: false };
     },


### PR DESCRIPTION
Allow to user change the payment method to MercadoPago when the user is canceled and the current payment method is Credit Card

**Task:** [DAT-1684](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-1684)

[DAT-1684]: https://makingsense.atlassian.net/browse/DAT-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ