### PR TITLE
[DOI-1511] Get user invitations through doppler-users API

### DIFF
--- a/src/components/ControlPanel/CollaboratorsSections/index.js
+++ b/src/components/ControlPanel/CollaboratorsSections/index.js
@@ -18,6 +18,7 @@ export const CollaboratorsSections = InjectAppServices(
     const [activeMenu, setActiveMenus] = useState(false);
     const [modalOpen, setModalOpen] = useState(false);
     const [modalError, setmodalError] = useState(null);
+    const [refreshTable, setRefreshTable] = useState(false);
 
     const modalFirstStep = {
       step: 'INITIAL_STEP',
@@ -44,27 +45,16 @@ export const CollaboratorsSections = InjectAppServices(
 
     useEffect(() => {
       const fetchData = async () => {
-        setData([
-          {
-            email: 'fgonzalez@makingsense.com',
-            firstname: 'Fernando',
-            lastname: 'Gonzalez',
-            invitationDate: '9/9/2019 5:00:24 PM',
-            status: 'Pendiente',
-          },
-          {
-            email: 'fgonzalez2@makingsense.com',
-            firstname: 'Fernando',
-            lastname: 'Gonzalez',
-            invitationDate: '9/9/2019 5:00:24 PM',
-            status: 'Activa',
-          },
-        ]);
+        const invitations = await dopplerUserApiClient.getCollaborationInvites();
+        if (invitations.success) {
+          setData(invitations.value);
+        }
+
         setLoading(false);
       };
 
       fetchData();
-    }, []);
+    }, [dopplerUserApiClient, refreshTable]);
 
     const toggleMenu = (index) => {
       if (activeMenu === index) {
@@ -78,6 +68,7 @@ export const CollaboratorsSections = InjectAppServices(
       const result = await dopplerUserApiClient.sendCollaboratorInvite(email);
       if (result.success) {
         setModalStep(modalFinalStep);
+        setRefreshTable(!refreshTable);
       } else {
         setmodalError(_('common.unexpected_error'));
       }
@@ -164,7 +155,9 @@ export const CollaboratorsSections = InjectAppServices(
                         </td>
                         <td aria-label="estado">
                           <div className="dp-flex-wrap">
-                            <span>{item.status}</span>
+                            <span>
+                              {_(`collaborators.table.statusType.${item.invitationStatus}`)}
+                            </span>
                             <div className="dp-button-dropdown-wrap dp-wrap-medium">
                               <div className="dp-button-box">
                                 <button

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -450,6 +450,12 @@ Payment details will be included in the invoice sent to the recipient you have i
       invitation_date: 'Invitation date',
       lastname: 'Lastname',
       status: 'Status',
+      statusType: {
+        APPROVED: 'Aprobado',
+        CANCELED: 'Cancelado',
+        PENDING: 'Pendiente',
+        REJECTED: 'Rechazado',
+      },
     },
     title: 'Profile Configuration',
     title_second: 'Your account collaborators',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -450,6 +450,12 @@ const messages_es = {
       invitation_date: 'Fecha de invitación',
       lastname: 'Apellido',
       status: 'Estado',
+      statusType: {
+        APPROVED: 'Approved',
+        CANCELED: 'Cancelled',
+        PENDING: 'Pending',
+        REJECTED: 'Rejected',
+      },
     },
     title: 'Configuración de perfiles',
     title_second: 'Colaboradores de tu cuenta',

--- a/src/services/doppler-user-api-client.double.ts
+++ b/src/services/doppler-user-api-client.double.ts
@@ -3,6 +3,7 @@ import {
   ContactInformation,
   Features,
   IntegrationsStatus,
+  CollaboratorInvite,
 } from './doppler-user-api-client';
 import { EmptyResultWithoutExpectedErrors, ResultWithoutExpectedErrors } from '../doppler-types';
 import { timeout } from '../utils';
@@ -51,6 +52,27 @@ const integrationsStatusResult: IntegrationsStatus = {
   JumpsellerStatus: 'disconnected',
 };
 
+const collaborationInvitesResult: Array<CollaboratorInvite> = [
+  {
+    idUser: 1,
+    email: 'test@fromdoppler.com',
+    firstname: 'Test',
+    lastname: 'Test',
+    invitationDate: '03-07-2024',
+    expirationDate: '03-07-2024',
+    invitationStatus: 'PENDING',
+  },
+  {
+    idUser: 1,
+    email: 'test2@fromdoppler.com',
+    firstname: 'Test 2',
+    lastname: 'Test 2',
+    invitationDate: '03-07-2024',
+    expirationDate: '03-07-2024',
+    invitationStatus: 'APPROVED',
+  },
+];
+
 export class HardcodedDopplerUserApiClient implements DopplerUserApiClient {
   public async getContactInformationData(): Promise<
     ResultWithoutExpectedErrors<ContactInformation>
@@ -97,6 +119,18 @@ export class HardcodedDopplerUserApiClient implements DopplerUserApiClient {
     console.log(value);
     return {
       success: true,
+    };
+  }
+
+  public async getCollaborationInvites(): Promise<
+    ResultWithoutExpectedErrors<Array<CollaboratorInvite>>
+  > {
+    console.log('getCollaborationInvites');
+    await timeout(1500);
+
+    return {
+      success: true,
+      value: collaborationInvitesResult,
     };
   }
 }

--- a/src/services/doppler-user-api-client.test.ts
+++ b/src/services/doppler-user-api-client.test.ts
@@ -178,4 +178,73 @@ describe('HttpDopplerUserApiClient', () => {
     expect(result).not.toBe(undefined);
     expect(result.success).toBe(true);
   });
+
+  it('should send collaboration invite', async () => {
+    // Arrange
+    const value = 'test@makingsense.com';
+
+    const response = {
+      status: 200,
+    };
+
+    const request = jest.fn(async () => response);
+    const dopplerUserApiClient = createHttpDopplerUserApiClient({ request });
+
+    // Act
+    const result = await dopplerUserApiClient.sendCollaboratorInvite(value);
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
+  });
+
+  it('send collaboration endpoint should set error when failed request', async () => {
+    // Arrange
+    const value = 'test@makingsense.com';
+
+    const response = {
+      status: 400,
+    };
+
+    const request = jest.fn(async () => response);
+    const dopplerUserApiClient = createHttpDopplerUserApiClient({ request });
+
+    // Act
+    const result = await dopplerUserApiClient.sendCollaboratorInvite(value);
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(false);
+  });
+
+  it('should get user collaboration invites', async () => {
+    // Arrange
+    const response = {
+      data: [
+        {
+          idUser: 1,
+          email: 'test1@fromdoppler.com',
+          firstname: 'name',
+          lastname: 'lastname',
+          invitationDate: '03-07-2024',
+          expirationDate: '03-07-2024',
+          invitationStatus: 'APPROVED',
+        },
+      ],
+      status: 200,
+    };
+
+    const request = jest.fn(async () => response);
+    const dopplerUserApiClient = createHttpDopplerUserApiClient({ request });
+
+    // Act
+    const result = await dopplerUserApiClient.getCollaborationInvites();
+
+    // Assert
+    expect(request).toBeCalledTimes(1);
+    expect(result).not.toBe(undefined);
+    expect(result.success).toBe(true);
+  });
 });

--- a/src/services/doppler-user-api-client.ts
+++ b/src/services/doppler-user-api-client.ts
@@ -46,6 +46,16 @@ export interface IntegrationsStatus {
   [key: string]: IntegrationStatus;
 }
 
+export interface CollaboratorInvite {
+  idUser: number;
+  email: string;
+  firstname: string;
+  lastname: string;
+  invitationDate: string;
+  expirationDate: string;
+  invitationStatus: string;
+}
+
 export class HttpDopplerUserApiClient implements DopplerUserApiClient {
   private readonly axios: AxiosInstance;
   private readonly baseUrl: string;
@@ -203,6 +213,28 @@ export class HttpDopplerUserApiClient implements DopplerUserApiClient {
         return { success: true };
       } else {
         return { success: false, error: response.data.message };
+      }
+    } catch (error) {
+      return { success: false, error: error };
+    }
+  }
+
+  public async getCollaborationInvites(): Promise<
+    ResultWithoutExpectedErrors<Array<CollaboratorInvite>>
+  > {
+    try {
+      const { email, jwtToken } = this.getDopplerUserApiConnectionData();
+
+      const response = await this.axios.request({
+        method: 'GET',
+        url: `/accounts/${email}/user-invitations`,
+        headers: { Authorization: `bearer ${jwtToken}` },
+      });
+
+      if (response.status === 200 && response.data) {
+        return { success: true, value: response.data };
+      } else {
+        return { success: false, error: response.data.title };
       }
     } catch (error) {
       return { success: false, error: error };


### PR DESCRIPTION
Display returned invitations from the doppler users API endpoint.
Also refresh on any new sent invitation.