### PR TITLE
[codex] limitar el autofill de promocode de contactos al plan de contactos

### DIFF
--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { PLAN_TYPE } from '../../../../doppler-types';
+import { useQueryParams } from '../../../../hooks/useQueryParams';
 import { InjectAppServices } from '../../../../services/pure-di';
 import { amountByPlanType, thousandSeparatorNumber } from '../../../../utils';
 import {
@@ -112,6 +113,7 @@ export const ContactsPlan = InjectAppServices(
     dependencies: { dopplerAccountPlansApiClient },
   }) => {
     const intl = useIntl();
+    const query = useQueryParams();
     const _ = (id, values) => intl.formatMessage({ id }, values);
     const isFreeAccount = sessionPlan?.plan?.isFreeAccount;
     const isEqualPlan = sessionPlan?.plan?.idPlan === selectedPlan?.id;
@@ -125,6 +127,20 @@ export const ContactsPlan = InjectAppServices(
       () => getSessionPromocodeApplied(sessionPlan),
       [sessionPlan],
     );
+    const contactsPromocode = useMemo(() => {
+      const rawValue = process.env.REACT_APP_PROMOCODE_CONTACTS?.trim() || '';
+      if (!rawValue || rawValue === 'undefined' || rawValue === 'null') {
+        return '';
+      }
+
+      const hasPromocodeInUrl = Boolean(
+        query.get('promo-code')?.trim() ||
+        query.get('Promo-code')?.trim() ||
+        query.get('PromoCode')?.trim(),
+      );
+      const isCreditPlan = sessionPlan?.plan?.planType === PLAN_TYPE.byCredit;
+      return !hasPromocodeInUrl && (isFreeAccount || isCreditPlan) ? rawValue : '';
+    }, [isFreeAccount, query, sessionPlan?.plan?.planType]);
     const effectivePromocodeApplied =
       promocodeApplied ?? (!defaultPromocodeDismissed ? sessionPromocodeApplied : null);
 
@@ -384,6 +400,7 @@ export const ContactsPlan = InjectAppServices(
                       hasPromocodeAppliedItem={Boolean(effectivePromocodeApplied?.promocode)}
                       isArgentina={sessionPlan.locationCountry === 'ar'}
                       isFreeAccount={isFreeAccount}
+                      defaultPromocode={contactsPromocode}
                       disabledPromocode={false}
                       handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                       currentPromocodeApplied={effectivePromocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
@@ -175,6 +175,7 @@ export const CreditsPlan = InjectAppServices(
                     hasPromocodeAppliedItem={Boolean(promocodeApplied?.promocode)}
                     isArgentina={sessionPlan.locationCountry === 'ar'}
                     isFreeAccount={sessionPlan?.plan?.isFreeAccount}
+                    defaultPromocode={null}
                     disabledPromocode={false}
                     handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                     currentPromocodeApplied={promocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
@@ -281,6 +281,7 @@ export const EmailsPlan = InjectAppServices(
                     hasPromocodeAppliedItem={Boolean(effectivePromocodeApplied?.promocode)}
                     isArgentina={sessionPlan.locationCountry === 'ar'}
                     isFreeAccount={isFreeAccount}
+                    defaultPromocode={null}
                     disabledPromocode={false}
                     handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                     currentPromocodeApplied={effectivePromocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
@@ -53,6 +53,7 @@ export const Promocode = InjectAppServices(
     hasPromocodeAppliedItem,
     isArgentina,
     isFreeAccount,
+    defaultPromocode,
     disabledPromocode,
     handleRemovePromocodeApplied,
     currentPromocodeApplied,
@@ -63,7 +64,9 @@ export const Promocode = InjectAppServices(
     dependencies: { dopplerAccountPlansApiClient },
   }) => {
     const query = useQueryParams();
-    const defaultPromocode = getPromocode(query, isArgentina, isFreeAccount);
+    const defaultPromocodeValue = defaultPromocode
+      ? defaultPromocode
+      : getPromocode(query, isArgentina, isFreeAccount);
     const promocodeFromUrl = getPromocodeFromQuery(query);
     const contactsPromocode = getContactsPromocode();
     const [currentPromotion, setCurrentPromotion] = useState(undefined);
@@ -308,7 +311,7 @@ export const Promocode = InjectAppServices(
       }
 
       const promoCodeFromState = currentPromocodeApplied?.promocode || '';
-      const promoCodeToInitialize = promoCodeFromState || defaultPromocode;
+      const promoCodeToInitialize = promoCodeFromState || defaultPromocodeValue;
 
       if (promoCodeToInitialize && allowPromocode && selectedMarketingPlan?.id) {
         const { setFieldValue } = promocodeInputRef.current;
@@ -330,7 +333,7 @@ export const Promocode = InjectAppServices(
     }, [
       validatePromocode,
       allowPromocode,
-      defaultPromocode,
+      defaultPromocodeValue,
       selectedMarketingPlan,
       isArgentina,
       defaultPromocodeDismissed,
@@ -342,7 +345,7 @@ export const Promocode = InjectAppServices(
       let initialValues = getFormInitialValues(fieldNames);
       initialValues[fieldNames.promocode] = defaultPromocodeDismissed
         ? ''
-        : currentPromocodeApplied?.promocode || defaultPromocode || '';
+        : currentPromocodeApplied?.promocode || defaultPromocodeValue || '';
 
       return initialValues;
     };
@@ -412,6 +415,7 @@ Promocode.propTypes = {
   selectedPaymentFrequency: PropTypes.object,
   hasPromocodeAppliedItem: PropTypes.bool, // it allows to know if a promocode was applied or not in Shopping Cart
   isFreeAccount: PropTypes.bool,
+  defaultPromocode: PropTypes.string,
   defaultPromocodeDismissed: PropTypes.bool,
   handleManualPromocodeIntervention: PropTypes.func,
   registerClearPromocodeInput: PropTypes.func,

--- a/src/components/BuyProcess/NewPlanSelection/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { PLAN_TYPE } from '../../../doppler-types';
 import { InjectAppServices } from '../../../services/pure-di';
 import { Loading } from '../../Loading/Loading';
@@ -18,20 +18,6 @@ import { NewPlanSelectionStyled } from './index.styles';
 const MORE_THAN_100K_OPTION_VALUE = 'more-than-100000';
 const LESS_THAN_100K_EMAILS_OPTION_VALUE = 'less-than-100000';
 const MORE_THAN_10M_EMAILS_OPTION_VALUE = 'more-than-10000000';
-const getContactsPromocode = () => {
-  const rawValue = process.env.REACT_APP_PROMOCODE_CONTACTS?.trim() || '';
-  if (!rawValue || rawValue === 'undefined' || rawValue === 'null') {
-    return '';
-  }
-
-  return rawValue;
-};
-
-const getPromocodeFromParams = (params) =>
-  params.get('promo-code')?.trim() ||
-  params.get('Promo-code')?.trim() ||
-  params.get('PromoCode')?.trim() ||
-  '';
 
 const getPlanIndexByQueryOrSession = ({ plans, search, sessionPlan, planType }) => {
   const query = new URLSearchParams(search);
@@ -86,10 +72,8 @@ const getPlanIndexByQueryOrSession = ({ plans, search, sessionPlan, planType }) 
 
 export const NewPlanSelection = InjectAppServices(
   ({ dependencies: { appSessionRef, planService } }) => {
-    const { pathname, search } = useLocation();
-    const navigate = useNavigate();
+    const { search } = useLocation();
     const sessionPlan = appSessionRef.current.userData.user;
-    const { isFreeAccount } = sessionPlan.plan;
     const [plansByContact, setPlansByContact] = useState([]);
     const [plansByCredit, setPlansByCredit] = useState([]);
     const [plansByEmail, setPlansByEmail] = useState([]);
@@ -102,28 +86,6 @@ export const NewPlanSelection = InjectAppServices(
     const [isLessThan100kEmailsSelected, setIsLessThan100kEmailsSelected] = useState(false);
     const [isMoreThan10mEmailsSelected, setIsMoreThan10mEmailsSelected] = useState(false);
     const [stickySummaryData, setStickySummaryData] = useState(null);
-
-    useEffect(() => {
-      const contactsPromocode = getContactsPromocode();
-      if (!contactsPromocode) {
-        return;
-      }
-
-      if (!isFreeAccount) {
-        return;
-      }
-
-      const params = new URLSearchParams(search);
-      const currentPromocode = getPromocodeFromParams(params);
-      if (currentPromocode) {
-        return;
-      }
-
-      params.delete('PromoCode');
-      params.delete('Promo-code');
-      params.set('promo-code', contactsPromocode);
-      navigate({ pathname, search: `?${params.toString()}` }, { replace: true });
-    }, [isFreeAccount, navigate, pathname, search]);
 
     useEffect(() => {
       const fetchPlans = async () => {

--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -717,6 +717,33 @@ describe('NewPlanSelection component', () => {
     }
   });
 
+  it('should load REACT_APP_PROMOCODE_CONTACTS automatically in contacts plan for paid users with credit plans when URL has no promocode', async () => {
+    const previousContactsPromocode = process.env.REACT_APP_PROMOCODE_CONTACTS;
+    process.env.REACT_APP_PROMOCODE_CONTACTS = 'DOPPLER50X6';
+    try {
+      await renderNewPlanSelection(
+        ['/new-plan-selection'],
+        {
+          appSessionUser: {
+            plan: {
+              idPlan: 20222,
+              planType: PLAN_TYPE.byCredit,
+              isFreeAccount: false,
+              planSubscription: 1,
+            },
+          },
+        },
+        { useI18nKeysAsValues: true },
+      );
+
+      await waitFor(() =>
+        expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('DOPPLER50X6'),
+      );
+    } finally {
+      process.env.REACT_APP_PROMOCODE_CONTACTS = previousContactsPromocode;
+    }
+  });
+
   it('should not reapply default promocode after removing it from contacts input', async () => {
     const user = userEvent.setup();
     await renderNewPlanSelection(['/new-plan-selection?Promo-code=DOPPLER50X6']);


### PR DESCRIPTION
## Qué cambió
- Limita el autofill de `REACT_APP_PROMOCODE_CONTACTS` solo al componente `ContactsPlan`.
- Evita que el promocode de contactos se aplique en el flujo de créditos.
- Mantiene la prioridad de los promocodes ingresados por query params.
- Actualiza los tests relacionados de `NewPlanSelection` para validar el nuevo comportamiento.

## Por qué
El promocode de contactos debe completarse automáticamente solo en planes relacionados con contactos. El flujo de créditos no debe heredar ese valor por defecto.

## Validaciones
- `yarn prettier-check`
- `yarn test:related -- src/components/BuyProcess/NewPlanSelection/index.test.js --runInBand`
