### PR TITLE
Cambio en la url de la integracion de google analytics

### DIFF
--- a/src/services/control-panel-service.ts
+++ b/src/services/control-panel-service.ts
@@ -137,7 +137,7 @@ export class ControlPanelService implements ControlPanelService {
           boxes: [
             {
               name: 'GoogleAnaliytic',
-              linkUrl: `${urlAdvancedPreferences}/GetGoogleAnaliyticPreferences`,
+              linkUrl: `${urlIntegrations}/GetGoogleAnaliyticPreferences`,
               imgSrc: google_analitics_icon,
               imgAlt: _('integrations.native_integrations.google_Analityc_title'),
               iconName: _('integrations.native_integrations.google_Analityc_title'),


### PR DESCRIPTION
Debido a que esta integracion se movio al controlador de Integrations debemos modificar su url.