### PR TITLE
feat: implement NewPlanSelection add-ons section (spec section 4)

### DIFF
--- a/src/components/BuyProcess/BuyProcessLayout/index.js
+++ b/src/components/BuyProcess/BuyProcessLayout/index.js
@@ -11,13 +11,16 @@ import { useQueryParams } from '../../../hooks/useQueryParams';
 import { InjectAppServices } from '../../../services/pure-di';
 import { Stepper } from '../Stepper';
 
-export const getSteps = (buyType, user) => {
+export const getSteps = (buyType, user, pathname) => {
+  const currentPathname = pathname.includes('/new-plan-selection')
+    ? '/new-plan-selection'
+    : '/plan-selection/premium';
   const steps = [
     {
       id: 1,
       label: 'buy_process.stepper.email_marketing_plan_step',
       icon: 'dpicon iconapp-email-alert',
-      pathname: '/plan-selection/premium',
+      pathname: currentPathname,
       visible: buyType === BUY_MARKETING_PLAN.toString(),
     },
     {
@@ -79,7 +82,7 @@ export const BuyProcessLayout = InjectAppServices(
     const { pathname } = useLocation();
     const query = useQueryParams();
     const buyType = query.get('buyType') ?? '1';
-    let steps = getSteps(buyType, appSessionRef.current.userData.user).filter(
+    let steps = getSteps(buyType, appSessionRef.current.userData.user, pathname).filter(
       (s) => s.visible === true,
     );
     const isNewPlanSelection = pathname === '/new-plan-selection';

--- a/src/components/BuyProcess/NewPlanSelection/AddOnsSection/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/AddOnsSection/index.js
@@ -1,0 +1,263 @@
+import { useEffect, useMemo, useState } from 'react';
+import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
+import { AddOnType } from '../../../../doppler-types';
+import { InjectAppServices } from '../../../../services/pure-di';
+
+const CARDS_PER_PAGE = 3;
+
+const getCheapestPrice = (plans, priceField) => {
+  const prices = plans
+    ?.map((plan) => Number(plan?.[priceField]))
+    .filter((price) => Number.isFinite(price) && price > 0);
+
+  if (!prices?.length) {
+    return null;
+  }
+
+  return Math.min(...prices);
+};
+
+const getAddOnPlansPrice = async (dopplerAccountPlansApiClient, addOnType) => {
+  const response = await dopplerAccountPlansApiClient.getAddOnPlans(addOnType);
+
+  if (!response.success) {
+    throw new Error(response.error || response.value || 'Unexpected Add-on plans error');
+  }
+
+  return getCheapestPrice(response.value, 'fee');
+};
+
+const getLandingPacksPrice = async (dopplerAccountPlansApiClient) => {
+  const response = await dopplerAccountPlansApiClient.getLandingPacks();
+
+  if (!response.success) {
+    throw new Error(response.error || response.value || 'Unexpected Landing Packs error');
+  }
+
+  return getCheapestPrice(response.value, 'price');
+};
+
+const getAddonConfigs = ({ canShowEcoIA, canShowPushNotification }) => [
+  ...(canShowEcoIA
+    ? [
+        {
+          id: 'eco-ai',
+          icon: 'dpicon icon-sparkle-ia',
+          titleKey: 'my_plan.addons.eco_ai.title',
+          descriptionKey: 'my_plan.addons.eco_ai.description',
+          priceLabelKey: 'my_plan.addons.eco_ai.access_by_legend',
+          periodKey: 'my_plan.addons.eco_ai.month_legend',
+          getPrice: (dopplerAccountPlansApiClient) =>
+            getAddOnPlansPrice(dopplerAccountPlansApiClient, AddOnType.EcoAI),
+        },
+      ]
+    : []),
+  {
+    id: 'conversations',
+    icon: 'dpicon iconapp-chatting',
+    titleKey: 'my_plan.addons.conversations.title',
+    descriptionKey: 'my_plan.addons.conversations.description',
+    priceLabelKey: 'my_plan.addons.conversations.plans_from_legend',
+    periodKey: 'my_plan.addons.conversations.month_legend',
+    getPrice: (dopplerAccountPlansApiClient) =>
+      getAddOnPlansPrice(dopplerAccountPlansApiClient, AddOnType.Conversations),
+  },
+  ...(canShowPushNotification
+    ? [
+        {
+          id: 'push-notification',
+          icon: 'dpicon iconapp-bell1',
+          titleKey: 'my_plan.addons.push_notification.title',
+          descriptionKey: 'my_plan.addons.push_notification.description',
+          priceLabelKey: 'my_plan.addons.push_notification.plans_from_legend',
+          periodKey: 'my_plan.addons.push_notification.month_legend',
+          getPrice: (dopplerAccountPlansApiClient) =>
+            getAddOnPlansPrice(dopplerAccountPlansApiClient, AddOnType.PushNotifications),
+        },
+      ]
+    : []),
+  {
+    id: 'onsite',
+    icon: 'dpicon iconapp-online-clothing',
+    titleKey: 'my_plan.addons.onsite.title',
+    descriptionKey: 'my_plan.addons.onsite.description',
+    priceLabelKey: 'my_plan.addons.onsite.plans_from_legend',
+    periodKey: 'my_plan.addons.onsite.month_legend',
+    getPrice: (dopplerAccountPlansApiClient) =>
+      getAddOnPlansPrice(dopplerAccountPlansApiClient, AddOnType.OnSite),
+  },
+  {
+    id: 'landing-pages',
+    icon: 'dpicon iconapp-landing-page',
+    titleKey: 'my_plan.addons.landing_pages.title',
+    descriptionKey: 'my_plan.addons.landing_pages.description',
+    priceLabelKey: 'my_plan.addons.landing_pages.packs_from_legend',
+    periodKey: 'my_plan.addons.landing_pages.month_legend',
+    getPrice: getLandingPacksPrice,
+  },
+];
+
+const AddOnCard = ({ addOn, price }) => {
+  const intl = useIntl();
+  const _ = (id, values) => intl.formatMessage({ id }, values);
+
+  return (
+    <article
+      className="dp-card-addons dp-new-plan-selection-addon-card"
+      data-testid={`dp-addon-card-${addOn.id}`}
+    >
+      <header>
+        <h3 className="card-title">
+          <div className="icon-container">
+            <span className={`p-l-6 ${addOn.icon}`} aria-hidden="true"></span>
+          </div>
+          <span className="p-l-8 m-l-6">{_(addOn.titleKey)}</span>
+        </h3>
+      </header>
+      <p className="dp-description-legend">{_(addOn.descriptionKey)}</p>
+      <div className="dp-new-plan-selection-addon-price">
+        <span className="dp-legend-price">{_(addOn.priceLabelKey)}</span>
+        {price ? (
+          <>
+            <p>
+              <b>
+                US${' '}
+                <FormattedNumber
+                  value={price}
+                  minimumFractionDigits={2}
+                  maximumFractionDigits={2}
+                />
+              </b>
+              <span className="dp-disclaimer">{_(addOn.periodKey)}</span>
+            </p>
+          </>
+        ) : (
+          <span className="dp-disclaimer">
+            <FormattedMessage id="buy_process.new_plan_selection.addons_section.price_unavailable" />
+          </span>
+        )}
+      </div>
+    </article>
+  );
+};
+
+export const AddOnsSection = InjectAppServices(
+  ({ dependencies: { appSessionRef, dopplerAccountPlansApiClient } }) => {
+    const intl = useIntl();
+    const canShowEcoIA = appSessionRef.current.userData.features?.ecoIAEnabled === true;
+    const canShowPushNotification =
+      process.env.REACT_APP_DOPPLER_CAN_BUY_PUSHNOTIFICATION_PLAN === 'true';
+    const addOns = useMemo(
+      () => getAddonConfigs({ canShowEcoIA, canShowPushNotification }),
+      [canShowEcoIA, canShowPushNotification],
+    );
+    const [prices, setPrices] = useState({});
+    const [isLoading, setIsLoading] = useState(true);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const maxIndex = Math.max(addOns.length - CARDS_PER_PAGE, 0);
+    const visibleAddOns = addOns.slice(currentIndex, currentIndex + CARDS_PER_PAGE);
+    const hasAvailablePrice = Object.values(prices).some(
+      (price) => Number.isFinite(price) && price > 0,
+    );
+
+    useEffect(() => {
+      let isMounted = true;
+
+      const fetchPrices = async () => {
+        setIsLoading(true);
+
+        const responses = await Promise.allSettled(
+          addOns.map(async (addOn) => ({
+            id: addOn.id,
+            price: await addOn.getPrice(dopplerAccountPlansApiClient),
+          })),
+        );
+
+        if (!isMounted) {
+          return;
+        }
+
+        setPrices(
+          responses.reduce((acc, response) => {
+            if (response.status === 'fulfilled') {
+              acc[response.value.id] = response.value.price;
+            }
+
+            return acc;
+          }, {}),
+        );
+        setIsLoading(false);
+      };
+
+      fetchPrices();
+
+      return () => {
+        isMounted = false;
+      };
+    }, [addOns, dopplerAccountPlansApiClient]);
+
+    useEffect(() => {
+      setCurrentIndex((index) => Math.min(index, maxIndex));
+    }, [maxIndex]);
+
+    const handlePrevious = () => {
+      setCurrentIndex((index) => Math.max(index - 1, 0));
+    };
+
+    const handleNext = () => {
+      setCurrentIndex((index) => Math.min(index + 1, maxIndex));
+    };
+
+    if (!addOns.length) {
+      return null;
+    }
+
+    return (
+      <section
+        className="dp-new-plan-selection-addons"
+        data-testid="dp-addons-section"
+        aria-busy={isLoading}
+      >
+        <header className="dp-new-plan-selection-addons-header">
+          <h2 className="dp-second-order-title">
+            <FormattedMessage id="buy_process.new_plan_selection.addons_section.title" />
+          </h2>
+          <p>
+            <FormattedMessage id="buy_process.new_plan_selection.addons_section.subtitle" />
+          </p>
+        </header>
+        {!isLoading && !hasAvailablePrice ? (
+          <p className="dp-new-plan-selection-addons-empty">
+            <FormattedMessage id="buy_process.new_plan_selection.addons_section.empty_message" />
+          </p>
+        ) : (
+          <div className="dp-new-plan-selection-addons-carousel">
+            <button
+              type="button"
+              className="ms-icon icon-arrow-prev dp-arrow-left"
+              aria-label={intl.formatMessage({
+                id: 'buy_process.new_plan_selection.addons_section.previous',
+              })}
+              disabled={currentIndex === 0}
+              onClick={handlePrevious}
+            ></button>
+            <div className="dp-new-plan-selection-addons-cards">
+              {visibleAddOns.map((addOn) => (
+                <AddOnCard key={addOn.id} addOn={addOn} price={prices[addOn.id]} />
+              ))}
+            </div>
+            <button
+              type="button"
+              className="ms-icon icon-arrow-next dp-arrow-right"
+              aria-label={intl.formatMessage({
+                id: 'buy_process.new_plan_selection.addons_section.next',
+              })}
+              disabled={currentIndex >= maxIndex}
+              onClick={handleNext}
+            ></button>
+          </div>
+        )}
+      </section>
+    );
+  },
+);

--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -46,7 +46,7 @@ const getCheckoutUrl = ({ search, selectedPlan, selectedPaymentFrequency, promoc
     params.set('PromoCode', promocodeApplied.promocode);
   }
 
-  return `/checkout/premium/${PLAN_TYPE.byContact}?${params.toString()}`;
+  return `/checkout/premium/${PLAN_TYPE.byContact}?${params.toString()}&buyType=1`;
 };
 
 export const ContactsPlan = InjectAppServices(

--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -211,9 +211,9 @@ export const ContactsPlan = InjectAppServices(
         <div className="dp-new-plan-selection-card-header">
           <div>
             <div className="dp-new-plan-selection-plan-title">
-              <h3 className="dp-second-order-title">
+              <h1 className="p-b-0">
                 <FormattedMessage id="buy_process.new_plan_selection.contacts_plan_title" />
-              </h3>
+              </h1>
               <span className="dp-new-plan-selection-badge">
                 <FormattedMessage id="buy_process.new_plan_selection.popular_label" />
               </span>
@@ -228,9 +228,9 @@ export const ContactsPlan = InjectAppServices(
           <div className="col-lg-6 col-md-12">
             <div className="dp-new-plan-selection-fields">
               <div className="dp-new-plan-selection-select-wrap">
-                <label htmlFor="new-plan-selection-contacts" className="labelcontrol">
+                <h2 className="labelcontrol">
                   <FormattedMessage id="buy_process.new_plan_selection.contacts_label" />
-                </label>
+                </h2>
                 <span className="dropdown-arrow" />
                 <select
                   id="new-plan-selection-contacts"

--- a/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
@@ -33,7 +33,7 @@ const getCheckoutUrl = ({ search, selectedPlan, promocodeApplied }) => {
     params.set('PromoCode', promocodeApplied.promocode);
   }
 
-  return `/checkout/premium/${PLAN_TYPE.byCredit}?${params.toString()}`;
+  return `/checkout/premium/${PLAN_TYPE.byCredit}?${params.toString()}&buyType=1`;
 };
 
 export const CreditsPlan = InjectAppServices(

--- a/src/components/BuyProcess/NewPlanSelection/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.js
@@ -10,6 +10,7 @@ import { ContactsPlan } from './ContactsPlan';
 import { CreditsPlan } from './CreditsPlan';
 import { IncludedFeatures } from './IncludedFeatures';
 import { StickyPlanSummary } from './StickyPlanSummary';
+import { AddOnsSection } from './AddOnsSection';
 import { NewPlanSelectionStyled } from './index.styles';
 
 const MORE_THAN_100K_OPTION_VALUE = 'more-than-100000';
@@ -222,6 +223,9 @@ export const NewPlanSelection = InjectAppServices(
             />
           </div>
         )}
+        <div className="dp-container">
+          <AddOnsSection />
+        </div>
       </NewPlanSelectionStyled>
     );
   },

--- a/src/components/BuyProcess/NewPlanSelection/index.styles.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.styles.js
@@ -30,6 +30,7 @@ export const NewPlanSelectionStyled = styled.div`
 
   .dp-new-plan-selection-back .dp-button.ctaTertiary .dp-new-plan-selection-back-text {
     text-decoration: underline;
+    text-transform: uppercase;
   }
 
   .dp-new-plan-selection-back .dp-button.ctaTertiary:hover {
@@ -257,11 +258,18 @@ export const NewPlanSelectionStyled = styled.div`
     font-weight: 700;
   }
 
-  .dp-new-plan-selection-select-wrap .dropdown-arrow {
+  .dp-new-plan-selection-card .dp-new-plan-selection-select-wrap .dropdown-arrow {
     pointer-events: none;
     position: absolute;
     right: 12px;
-    top: 39px;
+    top: 36px;
+  }
+
+  .dp-new-plan-selection-card-credits .dp-new-plan-selection-select-wrap .dropdown-arrow {
+    pointer-events: none;
+    position: absolute;
+    right: 12px;
+    top: 59px;
   }
 
   .dp-new-plan-selection-select {
@@ -702,7 +710,6 @@ export const NewPlanSelectionStyled = styled.div`
     gap: 6px;
     margin-top: 22px;
     padding: 0;
-    text-decoration: underline;
     text-transform: uppercase;
   }
 
@@ -815,6 +822,116 @@ export const NewPlanSelectionStyled = styled.div`
     flex: 0 0 auto;
   }
 
+  .dp-new-plan-selection-addons {
+    margin: 34px auto 36px;
+  }
+
+  .dp-new-plan-selection-addons-header {
+    margin-bottom: 22px;
+    text-align: center;
+  }
+
+  .dp-new-plan-selection-addons-header h2 {
+    text-transform: none;
+  }
+
+  .dp-new-plan-selection-addons-header p {
+    color: #666;
+    margin: 0;
+  }
+
+  .dp-new-plan-selection-addons-empty {
+    color: #666;
+    margin: 0;
+    text-align: center;
+  }
+
+  .dp-new-plan-selection-addons-carousel {
+    align-items: center;
+    display: flex;
+    gap: 16px;
+  }
+
+  .dp-new-plan-selection-addons-cards {
+    display: flex;
+    flex: 1 1 auto;
+    gap: 18px;
+  }
+
+  .dp-new-plan-selection-addon-card {
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 calc((100% - 36px) / 3);
+    margin-bottom: 0;
+    min-height: 100%;
+  }
+
+  .dp-new-plan-selection-addon-card .card-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 700;
+    margin-bottom: 6px;
+    font-size: 22px;
+  }
+
+  .dp-new-plan-selection-addon-card .dp-description-legend {
+    flex: 1 1 auto;
+  }
+
+  .dp-new-plan-selection-addon-card .card-title .icon-container {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 2px;
+    color: #fff;
+
+    span {
+      font-size: 40px;
+      line-height: 1;
+    }
+  }
+
+  .dp-new-plan-selection-addon-card .dpicon {
+    color: #fab221;
+    flex: 0 0 auto;
+  }
+
+  .dp-new-plan-selection-addon-price {
+    border-top: 1px solid #ccc;
+    margin-top: 14px;
+    padding-top: 12px;
+  }
+
+  .dp-new-plan-selection-addon-price .dp-legend-price {
+    font-size: 14px;
+    line-height: 24px;
+  }
+
+  .dp-new-plan-selection-addon-price h2 {
+    padding-bottom: 0;
+  }
+
+  .dp-new-plan-selection-addons-arrow {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: #333;
+    cursor: pointer;
+    display: inline-flex;
+    justify-content: center;
+    min-height: 36px;
+    min-width: 28px;
+    padding: 0;
+  }
+
+  .dp-new-plan-selection-addons-arrow:disabled {
+    cursor: default;
+    opacity: 0.35;
+  }
+
   @media (max-width: 991px) {
     .dp-new-plan-selection-sticky-summary-content {
       align-items: flex-start;
@@ -890,6 +1007,10 @@ export const NewPlanSelectionStyled = styled.div`
 
     .dp-new-plan-selection-included-features-item {
       max-width: none;
+    }
+
+    .dp-new-plan-selection-addon-card {
+      flex-basis: calc((100% - 18px) / 2);
     }
   }
 
@@ -990,6 +1111,14 @@ export const NewPlanSelectionStyled = styled.div`
     .dp-new-plan-selection-features-modal.modal-content--large {
       max-height: 90vh;
       overflow-y: auto;
+    }
+
+    .dp-new-plan-selection-addons-carousel {
+      gap: 10px;
+    }
+
+    .dp-new-plan-selection-addon-card {
+      flex-basis: 100%;
     }
   }
 `;

--- a/src/components/BuyProcess/NewPlanSelection/index.styles.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.styles.js
@@ -231,10 +231,10 @@ export const NewPlanSelectionStyled = styled.div`
 
   .dp-new-plan-selection-badge {
     background: #33ad73;
-    border-radius: 3px;
+    border-radius: 12px;
     color: #fff;
     flex: 0 0 auto;
-    font-size: 12px;
+    font-size: 10px;
     font-weight: 700;
     line-height: 1;
     padding: 7px 10px;
@@ -524,7 +524,7 @@ export const NewPlanSelectionStyled = styled.div`
     background-color: #fddc79;
     border-radius: 30px;
     color: #333;
-    font-size: 9px;
+    font-size: 12px;
     font-weight: 700;
     line-height: 1;
     padding: 2px 4px;

--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter as Router, Route, Routes } from 'react-router-dom';
-import { PLAN_TYPE } from '../../../doppler-types';
+import { AddOnType, PLAN_TYPE } from '../../../doppler-types';
 import DopplerIntlProvider from '../../../i18n/DopplerIntlProvider';
 import { AppServicesProvider } from '../../../services/pure-di';
 import { NewPlanSelection } from '.';
@@ -59,6 +59,27 @@ const creditPlans = [
     credits: 20000,
     price: 140,
   },
+];
+
+const addOnPlansByType = {
+  [AddOnType.OnSite]: [
+    { planId: 301, quantity: 5000, fee: 25 },
+    { planId: 302, quantity: 1000, fee: 15 },
+  ],
+  [AddOnType.Conversations]: [
+    { planId: 401, quantity: 1000, fee: 30 },
+    { planId: 402, quantity: 500, fee: 20 },
+  ],
+  [AddOnType.EcoAI]: [{ planId: 501, quantity: 1, fee: 49 }],
+  [AddOnType.PushNotifications]: [
+    { planId: 601, quantity: 1000, fee: 18 },
+    { planId: 602, quantity: 500, fee: 15 },
+  ],
+};
+
+const landingPacks = [
+  { planId: 701, description: 'PACK 25', landingsQty: 25, price: 8 },
+  { planId: 702, description: 'PACK 5', landingsQty: 5, price: 5 },
 ];
 
 const amountDetails = {
@@ -156,14 +177,19 @@ const settleAsyncState = async () => {
 const ACT_WARNING_PATTERN = /not wrapped in act/i;
 
 let consoleErrorSpy;
+let previousCanBuyPushNotificationPlan;
 
 const getContactsPlanSection = () => screen.getByTestId('dp-contacts-plan');
 const getCreditsPlanSection = () => screen.getByTestId('dp-credits-plan');
+const getAddOnsSection = () => screen.getByTestId('dp-addons-section');
+const hasPriceInBold = (price) => (_content, node) =>
+  node?.tagName === 'B' && node?.textContent?.includes(price);
 
-const createForcedServices = () => ({
+const createForcedServices = ({ features = {}, dopplerAccountPlansApiClient = {} } = {}) => ({
   appSessionRef: {
     current: {
       userData: {
+        features,
         user: {
           locationCountry: 'us',
           chat: { active: false },
@@ -193,6 +219,15 @@ const createForcedServices = () => ({
           ? { canApply: true, promotionApplied: { discountPercentage: 10, extraCredits: 0 } }
           : { canApply: true, promotionApplied: { discountPercentage: 10, duration: 3 } },
     })),
+    getAddOnPlans: jest.fn(async (addOnType) => ({
+      success: true,
+      value: addOnPlansByType[addOnType] || [],
+    })),
+    getLandingPacks: jest.fn(async () => ({
+      success: true,
+      value: landingPacks,
+    })),
+    ...dopplerAccountPlansApiClient,
   },
   planService: {
     getPlansByType: jest.fn(async (planType) => {
@@ -209,8 +244,11 @@ const createForcedServices = () => ({
   },
 });
 
-const renderNewPlanSelection = async (initialEntries = ['/new-plan-selection']) => {
-  const forcedServices = createForcedServices();
+const renderNewPlanSelection = async (
+  initialEntries = ['/new-plan-selection'],
+  serviceOptions = {},
+) => {
+  const forcedServices = createForcedServices(serviceOptions);
 
   render(
     <AppServicesProvider forcedServices={forcedServices}>
@@ -232,6 +270,9 @@ const renderNewPlanSelection = async (initialEntries = ['/new-plan-selection']) 
 
 describe('NewPlanSelection component', () => {
   beforeEach(() => {
+    previousCanBuyPushNotificationPlan =
+      process.env.REACT_APP_DOPPLER_CAN_BUY_PUSHNOTIFICATION_PLAN;
+    process.env.REACT_APP_DOPPLER_CAN_BUY_PUSHNOTIFICATION_PLAN = 'false';
     const originalConsoleError = console.error;
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args) => {
       if (typeof args[0] === 'string' && ACT_WARNING_PATTERN.test(args[0])) {
@@ -244,6 +285,8 @@ describe('NewPlanSelection component', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    process.env.REACT_APP_DOPPLER_CAN_BUY_PUSHNOTIFICATION_PLAN =
+      previousCanBuyPushNotificationPlan;
   });
 
   it('should render section controls without plan type tabs', async () => {
@@ -272,6 +315,136 @@ describe('NewPlanSelection component', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: creditsLabelPattern })).toHaveValue('0');
     expect(screen.getByRole('link', { name: /Comprar Cr[eé]ditos/i })).toBeInTheDocument();
+  });
+
+  it('should render informational add-ons cards with real minimum prices and no card actions', async () => {
+    await renderNewPlanSelection();
+
+    expect(
+      screen.getByText(/Explora nuestros Add-ons para potenciar tu Plan/i),
+    ).toBeInTheDocument();
+    expect(within(getAddOnsSection()).getByText(/OnSite Marketing/i)).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('dp-addon-card-conversations')).getByRole('heading', {
+        name: /Conversaciones/i,
+      }),
+    ).toBeInTheDocument();
+    expect(within(getAddOnsSection()).getByText(/Pack de Landing Pages/i)).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('dp-addon-card-onsite')).getByText(hasPriceInBold('US$ 15,00')),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      within(screen.getByTestId('dp-addon-card-conversations')).getByText(
+        hasPriceInBold('US$ 20,00'),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('dp-addon-card-landing-pages')).getByText(
+        hasPriceInBold('US$ 5,00'),
+      ),
+    ).toBeInTheDocument();
+
+    screen.getAllByTestId(/dp-addon-card-/).forEach((card) => {
+      expect(within(card).queryByRole('link')).not.toBeInTheDocument();
+      expect(within(card).queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should render Eco IA only when ecoIAEnabled is true', async () => {
+    await renderNewPlanSelection(['/new-plan-selection'], {
+      features: { ecoIAEnabled: true },
+    });
+
+    await waitFor(() => expect(screen.getByTestId('dp-addon-card-eco-ai')).toBeInTheDocument());
+    expect(within(getAddOnsSection()).getByText(/Eco IA/i)).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('dp-addon-card-eco-ai')).getByText(hasPriceInBold('US$ 49,00')),
+    ).toBeInTheDocument();
+  });
+
+  it('should hide Eco IA when ecoIAEnabled is not true', async () => {
+    await renderNewPlanSelection();
+
+    expect(within(getAddOnsSection()).queryByText(/Eco IA/i)).not.toBeInTheDocument();
+  });
+
+  it('should render Push Notification only when can buy env var is true', async () => {
+    process.env.REACT_APP_DOPPLER_CAN_BUY_PUSHNOTIFICATION_PLAN = 'true';
+    await renderNewPlanSelection(['/new-plan-selection'], {
+      features: { ecoIAEnabled: true },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dp-addon-card-push-notification')).toBeInTheDocument(),
+    );
+    expect(
+      within(screen.getByTestId('dp-addon-card-push-notification')).getByRole('heading', {
+        name: /Notificaciones Push/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('dp-addon-card-push-notification')).getByText(
+        hasPriceInBold('US$ 15,00'),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should hide Push Notification when can buy env var is not true', async () => {
+    await renderNewPlanSelection(['/new-plan-selection'], {
+      features: { ecoIAEnabled: true },
+    });
+
+    fireEvent.click(within(getAddOnsSection()).getByRole('button', { name: /siguiente add-on/i }));
+
+    expect(within(getAddOnsSection()).queryByText(/Notificaciones Push/i)).not.toBeInTheDocument();
+  });
+
+  it('should keep add-ons section visible with fallback price when one add-on source fails', async () => {
+    await renderNewPlanSelection(['/new-plan-selection'], {
+      dopplerAccountPlansApiClient: {
+        getAddOnPlans: jest.fn(async (addOnType) => {
+          if (addOnType === AddOnType.OnSite) {
+            return { success: false, error: 'Unexpected error' };
+          }
+
+          return { success: true, value: addOnPlansByType[addOnType] || [] };
+        }),
+      },
+    });
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('dp-addon-card-onsite')).getByText(/Precio no disponible/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      within(screen.getByTestId('dp-addon-card-conversations')).getByRole('heading', {
+        name: /Conversaciones/i,
+      }),
+    ).toBeInTheDocument();
+    expect(within(getAddOnsSection()).getByText(/Pack de Landing Pages/i)).toBeInTheDocument();
+  });
+
+  it('should hide add-ons carousel and show empty message when all sources fail', async () => {
+    await renderNewPlanSelection(['/new-plan-selection'], {
+      dopplerAccountPlansApiClient: {
+        getAddOnPlans: jest.fn(async () => ({ success: false, error: 'Unexpected error' })),
+        getLandingPacks: jest.fn(async () => ({ success: false, error: 'Unexpected error' })),
+      },
+    });
+
+    await waitFor(() =>
+      expect(
+        within(getAddOnsSection()).getByText(/No hay Add-ons disponibles en este momento/i),
+      ).toBeInTheDocument(),
+    );
+    expect(within(getAddOnsSection()).queryByTestId(/dp-addon-card-/)).not.toBeInTheDocument();
+    expect(
+      within(getAddOnsSection()).queryByRole('button', { name: /siguiente add-on/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('should open and close included features modal', async () => {
@@ -372,7 +545,7 @@ describe('NewPlanSelection component', () => {
         within(getCreditsPlanSection())
           .getByRole('link', { name: /Comprar Cr[eé]ditos/i })
           .getAttribute('href'),
-      ).toBe(`/checkout/premium/${PLAN_TYPE.byCredit}?selected-plan=20223`),
+      ).toBe(`/checkout/premium/${PLAN_TYPE.byCredit}?selected-plan=20223&buyType=1`),
     );
   });
 
@@ -384,7 +557,7 @@ describe('NewPlanSelection component', () => {
 
     await waitFor(() =>
       expect(screen.getByRole('link', { name: 'Elegir Plan' }).getAttribute('href')).toBe(
-        '/checkout/premium/subscribers?selected-plan=10222&discountId=798&monthPlan=12',
+        '/checkout/premium/subscribers?selected-plan=10222&discountId=798&monthPlan=12&buyType=1',
       ),
     );
     expect(screen.getByText(/US\$7,50\/mes/i)).toBeInTheDocument();

--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -12,6 +12,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter as Router, Route, Routes } from 'react-router-dom';
 import { AddOnType, PLAN_TYPE } from '../../../doppler-types';
 import DopplerIntlProvider from '../../../i18n/DopplerIntlProvider';
+import DopplerIntlProviderDoubleWithIdsAsValues from '../../../i18n/DopplerIntlProvider.double-with-ids-as-values';
 import { AppServicesProvider } from '../../../services/pure-di';
 import { NewPlanSelection } from '.';
 
@@ -166,8 +167,6 @@ const creditsAmountDetailsWithDiscountAndExtraCredits = {
   },
 };
 
-const contactsLabelPattern = /cu[aá]ntos contactos tienes\?/i;
-const creditsLabelPattern = /cu[aá]ntos cr[eé]ditos necesitas\?/i;
 const textContentIncludes = (text) => (_content, node) => node?.textContent?.includes(text);
 const settleAsyncState = async () => {
   await act(async () => {
@@ -182,8 +181,10 @@ let previousCanBuyPushNotificationPlan;
 const getContactsPlanSection = () => screen.getByTestId('dp-contacts-plan');
 const getCreditsPlanSection = () => screen.getByTestId('dp-credits-plan');
 const getAddOnsSection = () => screen.getByTestId('dp-addons-section');
-const hasPriceInBold = (price) => (_content, node) =>
-  node?.tagName === 'B' && node?.textContent?.includes(price);
+const getContactsSelect = () => within(getContactsPlanSection()).getByRole('combobox');
+const getCreditsSelect = () => within(getCreditsPlanSection()).getByRole('combobox');
+const hasPriceInBold = (priceRegex) => (_content, node) =>
+  node?.tagName === 'B' && priceRegex.test(node?.textContent || '');
 
 const createForcedServices = ({ features = {}, dopplerAccountPlansApiClient = {} } = {}) => ({
   appSessionRef: {
@@ -247,18 +248,22 @@ const createForcedServices = ({ features = {}, dopplerAccountPlansApiClient = {}
 const renderNewPlanSelection = async (
   initialEntries = ['/new-plan-selection'],
   serviceOptions = {},
+  { useI18nKeysAsValues = false } = {},
 ) => {
   const forcedServices = createForcedServices(serviceOptions);
+  const IntlProviderComponent = useI18nKeysAsValues
+    ? DopplerIntlProviderDoubleWithIdsAsValues
+    : DopplerIntlProvider;
 
   render(
     <AppServicesProvider forcedServices={forcedServices}>
-      <DopplerIntlProvider locale="es">
+      <IntlProviderComponent locale="es">
         <Router initialEntries={initialEntries}>
           <Routes>
             <Route path="/new-plan-selection" element={<NewPlanSelection />} />
           </Routes>
         </Router>
-      </DopplerIntlProvider>
+      </IntlProviderComponent>
     </AppServicesProvider>,
   );
 
@@ -298,7 +303,7 @@ describe('NewPlanSelection component', () => {
       }),
     ).toBeInTheDocument();
     expect(screen.getAllByText(/Plan Contactos/i).length).toBeGreaterThan(0);
-    expect(screen.getByRole('combobox', { name: contactsLabelPattern })).toHaveValue('0');
+    expect(getContactsSelect()).toHaveValue('0');
     expect(screen.getByRole('option', { name: /m[aá]s de 100.000/i })).toBeInTheDocument();
     expect(screen.getAllByText(/Suscripci[oó]n/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/C[oó]digo de descuento/i).length).toBeGreaterThan(0);
@@ -313,37 +318,41 @@ describe('NewPlanSelection component', () => {
         name: /Compra Cr[eé]ditos y usalos cuando quieras/i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: creditsLabelPattern })).toHaveValue('0');
+    expect(getCreditsSelect()).toHaveValue('0');
     expect(screen.getByRole('link', { name: /Comprar Cr[eé]ditos/i })).toBeInTheDocument();
   });
 
   it('should render informational add-ons cards with real minimum prices and no card actions', async () => {
-    await renderNewPlanSelection();
+    await renderNewPlanSelection(['/new-plan-selection'], {}, { useI18nKeysAsValues: true });
 
     expect(
-      screen.getByText(/Explora nuestros Add-ons para potenciar tu Plan/i),
+      screen.getByText('buy_process.new_plan_selection.addons_section.title'),
     ).toBeInTheDocument();
-    expect(within(getAddOnsSection()).getByText(/OnSite Marketing/i)).toBeInTheDocument();
+    expect(within(getAddOnsSection()).getByText('my_plan.addons.onsite.title')).toBeInTheDocument();
     expect(
       within(screen.getByTestId('dp-addon-card-conversations')).getByRole('heading', {
-        name: /Conversaciones/i,
+        name: 'my_plan.addons.conversations.title',
       }),
     ).toBeInTheDocument();
-    expect(within(getAddOnsSection()).getByText(/Pack de Landing Pages/i)).toBeInTheDocument();
+    expect(
+      within(getAddOnsSection()).getByText('my_plan.addons.landing_pages.title'),
+    ).toBeInTheDocument();
 
     await waitFor(() =>
       expect(
-        within(screen.getByTestId('dp-addon-card-onsite')).getByText(hasPriceInBold('US$ 15,00')),
+        within(screen.getByTestId('dp-addon-card-onsite')).getByText(
+          hasPriceInBold(/US\$\s*15[.,]00/),
+        ),
       ).toBeInTheDocument(),
     );
     expect(
       within(screen.getByTestId('dp-addon-card-conversations')).getByText(
-        hasPriceInBold('US$ 20,00'),
+        hasPriceInBold(/US\$\s*20[.,]00/),
       ),
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('dp-addon-card-landing-pages')).getByText(
-        hasPriceInBold('US$ 5,00'),
+        hasPriceInBold(/US\$\s*5[.,]00/),
       ),
     ).toBeInTheDocument();
 
@@ -354,96 +363,128 @@ describe('NewPlanSelection component', () => {
   });
 
   it('should render Eco IA only when ecoIAEnabled is true', async () => {
-    await renderNewPlanSelection(['/new-plan-selection'], {
-      features: { ecoIAEnabled: true },
-    });
+    await renderNewPlanSelection(
+      ['/new-plan-selection'],
+      {
+        features: { ecoIAEnabled: true },
+      },
+      { useI18nKeysAsValues: true },
+    );
 
     await waitFor(() => expect(screen.getByTestId('dp-addon-card-eco-ai')).toBeInTheDocument());
-    expect(within(getAddOnsSection()).getByText(/Eco IA/i)).toBeInTheDocument();
+    expect(within(getAddOnsSection()).getByText('my_plan.addons.eco_ai.title')).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('dp-addon-card-eco-ai')).getByText(hasPriceInBold('US$ 49,00')),
+      within(screen.getByTestId('dp-addon-card-eco-ai')).getByText(
+        hasPriceInBold(/US\$\s*49[.,]00/),
+      ),
     ).toBeInTheDocument();
   });
 
   it('should hide Eco IA when ecoIAEnabled is not true', async () => {
-    await renderNewPlanSelection();
+    await renderNewPlanSelection(['/new-plan-selection'], {}, { useI18nKeysAsValues: true });
 
-    expect(within(getAddOnsSection()).queryByText(/Eco IA/i)).not.toBeInTheDocument();
+    expect(
+      within(getAddOnsSection()).queryByText('my_plan.addons.eco_ai.title'),
+    ).not.toBeInTheDocument();
   });
 
   it('should render Push Notification only when can buy env var is true', async () => {
     process.env.REACT_APP_DOPPLER_CAN_BUY_PUSHNOTIFICATION_PLAN = 'true';
-    await renderNewPlanSelection(['/new-plan-selection'], {
-      features: { ecoIAEnabled: true },
-    });
+    await renderNewPlanSelection(
+      ['/new-plan-selection'],
+      {
+        features: { ecoIAEnabled: true },
+      },
+      { useI18nKeysAsValues: true },
+    );
 
     await waitFor(() =>
       expect(screen.getByTestId('dp-addon-card-push-notification')).toBeInTheDocument(),
     );
     expect(
       within(screen.getByTestId('dp-addon-card-push-notification')).getByRole('heading', {
-        name: /Notificaciones Push/i,
+        name: 'my_plan.addons.push_notification.title',
       }),
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('dp-addon-card-push-notification')).getByText(
-        hasPriceInBold('US$ 15,00'),
+        hasPriceInBold(/US\$\s*15[.,]00/),
       ),
     ).toBeInTheDocument();
   });
 
   it('should hide Push Notification when can buy env var is not true', async () => {
-    await renderNewPlanSelection(['/new-plan-selection'], {
-      features: { ecoIAEnabled: true },
-    });
+    await renderNewPlanSelection(
+      ['/new-plan-selection'],
+      {
+        features: { ecoIAEnabled: true },
+      },
+      { useI18nKeysAsValues: true },
+    );
 
-    fireEvent.click(within(getAddOnsSection()).getByRole('button', { name: /siguiente add-on/i }));
-
-    expect(within(getAddOnsSection()).queryByText(/Notificaciones Push/i)).not.toBeInTheDocument();
+    expect(
+      within(getAddOnsSection()).queryByText('my_plan.addons.push_notification.title'),
+    ).not.toBeInTheDocument();
   });
 
   it('should keep add-ons section visible with fallback price when one add-on source fails', async () => {
-    await renderNewPlanSelection(['/new-plan-selection'], {
-      dopplerAccountPlansApiClient: {
-        getAddOnPlans: jest.fn(async (addOnType) => {
-          if (addOnType === AddOnType.OnSite) {
-            return { success: false, error: 'Unexpected error' };
-          }
+    await renderNewPlanSelection(
+      ['/new-plan-selection'],
+      {
+        dopplerAccountPlansApiClient: {
+          getAddOnPlans: jest.fn(async (addOnType) => {
+            if (addOnType === AddOnType.OnSite) {
+              return { success: false, error: 'Unexpected error' };
+            }
 
-          return { success: true, value: addOnPlansByType[addOnType] || [] };
-        }),
+            return { success: true, value: addOnPlansByType[addOnType] || [] };
+          }),
+        },
       },
-    });
+      { useI18nKeysAsValues: true },
+    );
 
     await waitFor(() =>
       expect(
-        within(screen.getByTestId('dp-addon-card-onsite')).getByText(/Precio no disponible/i),
+        within(screen.getByTestId('dp-addon-card-onsite')).getByText(
+          'buy_process.new_plan_selection.addons_section.price_unavailable',
+        ),
       ).toBeInTheDocument(),
     );
     expect(
       within(screen.getByTestId('dp-addon-card-conversations')).getByRole('heading', {
-        name: /Conversaciones/i,
+        name: 'my_plan.addons.conversations.title',
       }),
     ).toBeInTheDocument();
-    expect(within(getAddOnsSection()).getByText(/Pack de Landing Pages/i)).toBeInTheDocument();
+    expect(
+      within(getAddOnsSection()).getByText('my_plan.addons.landing_pages.title'),
+    ).toBeInTheDocument();
   });
 
   it('should hide add-ons carousel and show empty message when all sources fail', async () => {
-    await renderNewPlanSelection(['/new-plan-selection'], {
-      dopplerAccountPlansApiClient: {
-        getAddOnPlans: jest.fn(async () => ({ success: false, error: 'Unexpected error' })),
-        getLandingPacks: jest.fn(async () => ({ success: false, error: 'Unexpected error' })),
+    await renderNewPlanSelection(
+      ['/new-plan-selection'],
+      {
+        dopplerAccountPlansApiClient: {
+          getAddOnPlans: jest.fn(async () => ({ success: false, error: 'Unexpected error' })),
+          getLandingPacks: jest.fn(async () => ({ success: false, error: 'Unexpected error' })),
+        },
       },
-    });
+      { useI18nKeysAsValues: true },
+    );
 
     await waitFor(() =>
       expect(
-        within(getAddOnsSection()).getByText(/No hay Add-ons disponibles en este momento/i),
+        within(getAddOnsSection()).getByText(
+          'buy_process.new_plan_selection.addons_section.empty_message',
+        ),
       ).toBeInTheDocument(),
     );
     expect(within(getAddOnsSection()).queryByTestId(/dp-addon-card-/)).not.toBeInTheDocument();
     expect(
-      within(getAddOnsSection()).queryByRole('button', { name: /siguiente add-on/i }),
+      within(getAddOnsSection()).queryByRole('button', {
+        name: 'buy_process.new_plan_selection.addons_section.next',
+      }),
     ).not.toBeInTheDocument();
   });
 
@@ -503,7 +544,7 @@ describe('NewPlanSelection component', () => {
       expect(choosePlanHref).not.toContain('PromoCode=');
     });
 
-    fireEvent.change(screen.getByRole('combobox', { name: contactsLabelPattern }), {
+    fireEvent.change(getContactsSelect(), {
       target: { value: '1' },
     });
     await settleAsyncState();
@@ -519,7 +560,7 @@ describe('NewPlanSelection component', () => {
   it('should update selected contacts plan in checkout URL when contacts dropdown changes', async () => {
     await renderNewPlanSelection();
 
-    fireEvent.change(screen.getByRole('combobox', { name: contactsLabelPattern }), {
+    fireEvent.change(getContactsSelect(), {
       target: { value: '1' },
     });
     await settleAsyncState();
@@ -535,7 +576,7 @@ describe('NewPlanSelection component', () => {
   it('should update selected credits plan in checkout URL when credits dropdown changes', async () => {
     await renderNewPlanSelection();
 
-    fireEvent.change(screen.getByRole('combobox', { name: creditsLabelPattern }), {
+    fireEvent.change(getCreditsSelect(), {
       target: { value: '1' },
     });
     await settleAsyncState();
@@ -578,16 +619,12 @@ describe('NewPlanSelection component', () => {
   it('should show tailored price and advisor CTA for more than 100k option', async () => {
     await renderNewPlanSelection();
 
-    fireEvent.change(screen.getByRole('combobox', { name: contactsLabelPattern }), {
+    fireEvent.change(getContactsSelect(), {
       target: { value: 'more-than-100000' },
     });
     await settleAsyncState();
 
-    await waitFor(() =>
-      expect(screen.getByRole('combobox', { name: contactsLabelPattern })).toHaveValue(
-        'more-than-100000',
-      ),
-    );
+    await waitFor(() => expect(getContactsSelect()).toHaveValue('more-than-100000'));
 
     const infoBanner = screen.getByTestId('dp-more-than-100k-message');
     expect(infoBanner).toBeInTheDocument();

--- a/src/components/BuyProcess/ShoppingCart/utils.js
+++ b/src/components/BuyProcess/ShoppingCart/utils.js
@@ -276,8 +276,8 @@ export const mapItemFromMarketingPlan = ({
   }
 
   if (
-    promocodeApplied?.planType === PLAN_TYPE.byCredit &&
-    promocodeApplied?.promotionApplied?.extraCredits > 0
+    marketingPlan.type === PLAN_TYPE.byCredit &&
+    amountDetailsData?.value?.discountPromocode?.extraCredits > 0
   ) {
     planInformation.featureList.push(
       <>
@@ -287,7 +287,7 @@ export const mapItemFromMarketingPlan = ({
             values={{
               units: thousandSeparatorNumber(
                 intl.defaultLocale,
-                promocodeApplied?.promotionApplied?.extraCredits,
+                amountDetailsData?.value?.discountPromocode?.extraCredits,
               ),
             }}
           />

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -162,6 +162,14 @@ other {}}}}}}}}}}
     months_to_hire: 'Months to hire:',
     months_to_pay: 'Months to pay:',
     new_plan_selection: {
+      addons_section: {
+        empty_message: 'There are no Add-ons available right now.',
+        next: 'Next Add-on',
+        previous: 'Previous Add-on',
+        price_unavailable: 'Price unavailable',
+        subtitle: 'Add extra solutions to expand the reach of your strategy.',
+        title: 'Explore our Add-ons to boost your Plan',
+      },
       buy_credits: 'Buy Credits',
       choose_plan: 'Choose Plan',
       contact_advisor_cta: 'Contact an Advisor',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -163,6 +163,14 @@ other {}}}}}}}}}}
     months_to_hire: 'Meses a contratar:',
     months_to_pay: `Meses a abonar:`,
     new_plan_selection: {
+      addons_section: {
+        empty_message: 'No hay Add-ons disponibles en este momento.',
+        next: 'Siguiente Add-on',
+        previous: 'Anterior Add-on',
+        price_unavailable: 'Precio no disponible',
+        subtitle: 'Suma soluciones adicionales para ampliar el alcance de tu estrategia.',
+        title: 'Explora nuestros Add-ons para potenciar tu Plan',
+      },
       buy_credits: 'Comprar Creditos',
       choose_plan: 'Elegir Plan',
       contact_advisor_cta: 'Contactar a Asesor',


### PR DESCRIPTION
## Summary
- implement section 4 of New Plan Selection with a new `AddOnsSection` component under CreditsPlan
- render informational add-on cards (no CTA/navigation) using real minimum prices from add-on/landing APIs
- add conditional cards for Eco IA (`features.ecoIAEnabled`) and Push Notification (`REACT_APP_DOPPLER_CAN_BUY_PUSHNOTIFICATION_PLAN === 'true'`)
- keep partial-failure fallback per card and add empty-state message when all sources fail
- update checkout URLs in Contacts/Credits cards to include `buyType=1`
- update ShoppingCart credits extra-credits source to use amount details promocode data
- adjust tests and i18n keys for the new section and behavior

## Source of truth
- SPEC: `docs/specs/SPEC_20260514_plan-contactos-seccion-4-addons.md`

## Validation
- `yarn prettier-check`
- `yarn test:ci`
