### PR TITLE
Hide rfm shopify

### DIFF
--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -342,7 +342,7 @@ const Shopify = ({ dependencies: { shopifyClient, dopplerApiClient } }) => {
                   </div>
                 </>
               )}
-            <div className="dp-box-shadow m-b-24">
+            <div className="dp-box-shadow m-b-24" style={{ display: "none" }}>
               <iframe
                 ref={iframeRef}
                 src="/integration/shopify/rfm"


### PR DESCRIPTION
Se oculta RFM por tag de webapp que se va a realizar el 9/9 por la mañana.