### PR TITLE
Hide iframe when integration is disconnected

### DIFF
--- a/src/components/Integrations/Shopify/Shopify.js
+++ b/src/components/Integrations/Shopify/Shopify.js
@@ -315,6 +315,15 @@ const Shopify = ({ dependencies: { shopifyClient, dopplerApiClient } }) => {
                         </div>
                       </div>
                     </div>
+                    <div className="dp-box-shadow m-b-24">
+                      {rfmLoading && <Loading />}
+                      <iframe
+                        ref={iframeRef}
+                        src="/integration/shopify/rfm"
+                        style={{ border: 'none', width: '100%', display: rfmLoading ? 'none' : 'block' }}
+                        title="rfm"
+                      />
+                    </div>
                   </React.Fragment>
                 ))
               ) : (
@@ -346,15 +355,6 @@ const Shopify = ({ dependencies: { shopifyClient, dopplerApiClient } }) => {
                   </div>
                 </>
               )}
-              <div className="dp-box-shadow m-b-24">
-                {rfmLoading && <Loading />}
-                <iframe
-                  ref={iframeRef}
-                  src="/integration/shopify/rfm"
-                  style={{ border: 'none', width: '100%', display: rfmLoading ? 'none' : 'block' }}
-                  title="rfm"
-                />
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Al haber trabajado y probado el iframe siempre estando integrado, al estar prepararando Shopify para la demo note que se veia el iframe debajo al estar desconectado. Movi el div donde corresponde. Ya probado en INT.

<img width="1081" height="458" alt="image" src="https://github.com/user-attachments/assets/dadbc161-0f53-4ce6-babb-24e41a45fc3c" />
