### PR TITLE
fix: auto go-back after successful upgrade suggestion submit

### DIFF
--- a/src/components/DopplerPlus/UpgradeSuggestionForm.js
+++ b/src/components/DopplerPlus/UpgradeSuggestionForm.js
@@ -17,10 +17,12 @@ import { getFormInitialValues } from '../../utils';
 import { FAQSection } from '../BuyProcess/NewPlanSelection/FAQSection';
 import { NewPlanSelectionStyled } from '../BuyProcess/NewPlanSelection/index.styles';
 import { GoBackButton } from '../BuyProcess/NewPlanSelection/GoBackButton';
+import useTimeout from '../../hooks/useTimeout';
 
 const UpgradeSuggestionForm = ({ dependencies: { dopplerLegacyClient, appSessionRef } }) => {
   const intl = useIntl();
   const _ = (id, values) => intl.formatMessage({ id: id }, values);
+  const createTimeout = useTimeout();
 
   const [formSubmitted, setFormSubmitted] = useState(false);
 
@@ -51,6 +53,9 @@ const UpgradeSuggestionForm = ({ dependencies: { dopplerLegacyClient, appSession
       const result = await dopplerLegacyClient.requestSuggestionUpgradeForm(values);
       if (result) {
         setFormSubmitted(true);
+        createTimeout(() => {
+          window.history.back();
+        }, 3000);
       }
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
## Summary
- add `useTimeout` in `UpgradeSuggestionForm`
- after successful submit, keep success message visible and navigate back automatically after 3 seconds (`window.history.back()`)
- preserve current `master` layout/content (including back button and FAQ section), adding only the auto-back behavior

## Testing
- `yarn prettier --write src/components/DopplerPlus/UpgradeSuggestionForm.js`
- `yarn test --watchAll=false --coverage=false src/components/DopplerPlus/UpgradeSuggestionForm.test.js`

## Notes
- rebased on latest `origin/master` before push
