### PR TITLE
[DOI-1670] Add collaborators permission configuration step

### DIFF
--- a/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorInviteForm.js
+++ b/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorInviteForm.js
@@ -9,7 +9,7 @@ import {
 import { InjectAppServices } from '../../../../services/pure-di';
 
 export const CollaboratorInviteForm = InjectAppServices(
-  ({ title, onSubmit, dependencies: { appSessionRef } }) => {
+  ({ title, onSubmit, currentEmail, dependencies: { appSessionRef } }) => {
     const intl = useIntl();
     const _ = (id, values) => intl.formatMessage({ id: id }, values);
     const userEmail = appSessionRef.current.userData.user.email;
@@ -28,7 +28,7 @@ export const CollaboratorInviteForm = InjectAppServices(
 
     const formikConfig = {
       enableReinitialize: true,
-      initialValues: {},
+      initialValues: currentEmail ? { Email: currentEmail } : { Email: '' },
       validateOnChange: false,
       validateOnBlur: false,
       validate: validate,

--- a/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.js
+++ b/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.js
@@ -1,0 +1,79 @@
+import { Formik, Form } from 'formik';
+import { useIntl } from 'react-intl';
+import {
+  CheckboxFieldItemAccessible,
+  FieldGroup,
+  FormMessages,
+  SubmitButton,
+} from '../../../form-helpers/form-helpers';
+import { InjectAppServices } from '../../../../services/pure-di';
+import { getFormInitialValues } from '../../../../utils';
+
+const fieldNames = {
+  campaigns: 'campaigns',
+  lists: 'lists',
+  reports: 'reports',
+  automation: 'automation',
+  templates: 'templates',
+  integrations: 'integrations',
+  control_panel: 'control_panel',
+  dashboard: 'dashboard',
+  download_center: 'download_center',
+};
+
+export const CollaboratorPermissionsForm = InjectAppServices(({ title, onSubmit, onBack }) => {
+  const intl = useIntl();
+  const _ = (id, values) => intl.formatMessage({ id: id }, values);
+
+  const handleSubmit = (values) => {
+    for (let key in values) {
+      if (values[key] === '') {
+        values[key] = false;
+      }
+    }
+    onSubmit(values);
+  };
+
+  const formikConfig = {
+    enableReinitialize: true,
+    initialValues: getFormInitialValues(fieldNames),
+    onSubmit: handleSubmit,
+  };
+
+  return (
+    <>
+      <Formik {...formikConfig}>
+        <Form className="awa-form" data-testid="collaboration-permissions-form">
+          <legend>{title}</legend>
+          <fieldset>
+            <FieldGroup>
+              {Object.keys(fieldNames).map((field, index) => (
+                <CheckboxFieldItemAccessible
+                  fieldName={field}
+                  label={_(`collaborators.form_modal.permissions.${field}`)}
+                  className="field-item--50"
+                  key={index}
+                />
+              ))}
+            </FieldGroup>
+            <FormMessages />
+            <FieldGroup className="dp-group-buttons">
+              <li data-testid="success-form">
+                <button
+                  type="button"
+                  className="dp-button button-medium ctaTertiary"
+                  onClick={() => onBack()}
+                >
+                  {_('common.back')}
+                </button>
+              </li>
+              <SubmitButton className="dp-button button-medium primary-green">
+                {_('common.next')}
+              </SubmitButton>
+            </FieldGroup>
+          </fieldset>
+        </Form>
+      </Formik>
+    </>
+  );
+});

--- a/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.test.js
+++ b/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, cleanup, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { BrowserRouter } from 'react-router-dom';
+import DopplerIntlProvider from '../../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
+import { AppServicesProvider } from '../../../../services/pure-di';
+import { CollaboratorPermissionsForm } from './CollaboratorPermissionsForm';
+
+describe('CollaboratorInviteForm Component', () => {
+  afterEach(cleanup);
+
+  it('should render success form', () => {
+    //Act
+    render(
+      <BrowserRouter>
+        <AppServicesProvider>
+          <DopplerIntlProvider>
+            <CollaboratorPermissionsForm />
+          </DopplerIntlProvider>
+        </AppServicesProvider>
+      </BrowserRouter>,
+    );
+
+    // Asserts
+    expect(screen.getByTestId('collaboration-permissions-form')).toBeInTheDocument();
+  });
+});

--- a/src/components/ControlPanel/CollaboratorsSections/index.js
+++ b/src/components/ControlPanel/CollaboratorsSections/index.js
@@ -26,24 +26,30 @@ export const CollaboratorsSections = InjectAppServices(
       appSessionRef.current.userData.userAccount.userProfileType !== 'USER';
 
     const modalFirstStep = {
-      step: 'INITIAL_STEP',
+      name: 'INITIAL_STEP',
       title: _('collaborators.add_collaborator'),
       description: _('collaborators.form_modal.description'),
     };
 
+    const modalSecondStep = {
+      name: 'PERMISSIONS_STEP',
+      title: _('collaborators.add_collaborator_permissions'),
+      description: _('collaborators.form_modal.permission_description'),
+    };
+
     const modalFinalStep = {
-      step: 'FINAL_STEP',
+      name: 'FINAL_STEP',
       title: _('collaborators.form_modal.success_title'),
       description: _('collaborators.form_modal.success_subtitle'),
     };
 
-    const [modalStep, setModalStep] = useState(modalFirstStep);
+    const [modalStep, setModalStep] = useState({ step: modalFirstStep, email: '' });
 
     const handleModalOpen = (open) => {
       if (open) {
         setModalOpen(open);
       } else {
-        setModalStep(modalFirstStep);
+        setModalStep({ step: modalFirstStep, email: '' });
         setModalOpen(open);
       }
     };
@@ -243,12 +249,12 @@ export const CollaboratorsSections = InjectAppServices(
               </div>
               <Modal
                 isOpen={modalOpen}
-                type="medium"
-                handleClose={() => handleModalOpen()}
+                type="large"
+                handleClose={() => handleModalOpen(false)}
                 modalId="modal-new-collaborator"
               >
-                <h2 className="modal-title">{modalStep.title}</h2>
-                <p>{modalStep.description}</p>
+                <h2 className="modal-title">{modalStep.step.title}</h2>
+                <p>{modalStep.step.description}</p>
                 {modalError ? (
                   <div className="dp-msj-error dpsg-slow-animation bounceIn">
                     <p>{modalError}</p>
@@ -256,11 +262,21 @@ export const CollaboratorsSections = InjectAppServices(
                 ) : (
                   <></>
                 )}
-                {modalStep.step === 'INITIAL_STEP' ? (
-                  <CollaboratorInviteForm title={modalStep.title} onSubmit={formSendInvitation} />
-                ) : modalStep.step === 'FINAL_STEP' ? (
+                {modalStep.step.name === 'INITIAL_STEP' ? (
+                  <CollaboratorInviteForm
+                    title={modalStep.step.title}
+                    currentEmail={modalStep.email}
+                    onSubmit={(value) => setModalStep({ step: modalSecondStep, email: value })}
+                  />
+                ) : modalStep.step.name === 'PERMISSIONS_STEP' ? (
+                  <CollaboratorPermissionsForm
+                    title={modalStep.title}
+                    onBack={() => setModalStep({ step: modalFirstStep, email: modalStep.email })}
+                    onSubmit={formSendInvitation}
+                  />
+                ) : modalStep.step.name === 'FINAL_STEP' ? (
                   <SuccessStepForm
-                    onBack={() => setModalStep(modalFirstStep)}
+                    onBack={() => setModalStep({ step: modalFirstStep, email: '' })}
                     onFinish={handleModalOpen}
                   />
                 ) : (

--- a/src/components/ControlPanel/CollaboratorsSections/index.js
+++ b/src/components/ControlPanel/CollaboratorsSections/index.js
@@ -9,6 +9,7 @@ import { CollaboratorInviteForm } from './Forms/CollaboratorInviteForm';
 import { SuccessStepForm } from './Forms/SuccessStepForm';
 import Modal from '../../Modal/Modal';
 import { Navigate } from 'react-router-dom';
+import { CollaboratorPermissionsForm } from './Forms/CollaboratorPermissionsForm';
 
 export const CollaboratorsSections = InjectAppServices(
   ({ dependencies: { dopplerUserApiClient, appSessionRef } }) => {

--- a/src/components/ControlPanel/CollaboratorsSections/index.js
+++ b/src/components/ControlPanel/CollaboratorsSections/index.js
@@ -75,21 +75,29 @@ export const CollaboratorsSections = InjectAppServices(
       }
     };
 
-    const sendInvitation = async (email) => {
+    const sendInvitation = async (body) => {
       setActiveMenus(false);
-      const result = await dopplerUserApiClient.sendCollaboratorInvite(email);
+      const result = await dopplerUserApiClient.sendCollaboratorInvite(body);
       setRefreshTable(!refreshTable);
 
       return result.success;
     };
 
-    const formSendInvitation = async (email) => {
-      const success = sendInvitation(email);
-      if (success) {
-        setModalStep(modalFinalStep);
-      } else {
+    const formSendInvitation = async (values) => {
+      if (!modalStep.email) {
         setmodalError(_('common.unexpected_error'));
       }
+
+      const body = {
+        email: modalStep.email,
+        permissions: { ...values },
+      };
+      const success = sendInvitation(body);
+      if (!success) {
+        setmodalError(_('common.unexpected_error'));
+      }
+
+      setModalStep({ step: modalFinalStep, email: modalStep.email });
     };
 
     const sendInvitationCancelation = async (email) => {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -505,12 +505,25 @@ Payment details will be included in the invoice sent to the recipient you have i
   },
   collaborators: {
     add_collaborator: 'New Collaborator',
+    add_collaborator_permissions: 'Configure collaborator permissions',
     edition_subtitle: 'Edit your data to keep using your account. Do not forget to save before leaving!',
     form_modal: {
       description: `The collaborator will have access to manage your Doppler account. It will be able to send campaigns,
       manage lists, edit automations and any other feature.`,
       email: 'Email',
       email_placeholder: 'owner_user@example.com',
+      permission_description: 'Choose the accesses to your account that you will grant.',
+      permissions: {
+        automation: 'Automation',
+        campaigns: 'Campaigns',
+        control_panel: 'Control Panel',
+        dashboard: 'Dashboard',
+        download_center: 'Download Center',
+        integrations: 'Integrations',
+        lists: 'Lists',
+        reports: 'Reports',
+        templates: 'Templates',
+      },
       success_subtitle: `Your Collaborator will receive the invitation in their email box.
     Once accepted the invitation, it will be able to manage your account.`,
       success_title: 'Collaborator successfully added',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -505,6 +505,7 @@ const messages_es = {
   },
   collaborators: {
     add_collaborator: 'Nuevo Colaborador',
+    add_collaborator_permissions: 'Configurar permisos del colaborador',
     edition_subtitle: `Edita los datos que necesitas para poder continuar utilizando tu cuenta.
     ¡No olvides guardar tu información!`,
     form_modal: {
@@ -512,6 +513,18 @@ const messages_es = {
       gestión de listas, edición de automations y demás funcionalidades`,
       email: 'Email',
       email_placeholder: 'usuario_owner@ejemplo.com',
+      permission_description: 'Elige los accesos de tu cuenta que le otorgarás.',
+      permissions: {
+        automation: 'Automation',
+        campaigns: 'Campañas',
+        control_panel: 'Panel de Control',
+        dashboard: 'Tablero de Inicio',
+        download_center: 'Centro de Descargas',
+        integrations: 'Integraciones',
+        lists: 'Listas',
+        reports: 'Reportes',
+        templates: 'Plantillas',
+      },
       success_subtitle: `Tu Colaborador recibirá la invitación en su casilla de correo electrónico.
     Una vez aceptada la invitación, podrá comenzar a gestionar tu cuenta.`,
       success_title: 'Has añadido a tu Colaborador con éxito',

--- a/src/services/doppler-user-api-client.double.ts
+++ b/src/services/doppler-user-api-client.double.ts
@@ -114,9 +114,9 @@ export class HardcodedDopplerUserApiClient implements DopplerUserApiClient {
     };
   }
 
-  public async sendCollaboratorInvite(value: string): Promise<EmptyResultWithoutExpectedErrors> {
+  public async sendCollaboratorInvite(body: any): Promise<EmptyResultWithoutExpectedErrors> {
     await timeout(1500);
-    console.log(value);
+    console.log({ ...body, iduser: 123 }, 'sendCollaboratorInvite');
     return {
       success: true,
     };

--- a/src/services/doppler-user-api-client.ts
+++ b/src/services/doppler-user-api-client.ts
@@ -12,7 +12,7 @@ export interface DopplerUserApiClient {
   updateContactInformation(values: any): Promise<EmptyResultWithoutExpectedErrors>;
   getFeatures(): Promise<ResultWithoutExpectedErrors<Features>>;
   getIntegrationsStatus(): Promise<ResultWithoutExpectedErrors<IntegrationsStatus>>;
-  sendCollaboratorInvite(value: string): Promise<EmptyResultWithoutExpectedErrors>;
+  sendCollaboratorInvite(body: any): Promise<EmptyResultWithoutExpectedErrors>;
   updateUserAccountInformation(values: any): Promise<EmptyResultWithoutExpectedErrors>;
 }
 
@@ -198,7 +198,7 @@ export class HttpDopplerUserApiClient implements DopplerUserApiClient {
     }
   }
 
-  public async sendCollaboratorInvite(value: string): Promise<EmptyResultWithoutExpectedErrors> {
+  public async sendCollaboratorInvite(body: any): Promise<EmptyResultWithoutExpectedErrors> {
     try {
       const { email, jwtToken, idUser } = this.getDopplerUserApiConnectionData();
 
@@ -206,7 +206,7 @@ export class HttpDopplerUserApiClient implements DopplerUserApiClient {
         method: 'POST',
         url: `/accounts/${email}/user-invitations`,
         data: {
-          email: value,
+          ...body,
           idUser: idUser,
         },
         headers: { Authorization: `bearer ${jwtToken}` },


### PR DESCRIPTION
This will add a new step in the modal for collaborators invite, to set the permissions the collaborator will have over the account.
Also the body request to the API is modified.

![image](https://github.com/user-attachments/assets/a532abad-6feb-49fe-b211-dd72ceb97ca3)
