### PR TITLE
fix: resolve eslint warnings in NewPlanSelection i18n/promocode

### DIFF
--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -283,6 +283,7 @@ export const ContactsPlan = InjectAppServices(
                       id="buy_process.new_plan_selection.savings_text"
                       values={{
                         percentage: selectedDiscountPercentage,
+                        currency: 'US$',
                         period: _(
                           `buy_process.new_plan_selection.payment_period_${selectedPaymentFrequency.subscriptionType.replace(
                             '-',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -180,8 +180,7 @@ other {}}}}}}}}}}
       popular_label: 'POPULAR',
       price_label: 'Price',
       promocode_savings_text: 'You save {percentage}% for {months, plural, one {# month} other {# months}}',
-      // eslint-disable-next-line no-template-curly-in-string
-      savings_text: 'You save {percentage}% with 1 {period} payment of US${total}',
+      savings_text: 'You save {percentage}% with 1 {period} payment of {currency}{total}',
       subscription_label: 'Subscription',
       subtitle: "Select the Plan that best fits your Email Marketing strategy. Not sure which Plan works best for you? Contact us and we'll help you find it.",
       title: 'Choose the ideal Plan to grow your business',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -181,8 +181,7 @@ other {}}}}}}}}}}
       popular_label: 'POPULAR',
       price_label: 'Precio',
       promocode_savings_text: 'Ahorras {percentage}% durante {months, plural, one {# mes} other {# meses}}',
-      // eslint-disable-next-line no-template-curly-in-string
-      savings_text: 'Ahorras {percentage}% realizando 1 pago {period} de US${total}',
+      savings_text: 'Ahorras {percentage}% realizando 1 pago {period} de {currency}{total}',
       subscription_label: 'Suscripción',
       subtitle: 'Selecciona el Plan que mejor se adapte a tu estrategia de Email Marketing. ¿Tienes dudas sobre qué Plan te conviene más? Contáctanos y te ayudamos a encontrarlo.',
       title: 'Elige el Plan ideal para hacer crecer tu negocio',


### PR DESCRIPTION
## Summary
- removed unused `PromocodeMessageWithBillingCicle` from `NewPlanSelection/PromocodeMessages`
- fixed i18n string used by `buy_process.new_plan_selection.savings_text` in `es` and `en`
- updated `ContactsPlan` to pass `currency: 'US$'` so the savings text no longer relies on `US${total}` literal

## Why
This fixes lint issues reported in CI:
- `no-unused-vars` in `PromocodeMessages/index.js`
- `no-template-curly-in-string` in `src/i18n/en.js` and `src/i18n/es.js`

## Files changed
- `src/components/BuyProcess/NewPlanSelection/Promocode/PromocodeMessages/index.js`
- `src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js`
- `src/i18n/en.js`
- `src/i18n/es.js`

## Validation
- `yarn eslint src/components/BuyProcess/NewPlanSelection/Promocode/PromocodeMessages/index.js src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js src/i18n/en.js src/i18n/es.js`