### PR TITLE
[DAT-2644] - Change update view when the payment method is cc and ccnumber is empty

### DIFF
--- a/src/components/Plans/Checkout/PaymentMethod/PaymentMethod.js
+++ b/src/components/Plans/Checkout/PaymentMethod/PaymentMethod.js
@@ -335,6 +335,13 @@ export const PaymentMethod = InjectAppServices(
             handleChangeView(actionPage.UPDATE);
           } else if (paymentMethodData.value.paymentMethodName !== paymentType.creditCard) {
             handleChangePaymentMethod(paymentMethodToShow.paymentMethodName);
+          } else {
+            if (
+              paymentMethodData.value.paymentMethodName === paymentType.creditCard &&
+              paymentMethodData.value.ccNumber === ''
+            ) {
+              handleChangeView(actionPage.UPDATE);
+            }
           }
         } else {
           handleChangeView(actionPage.UPDATE);


### PR DESCRIPTION
Change update view when the payment method is cc and ccnumber is empty.

**Task:** [DAT-2644](https://makingsense.atlassian.net/jira/software/projects/DAT/boards/62?selectedIssue=DAT-2644)

[DAT-2644]: https://makingsense.atlassian.net/browse/DAT-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ