### PR TITLE
[Tests] Stabilize CollaborationInvite flaky test

### DIFF
--- a/src/components/CollaborationInvite/index.test.js
+++ b/src/components/CollaborationInvite/index.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/extend-expect';
-import { cleanup, render, screen, act, waitForElementToBeRemoved } from '@testing-library/react';
+import { cleanup, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { AppServicesProvider } from '../../services/pure-di';
 import DopplerIntlProvider from '../../i18n/DopplerIntlProvider';
 import { MemoryRouter as Router } from 'react-router-dom';
@@ -44,11 +44,9 @@ describe('CollaborationInvite', () => {
     const loader = screen.getByTestId('wrapper-loading');
     await waitForElementToBeRemoved(loader);
 
-    act(() => expect(screen.getByTestId('unexpected-error')).toBeInTheDocument());
-    act(() =>
-      expect(
-        screen.findAllByText('validation_messages.error_expired_invitation_link'),
-      ).not.toBeNull(),
+    expect(screen.getByTestId('unexpected-error')).toBeInTheDocument();
+    expect(screen.getByTestId('unexpected-error')).toHaveTextContent(
+      /aviso importante|invitación como colaborador ha expirado/i,
     );
   });
 
@@ -81,6 +79,7 @@ describe('CollaborationInvite', () => {
     const loader = screen.getByTestId('wrapper-loading');
     await waitForElementToBeRemoved(loader);
 
-    act(() => expect(screen.getByTestId('collaboration-invite-form')).toBeInTheDocument());
+    expect(screen.getByTestId('collaboration-invite-form')).toBeInTheDocument();
+    expect(screen.queryByTestId('unexpected-error')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Fixed flaky behavior in `src/components/CollaborationInvite/index.test.js`.
- Removed incorrect async usage where a `findAllByText` promise was asserted without `await` inside `act`.
- Updated assertion to validate the rendered error message content in `unexpected-error` deterministically.
- Added explicit check that `unexpected-error` is not rendered in the success scenario.

## Why
The previous test could leave unresolved async assertions, causing intermittent failures in subsequent tests and confusing error reporting in CI.

## Validation
- `prettier --check src/components/CollaborationInvite/index.test.js` ✅
- `yarn test src/components/CollaborationInvite/index.test.js --watch=false --watchAll=false --runInBand --coverage=false` ✅