### PR TITLE
[No ticket] Withelist conversations url for qa

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,6 +175,7 @@ export function isWhitelisted(url: string) {
     'https://reports2.fromdoppler.com/',
     'https://reportsqa.fromdoppler.net:400/',
     'https://reportsint.fromdoppler.net:400/',
+    'https://conversationsqa.fromdoppler.net/',
   ];
   return !!url && loginWhitelist.some((element) => url.startsWith(element));
 }


### PR DESCRIPTION
We are getting a CORS error when redirecting to the login from conversations.fromdoppler.

If this works I will add the urls for every environment.