### PR TITLE
fix(new-plan-selection): ocultar duración de promocode cuando es 0 en ContactsPlan

### DIFF
--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -472,7 +472,11 @@ export const ContactsPlan = InjectAppServices(
                   <span> </span>
                   <span className="dp-new-plan-selection-savings">
                     <FormattedMessage
-                      id="buy_process.new_plan_selection.promocode_savings_text"
+                      id={
+                        Number(promocodeDuration) > 0
+                          ? 'buy_process.new_plan_selection.promocode_savings_text'
+                          : 'buy_process.new_plan_selection.promocode_savings_text_without_months'
+                      }
                       values={{
                         percentage: promocodeDiscountPercentage,
                         months: promocodeDuration,

--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -1324,6 +1324,10 @@ describe('NewPlanSelection component', () => {
     );
 
     expect(
+      within(getContactsPlanSection()).queryByText(/durante 0 meses/i),
+    ).not.toBeInTheDocument();
+    expect(within(getContactsPlanSection()).getByText(/Ahorras 10%/i)).toBeInTheDocument();
+    expect(
       within(screen.getByTestId('dp-sticky-plan-summary')).queryByText(/por.*mes/i),
     ).not.toBeInTheDocument();
   });

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -226,6 +226,7 @@ other {}}}}}}}}}}
       popular_label: 'POPULAR',
       price_label: 'Price',
       promocode_savings_text: 'You save {percentage}% for {months, plural, one {# month} other {# months}}',
+      promocode_savings_text_without_months: 'You save {percentage}%',
       savings_text: 'You save {percentage}% with 1 {period} payment of {currency}{total}',
       single_payment_period: 'one-time payment',
       sticky_contacts_subtitle: 'Up to {contacts} Contacts + Unlimited emails',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -227,6 +227,7 @@ other {}}}}}}}}}}
       popular_label: 'POPULAR',
       price_label: 'Precio',
       promocode_savings_text: 'Ahorras {percentage}% durante {months, plural, one {# mes} other {# meses}}',
+      promocode_savings_text_without_months: 'Ahorras {percentage}%',
       savings_text: 'Ahorras {percentage}% realizando 1 pago {period} de {currency}{total}',
       single_payment_period: 'pago unico',
       sticky_contacts_subtitle: 'Hasta {contacts} Contactos + Envios ilimitados',


### PR DESCRIPTION
## Resumen
Este PR corrige un issue visual/funcional en `NewPlanSelection` (sección `ContactsPlan`): cuando el promocode tiene `duration = 0`, la UI mostraba el texto **"durante 0 meses"**, lo cual es incorrecto.

Con este cambio, cuando la duración es 0 (o no mayor a 0), se muestra solo el ahorro porcentual, sin meses.

## Problema detectado
En la tarjeta de precio de `ContactsPlan`, el mensaje de ahorro por promocode siempre usaba la key con duración en meses:
- `buy_process.new_plan_selection.promocode_savings_text`

Eso generaba textos como:
- `Ahorras 20% durante 0 meses`

## Solución implementada
### 1) Render condicional del mensaje de ahorro
En `ContactsPlan`, el mensaje ahora selecciona la key según `promocodeDuration`:
- si `promocodeDuration > 0`: usa `promocode_savings_text`
- si `promocodeDuration <= 0`: usa `promocode_savings_text_without_months`

Archivo:
- `src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js`

### 2) Nuevas keys i18n para el caso sin duración
Se agregaron textos sin meses para ambos idiomas:

- ES: `buy_process.new_plan_selection.promocode_savings_text_without_months = "Ahorras {percentage}%"`
- EN: `buy_process.new_plan_selection.promocode_savings_text_without_months = "You save {percentage}%"`

Archivos:
- `src/i18n/es.js`
- `src/i18n/en.js`

### 3) Cobertura de tests
Se reforzó el test del escenario `duration = 0` para validar también la card de `ContactsPlan`:
- no debe aparecer `durante 0 meses`
- sí debe aparecer el texto de ahorro sin duración

Archivo:
- `src/components/BuyProcess/NewPlanSelection/index.test.js`

## Archivos modificados
- `src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js`
- `src/components/BuyProcess/NewPlanSelection/index.test.js`
- `src/i18n/es.js`
- `src/i18n/en.js`

## Validaciones ejecutadas
- Formato (Prettier) sobre archivos modificados:
  - `./node_modules/.bin/prettier --check ...`
- Tests relacionados:
  - `yarn test:related --runInBand src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js src/components/BuyProcess/NewPlanSelection/index.test.js`

Resultado:
- Tests relacionados en verde (`2` suites, `67` tests).

## Impacto
- Corrige el copy mostrado al usuario en un caso de promocode válido sin duración en meses.
- No cambia lógica de cálculo de precio/descuento.
- No afecta los mensajes de sticky (ya contemplaban el caso sin meses).