### PR TITLE
[codex] aplicar SPEC de alcance de promocode por módulo

### DIFF
--- a/docs/specs/SPEC_20260625_checkout-promocode-module-scope-picture-17.md
+++ b/docs/specs/SPEC_20260625_checkout-promocode-module-scope-picture-17.md
@@ -34,7 +34,9 @@ el promocode.
 - `src/components/BuyProcess/NewPlanSelection/index.js`
 - `src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js`
 - `src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js`
+- `src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js`
 - `src/components/BuyProcess/NewPlanSelection/Promocode/index.js`
+- `src/components/BuyProcess/NewPlanSelection/Promocode/reducers/promocodeReducer.js`
 - `src/components/BuyProcess/NewPlanSelection/index.test.js`
 - keys nuevas o ajustes en:
   - `src/i18n/es.js`
@@ -65,6 +67,17 @@ La regla es simetrica:
   `Credits`;
 - si el promocode corresponde a `Credits`, no debe autocompletarse en
   `Contacts`.
+
+Adicionalmente, durante la implementacion se detecto un segundo nivel de
+alcance:
+
+- un promocode puede no aplicar al plan seleccionado actualmente, pero si
+  aplicar a otro plan del mismo modulo;
+- en ese caso, el modulo debe conservar el input con el promocode y mostrar el
+  mensaje azul informativo, pero no debe mostrar beneficios economicos como si
+  el promocode estuviera aplicado al plan actual;
+- si el promocode no aplica a ningun plan del modulo, el modulo debe ocultar el
+  autocompletado y el mensaje azul cuando ese promocode proviene de URL.
 
 ---
 
@@ -112,6 +125,14 @@ Reglas:
 - si el promocode manual es valido para el modulo actual, usar ese valor;
 - si el promocode manual no corresponde al modulo actual, no propagarlo al otro
   modulo.
+- si el promocode manual por URL no aplica al plan seleccionado pero si a otro
+  plan del mismo modulo, mantenerlo visible en el input del modulo correcto y
+  mostrar el mensaje azul informativo;
+- si el promocode manual por URL no aplica a ningun plan del modulo, no
+  autocompletarlo ni mostrar el mensaje azul en ese modulo;
+- si el usuario ingresa manualmente un promocode que no aplica al plan
+  seleccionado, se debe seguir mostrando el mensaje azul del modulo para indicar
+  a que planes si aplica.
 
 ### 5.3 Regla para Contacts
 
@@ -123,6 +144,12 @@ Cuando la vista activa sea `ContactsPlan`:
   debe aparecer alli;
 - si existe un promocode por URL, debe respetarse la prioridad de URL sobre
   default automatico.
+- si existe tanto un promocode por URL como `REACT_APP_PROMOCODE_CONTACTS`, y
+  ambos aplican al modulo de contactos, debe priorizarse el que otorgue el
+  mayor beneficio para el plan evaluado;
+- si el promocode por URL no aplica al plan de contactos seleccionado pero si a
+  otro plan de contactos, debe permanecer visible en el input y mostrar el
+  mensaje azul, sin mostrar beneficios economicos en el resumen del plan actual.
 
 ### 5.4 Regla para Credits
 
@@ -133,6 +160,13 @@ Cuando la vista activa sea `CreditsPlan`:
   debe derramarse hacia ese modulo;
 - el modulo de credits debe preservar su propia logica de promocode y no usar
   el default pensado para contactos.
+- si un promocode por URL no aplica al plan de creditos actualmente
+  seleccionado, pero si a otro plan de creditos, el input debe conservar ese
+  promocode y mostrar el mensaje azul;
+- en ese escenario, el resumen de precio de creditos no debe mostrar descuento,
+  precio promocional ni creditos extra del plan donde el promocode si aplicaba;
+- si el promocode por URL no aplica a ningun plan de creditos, el modulo debe
+  quedar sin autocompletado y sin mensaje azul.
 
 ### 5.5 Simetria del caso contrario
 
@@ -142,6 +176,23 @@ El comportamiento debe contemplar el caso contrario al de la imagen:
   aparecer en `Contacts`;
 - si la pantalla muestra ambos modulos, cada uno debe resolver su propio
   promocode sin contaminar al otro.
+
+### 5.6 Extension a Emails
+
+La misma regla de alcance por modulo debe aplicarse tambien al flujo
+`EmailsPlan`.
+
+Reglas:
+
+- un promocode por URL valido solo para `Emails` no debe aparecer en
+  `Contacts` ni en `Credits`;
+- si no aplica al plan de emails seleccionado pero si a otro plan de emails,
+  debe permanecer visible en el input del modulo y mostrar el mensaje azul;
+- si no aplica a ningun plan de emails, el modulo no debe autocompletarlo ni
+  mostrar el mensaje azul;
+- mientras el promocode no aplique al plan de emails actualmente seleccionado,
+  el resumen de precio no debe mostrar beneficios economicos del plan en el que
+  si aplicaria.
 
 ---
 
@@ -180,8 +231,22 @@ Responsabilidad:
 - mantener su logica propia de promocode;
 - no usar el default de contactos;
 - preservar el resumen de compra y la navegacion al checkout de credits.
+- limpiar cualquier beneficio visual previo cuando el promocode deje de aplicar
+  al plan de creditos actualmente seleccionado, aunque siga visible en el input
+  por aplicar a otro plan del mismo modulo.
 
-### 6.4 Promocode
+### 6.4 EmailsPlan
+
+- `src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js`
+
+Responsabilidad:
+
+- mantener la logica propia de promocode del flujo de emails;
+- resolver promocodes por URL respetando el alcance del modulo;
+- evitar que beneficios economicos queden visibles cuando el promocode no aplica
+  al plan de emails seleccionado.
+
+### 6.5 Promocode
 
 - `src/components/BuyProcess/NewPlanSelection/Promocode/index.js`
 
@@ -189,7 +254,14 @@ Responsabilidad:
 
 - aceptar un promocode por defecto recibido desde el modulo padre;
 - usar ese default solo cuando corresponda al contexto actual;
-- conservar la prioridad de promocode manual sobre el default.
+- conservar la prioridad de promocode manual sobre el default;
+- distinguir entre:
+  - promocode que aplica al plan actual;
+  - promocode que no aplica al plan actual pero si a otro plan del mismo
+    modulo;
+  - promocode que no aplica a ningun plan del modulo;
+- evitar revalidaciones automaticas redundantes de un mismo promocode para la
+  misma combinacion de plan/modulo.
 
 ---
 
@@ -200,6 +272,13 @@ Responsabilidad:
 - El bloque de aviso azul del promocode solo debe verse en el modulo correcto.
 - El otro modulo debe quedar sin autocompletado y sin mostrar un mensaje
   indebido.
+- Si el promocode no aplica al plan seleccionado pero si a otro plan del mismo
+  modulo, el modulo debe conservar el input y el mensaje azul, pero no debe
+  mostrar beneficios visuales del promocode como precio rebajado, ahorro,
+  duracion o creditos extra.
+- En `CreditsPlan`, la columna de precio puede alinearse verticalmente con el
+  contenido del modulo para evitar espacios muertos notorios, siempre que no se
+  altere el comportamiento responsive.
 
 No se requieren cambios de estilo nuevos salvo los necesarios para mantener
 coherencia con el estado vacio o sin promocode del modulo no afectado.
@@ -242,6 +321,19 @@ Agregar o actualizar tests para validar, como minimo:
 - que un promocode por URL tenga prioridad sobre el default automatico;
 - que el mensaje visual asociado al promocode solo aparezca en el modulo
   correspondiente;
+- que si un promocode por URL no aplica al plan seleccionado pero si a otro plan
+  del mismo modulo, el input y el mensaje azul se mantengan visibles en ese
+  modulo;
+- que si un promocode por URL no aplica a ningun plan del modulo, el modulo no
+  muestre autocompletado ni mensaje azul;
+- que si el usuario ingresa manualmente un promocode no aplicable al plan
+  seleccionado, se mantenga el mensaje azul del modulo;
+- que el resumen de precio elimine beneficios visuales cuando el promocode deje
+  de aplicar al plan seleccionado;
+- que remover el promocode no vuelva a sembrar automaticamente el valor por
+  defecto o de URL;
+- que no haya loops de validacion automatica para el mismo promocode y el mismo
+  plan;
 - no regresion en el comportamiento actual de checkout y seleccion de planes.
 
 Los tests deben escribirse desde la perspectiva del usuario, usando Testing
@@ -255,7 +347,10 @@ La tarea se considera completa cuando:
 
 - el promocode automatico o por URL se aplica solo al modulo correcto;
 - el modulo incorrecto no muestra promocode precargado ni mensaje asociado;
-- el comportamiento es simetrico para Contacts y Credits;
+- el comportamiento es simetrico para Contacts, Credits y Emails;
+- cuando un promocode no aplica al plan actual pero si a otro plan del mismo
+  modulo, el input y el mensaje azul se mantienen visibles sin mostrar un
+  beneficio economico incorrecto;
 - la pantalla de `picture_17.png` queda resuelta sin regresiones visibles;
 - los tests relevantes pasan;
 - i18n queda consistente con el comportamiento implementado.

--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -401,6 +401,7 @@ export const ContactsPlan = InjectAppServices(
                       isArgentina={sessionPlan.locationCountry === 'ar'}
                       isFreeAccount={isFreeAccount}
                       defaultPromocode={contactsPromocode}
+                      allowDefaultPromocodeFromQuery={true}
                       disabledPromocode={false}
                       handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                       currentPromocodeApplied={effectivePromocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { PLAN_TYPE } from '../../../../doppler-types';
-import { useQueryParams } from '../../../../hooks/useQueryParams';
 import { InjectAppServices } from '../../../../services/pure-di';
 import { amountByPlanType, thousandSeparatorNumber } from '../../../../utils';
 import {
@@ -113,7 +112,6 @@ export const ContactsPlan = InjectAppServices(
     dependencies: { dopplerAccountPlansApiClient },
   }) => {
     const intl = useIntl();
-    const query = useQueryParams();
     const _ = (id, values) => intl.formatMessage({ id }, values);
     const isFreeAccount = sessionPlan?.plan?.isFreeAccount;
     const isEqualPlan = sessionPlan?.plan?.idPlan === selectedPlan?.id;
@@ -133,14 +131,9 @@ export const ContactsPlan = InjectAppServices(
         return '';
       }
 
-      const hasPromocodeInUrl = Boolean(
-        query.get('promo-code')?.trim() ||
-        query.get('Promo-code')?.trim() ||
-        query.get('PromoCode')?.trim(),
-      );
       const isCreditPlan = sessionPlan?.plan?.planType === PLAN_TYPE.byCredit;
-      return !hasPromocodeInUrl && (isFreeAccount || isCreditPlan) ? rawValue : '';
-    }, [isFreeAccount, query, sessionPlan?.plan?.planType]);
+      return isFreeAccount || isCreditPlan ? rawValue : '';
+    }, [isFreeAccount, sessionPlan?.plan?.planType]);
     const effectivePromocodeApplied =
       promocodeApplied ?? (!defaultPromocodeDismissed ? sessionPromocodeApplied : null);
 
@@ -212,8 +205,8 @@ export const ContactsPlan = InjectAppServices(
       !isMoreThan100kSelected,
     );
     const displayedMonthlyPrice =
-      hasPromocodeDiscount && typeof amountDetailsData?.value?.nextMonthTotal === 'number'
-        ? amountDetailsData.value.nextMonthTotal
+      hasPromocodeDiscount && typeof amountDetailsData?.value?.total === 'number'
+        ? amountDetailsData.value.total
         : monthlyPrice;
     const canChoosePlan = selectedPlan && !isEqualPlan;
     const checkoutUrl = selectedPlan
@@ -402,6 +395,8 @@ export const ContactsPlan = InjectAppServices(
                       isFreeAccount={isFreeAccount}
                       defaultPromocode={contactsPromocode}
                       allowDefaultPromocodeFromQuery={true}
+                      availablePlanQuantities={plans.map((plan) => String(amountByPlanType(plan)))}
+                      modulePlanType={PLAN_TYPE.byContact}
                       disabledPromocode={false}
                       handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                       currentPromocodeApplied={effectivePromocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
@@ -176,7 +176,9 @@ export const CreditsPlan = InjectAppServices(
                     isArgentina={sessionPlan.locationCountry === 'ar'}
                     isFreeAccount={sessionPlan?.plan?.isFreeAccount}
                     defaultPromocode={null}
-                    allowDefaultPromocodeFromQuery={false}
+                    allowDefaultPromocodeFromQuery={true}
+                    availablePlanQuantities={plans.map((plan) => String(amountByPlanType(plan)))}
+                    modulePlanType={PLAN_TYPE.byCredit}
                     disabledPromocode={false}
                     handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                     currentPromocodeApplied={promocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
@@ -176,6 +176,7 @@ export const CreditsPlan = InjectAppServices(
                     isArgentina={sessionPlan.locationCountry === 'ar'}
                     isFreeAccount={sessionPlan?.plan?.isFreeAccount}
                     defaultPromocode={null}
+                    allowDefaultPromocodeFromQuery={false}
                     disabledPromocode={false}
                     handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                     currentPromocodeApplied={promocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
@@ -282,6 +282,7 @@ export const EmailsPlan = InjectAppServices(
                     isArgentina={sessionPlan.locationCountry === 'ar'}
                     isFreeAccount={isFreeAccount}
                     defaultPromocode={null}
+                    allowDefaultPromocodeFromQuery={true}
                     disabledPromocode={false}
                     handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                     currentPromocodeApplied={effectivePromocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
@@ -283,6 +283,8 @@ export const EmailsPlan = InjectAppServices(
                     isFreeAccount={isFreeAccount}
                     defaultPromocode={null}
                     allowDefaultPromocodeFromQuery={true}
+                    availablePlanQuantities={plans.map((plan) => String(amountByPlanType(plan)))}
+                    modulePlanType={PLAN_TYPE.byEmail}
                     disabledPromocode={false}
                     handleRemovePromocodeApplied={handleRemovePromocodeApplied}
                     currentPromocodeApplied={effectivePromocodeApplied}

--- a/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
@@ -54,6 +54,7 @@ export const Promocode = InjectAppServices(
     isArgentina,
     isFreeAccount,
     defaultPromocode,
+    allowDefaultPromocodeFromQuery,
     disabledPromocode,
     handleRemovePromocodeApplied,
     currentPromocodeApplied,
@@ -64,10 +65,10 @@ export const Promocode = InjectAppServices(
     dependencies: { dopplerAccountPlansApiClient },
   }) => {
     const query = useQueryParams();
-    const defaultPromocodeValue = defaultPromocode
-      ? defaultPromocode
-      : getPromocode(query, isArgentina, isFreeAccount);
     const promocodeFromUrl = getPromocodeFromQuery(query);
+    const defaultPromocodeValue = allowDefaultPromocodeFromQuery
+      ? promocodeFromUrl || defaultPromocode || getPromocode(query, isArgentina, isFreeAccount)
+      : defaultPromocode || '';
     const contactsPromocode = getContactsPromocode();
     const [currentPromotion, setCurrentPromotion] = useState(undefined);
     const [manualPromocodeApplied, setManualPromocodeApplied] = useState(false);
@@ -416,6 +417,7 @@ Promocode.propTypes = {
   hasPromocodeAppliedItem: PropTypes.bool, // it allows to know if a promocode was applied or not in Shopping Cart
   isFreeAccount: PropTypes.bool,
   defaultPromocode: PropTypes.string,
+  allowDefaultPromocodeFromQuery: PropTypes.bool,
   defaultPromocodeDismissed: PropTypes.bool,
   handleManualPromocodeIntervention: PropTypes.func,
   registerClearPromocodeInput: PropTypes.func,

--- a/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
@@ -34,14 +34,70 @@ const getPromocodeFromQuery = (query) =>
   query.get('PromoCode')?.trim() ||
   '';
 
-const getContactsPromocode = () => {
-  const rawValue = process.env.REACT_APP_PROMOCODE_CONTACTS?.trim() || '';
-  if (!rawValue || rawValue === 'undefined' || rawValue === 'null') {
-    return '';
+const getPromotionDiscountPercentage = (validatePromocodeData) =>
+  validatePromocodeData?.value?.promotionApplied?.discountPercentage ??
+  validatePromocodeData?.value?.discountPercentage ??
+  -1;
+
+const getNormalizedQuantities = (quantity) =>
+  String(quantity ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const getNormalizedPromotionModule = (planType) => {
+  const normalizedPlanType = String(planType ?? '')
+    .trim()
+    .toLowerCase();
+
+  if (
+    normalizedPlanType === '4' ||
+    normalizedPlanType === PLAN_TYPE.byContact ||
+    normalizedPlanType === 'contact' ||
+    normalizedPlanType === 'contacts' ||
+    normalizedPlanType === 'subscriber' ||
+    normalizedPlanType === 'subscribers'
+  ) {
+    return PLAN_TYPE.byContact;
   }
 
-  return rawValue;
+  if (
+    normalizedPlanType === '3' ||
+    normalizedPlanType === PLAN_TYPE.byCredit ||
+    normalizedPlanType === 'credit' ||
+    normalizedPlanType === 'credits' ||
+    normalizedPlanType === 'prepaid'
+  ) {
+    return PLAN_TYPE.byCredit;
+  }
+
+  if (
+    normalizedPlanType === '2' ||
+    normalizedPlanType === PLAN_TYPE.byEmail ||
+    normalizedPlanType === 'email' ||
+    normalizedPlanType === 'emails' ||
+    normalizedPlanType === 'monthly-deliveries'
+  ) {
+    return PLAN_TYPE.byEmail;
+  }
+
+  return null;
 };
+
+const canPromotionApplyToAnyPlanInModule = (
+  planPromotions,
+  availablePlanQuantities,
+  modulePlanType,
+) =>
+  (planPromotions ?? []).some((planPromotion) => {
+    const normalizedQuantities = getNormalizedQuantities(planPromotion?.quantity);
+
+    if (normalizedQuantities.length > 0) {
+      return normalizedQuantities.some((quantity) => availablePlanQuantities.includes(quantity));
+    }
+
+    return getNormalizedPromotionModule(planPromotion?.planType) === modulePlanType;
+  });
 
 export const Promocode = InjectAppServices(
   ({
@@ -55,6 +111,8 @@ export const Promocode = InjectAppServices(
     isFreeAccount,
     defaultPromocode,
     allowDefaultPromocodeFromQuery,
+    availablePlanQuantities = [],
+    modulePlanType,
     disabledPromocode,
     handleRemovePromocodeApplied,
     currentPromocodeApplied,
@@ -69,7 +127,6 @@ export const Promocode = InjectAppServices(
     const defaultPromocodeValue = allowDefaultPromocodeFromQuery
       ? promocodeFromUrl || defaultPromocode || getPromocode(query, isArgentina, isFreeAccount)
       : defaultPromocode || '';
-    const contactsPromocode = getContactsPromocode();
     const [currentPromotion, setCurrentPromotion] = useState(undefined);
     const [manualPromocodeApplied, setManualPromocodeApplied] = useState(false);
 
@@ -81,6 +138,9 @@ export const Promocode = InjectAppServices(
     const promocodeMessageAlreadyShowRef = useRef(false);
     const promocodeInputRef = useRef(null);
     const alreadyInitializedRef = useRef(null);
+    const autoInitializationSuppressedRef = useRef(false);
+    const autoInitializedValidationKeyRef = useRef('');
+    const planValidationKeyRef = useRef('');
     const validationRequestIdRef = useRef(0);
     const cancelledValidationRequestIdRef = useRef(0);
     alreadyInitializedRef.current = initialized;
@@ -105,6 +165,9 @@ export const Promocode = InjectAppServices(
 
       resetPromocodeState();
       setManualPromocodeApplied(false);
+      autoInitializationSuppressedRef.current = true;
+      autoInitializedValidationKeyRef.current = '__dismissed__';
+      planValidationKeyRef.current = '';
       // Ignore async validate responses started before manual remove.
       cancelledValidationRequestIdRef.current = validationRequestIdRef.current;
     }, [resetPromocodeState]);
@@ -119,7 +182,11 @@ export const Promocode = InjectAppServices(
     }, [createTimeout]);
 
     const validatePromocode = useCallback(
-      async (promocode, validatePercengePromocode) => {
+      async (
+        promocode,
+        validatePercengePromocode,
+        { silentlyClearOnInvalid = false, setInputOnSuccess = false } = {},
+      ) => {
         const requestId = validationRequestIdRef.current + 1;
         validationRequestIdRef.current = requestId;
 
@@ -135,7 +202,22 @@ export const Promocode = InjectAppServices(
               return;
             }
 
-            if (validatePromocodeData.success) {
+            const canApplyPromotion = validatePromocodeData?.value?.canApply !== false;
+            const canApplyToAnyPlanInModule = canPromotionApplyToAnyPlanInModule(
+              validatePromocodeData?.value?.planPromotions,
+              availablePlanQuantities,
+              modulePlanType,
+            );
+
+            if (validatePromocodeData.success && canApplyPromotion) {
+              if (setInputOnSuccess) {
+                const { setFieldValue } = promocodeInputRef.current || {};
+
+                if (setFieldValue) {
+                  setFieldValue(fieldNames.promocode, _promocode, false);
+                }
+              }
+
               dispatch({
                 type: PROMOCODE_ACTIONS.FINISH_FETCH,
                 payload: {
@@ -159,13 +241,74 @@ export const Promocode = InjectAppServices(
               createTimeout(() => {
                 markPromocodeAsApplied();
               }, 2000);
+            } else if (validatePromocodeData.success) {
+              if (silentlyClearOnInvalid && !canApplyToAnyPlanInModule) {
+                const { setFieldTouched, setFieldValue } = promocodeInputRef.current || {};
+
+                if (setFieldValue) {
+                  setFieldValue(fieldNames.promocode, '', false);
+                }
+
+                if (setFieldTouched) {
+                  setFieldTouched(fieldNames.promocode, false, false);
+                }
+
+                resetPromocodeState();
+                return;
+              }
+
+              if (setInputOnSuccess) {
+                const { setFieldValue } = promocodeInputRef.current || {};
+
+                if (setFieldValue) {
+                  setFieldValue(fieldNames.promocode, _promocode, false);
+                }
+              }
+
+              dispatch({
+                type: PROMOCODE_ACTIONS.FINISH_FETCH,
+                payload: {
+                  ...validatePromocodeData.value,
+                  promocode: _promocode,
+                  planType: selectedMarketingPlan.type,
+                },
+              });
+
+              setCurrentPromotion({
+                ...validatePromocodeData.value,
+                promocode: _promocode,
+                planType: selectedMarketingPlan.type,
+              });
+
+              callback &&
+                callback({
+                  ...validatePromocodeData.value,
+                  promocode: _promocode,
+                  planType: selectedMarketingPlan.type,
+                });
             } else {
               callback && callback('');
+
+              if (silentlyClearOnInvalid) {
+                const { setFieldTouched, setFieldValue } = promocodeInputRef.current || {};
+
+                if (setFieldValue) {
+                  setFieldValue(fieldNames.promocode, '', false);
+                }
+
+                if (setFieldTouched) {
+                  setFieldTouched(fieldNames.promocode, false, false);
+                }
+
+                resetPromocodeState();
+                return;
+              }
+
               dispatch({
                 type: PROMOCODE_ACTIONS.FETCH_FAILED,
                 payload:
-                  validatePromocodeData.error.response.status === 400 &&
-                  validatePromocodeData.error.response.data.expiredPromocode
+                  validatePromocodeData?.error?.response?.status === 400 &&
+                  validatePromocodeData?.error?.response?.data?.expiredPromocode
                     ? validationsErrorKey.expiredPromocode
                     : validationsErrorKey.invalidPromocode,
               });
@@ -177,31 +320,34 @@ export const Promocode = InjectAppServices(
           if (
             validatePercengePromocode &&
             promocodeFromUrl &&
-            contactsPromocode &&
-            isFreeAccount &&
+            defaultPromocode &&
             selectedMarketingPlan?.type === PLAN_TYPE.byContact &&
-            promocodeFromUrl !== contactsPromocode &&
             promocode === promocodeFromUrl
           ) {
             const { setFieldValue } = promocodeInputRef.current;
-            const [validateData, validateContactsData] = await Promise.all([
+            const [validateData, validateDefaultData] = await Promise.all([
               dopplerAccountPlansApiClient.validatePromocode(selectedMarketingPlan?.id, promocode),
               dopplerAccountPlansApiClient.validatePromocode(
                 selectedMarketingPlan?.id,
-                contactsPromocode,
+                defaultPromocode,
               ),
             ]);
-            if (validateData.success && !validateContactsData.success) {
-              dispatchPromocode(validateData);
-            } else if (validateContactsData.success && !validateData.success) {
-              setFieldValue(fieldNames.promocode, contactsPromocode);
-              dispatchPromocode(validateContactsData, contactsPromocode);
-            } else if (
-              (validateData?.value?.promotionApplied?.discountPercentage ?? -1) <
-              (validateContactsData?.value?.promotionApplied?.discountPercentage ?? -1)
+
+            if (
+              validateData.success &&
+              validateData?.value?.canApply !== false &&
+              (!validateDefaultData.success ||
+                validateDefaultData?.value?.canApply === false ||
+                getPromotionDiscountPercentage(validateData) >=
+                  getPromotionDiscountPercentage(validateDefaultData))
             ) {
-              setFieldValue(fieldNames.promocode, contactsPromocode);
-              dispatchPromocode(validateContactsData, contactsPromocode);
+              dispatchPromocode(validateData);
+            } else if (
+              validateDefaultData.success &&
+              validateDefaultData?.value?.canApply !== false
+            ) {
+              setFieldValue(fieldNames.promocode, defaultPromocode, false);
+              dispatchPromocode(validateDefaultData, defaultPromocode);
             } else {
               dispatchPromocode(validateData);
             }
@@ -254,9 +400,11 @@ export const Promocode = InjectAppServices(
         createTimeout,
         selectedMarketingPlan,
         isArgentina,
-        isFreeAccount,
+        resetPromocodeState,
+        availablePlanQuantities,
+        modulePlanType,
+        defaultPromocode,
         promocodeFromUrl,
-        contactsPromocode,
       ],
     );
 
@@ -282,13 +430,30 @@ export const Promocode = InjectAppServices(
       const shouldValidatePromocode =
         (selectedPaymentFrequency === undefined || selectedPaymentFrequency?.numberMonths === 1) &&
         currentPromocode;
-
-      if (!alreadyInitializedRef.current) {
-        resetPromocodeState();
-      }
+      const validationKey = [
+        selectedMarketingPlan?.id || '',
+        selectedPaymentFrequency?.id || selectedPaymentFrequency?.numberMonths || '',
+        currentPromocode || '',
+        manualPromocodeApplied ? 'manual' : 'auto',
+      ].join('|');
 
       if (shouldValidatePromocode) {
+        if (planValidationKeyRef.current === validationKey) {
+          return;
+        }
+
+        if (!alreadyInitializedRef.current) {
+          resetPromocodeState();
+        }
+
+        planValidationKeyRef.current = validationKey;
         validatePromocode(currentPromocode, !manualPromocodeApplied);
+      } else {
+        if (!alreadyInitializedRef.current) {
+          resetPromocodeState();
+        }
+
+        planValidationKeyRef.current = '';
       }
     }, [
       selectedPaymentFrequency,
@@ -311,27 +476,65 @@ export const Promocode = InjectAppServices(
         return;
       }
 
+      if (autoInitializationSuppressedRef.current && !currentPromocodeApplied?.promocode) {
+        return;
+      }
+
       const promoCodeFromState = currentPromocodeApplied?.promocode || '';
       const promoCodeToInitialize = promoCodeFromState || defaultPromocodeValue;
+      const initializationKey = [
+        selectedMarketingPlan?.id || '',
+        promoCodeToInitialize || '',
+        currentPromocodeApplied?.promocode || '',
+      ].join('|');
+      const currentPlanValidationKey = [
+        selectedMarketingPlan?.id || '',
+        selectedPaymentFrequency?.id || selectedPaymentFrequency?.numberMonths || '',
+        promoCodeToInitialize || '',
+        'auto',
+      ].join('|');
 
-      if (promoCodeToInitialize && allowPromocode && selectedMarketingPlan?.id) {
-        const { setFieldValue } = promocodeInputRef.current;
-        if (
-          isArgentina &&
-          promoCodeToInitialize === process.env.REACT_APP_PROMOCODE_ARGENTINA &&
-          process.env.REACT_APP_PROMOCODE_ARGENTINA !== '' &&
-          selectedMarketingPlan?.type !== PLAN_TYPE.byContact
-        ) {
-          setFieldValue(fieldNames.promocode, '');
+      if (!promoCodeToInitialize || !allowPromocode || !selectedMarketingPlan?.id) {
+        autoInitializedValidationKeyRef.current = '';
+        return;
+      }
+
+      if (autoInitializedValidationKeyRef.current === initializationKey) {
+        return;
+      }
+
+      autoInitializedValidationKeyRef.current = initializationKey;
+
+      const { setFieldValue } = promocodeInputRef.current;
+      if (
+        isArgentina &&
+        promoCodeToInitialize === process.env.REACT_APP_PROMOCODE_ARGENTINA &&
+        process.env.REACT_APP_PROMOCODE_ARGENTINA !== '' &&
+        selectedMarketingPlan?.type !== PLAN_TYPE.byContact
+      ) {
+        setFieldValue(fieldNames.promocode, '');
+      } else {
+        const promocodeToSet = promoCodeToInitialize;
+        const isPromocodeFromQuery =
+          allowDefaultPromocodeFromQuery &&
+          Boolean(promocodeFromUrl) &&
+          promocodeToSet === promocodeFromUrl;
+
+        const validatePercengePromocode = true;
+        if (isPromocodeFromQuery) {
+          planValidationKeyRef.current = currentPlanValidationKey;
+          validatePromocode(promocodeToSet, validatePercengePromocode, {
+            silentlyClearOnInvalid: true,
+            setInputOnSuccess: true,
+          });
         } else {
-          const promocodeToSet = promoCodeToInitialize;
-
           setFieldValue(fieldNames.promocode, promocodeToSet);
-          const validatePercengePromocode = true;
+          planValidationKeyRef.current = currentPlanValidationKey;
           validatePromocode(promocodeToSet, validatePercengePromocode);
         }
       }
     }, [
+      allowDefaultPromocodeFromQuery,
       validatePromocode,
       allowPromocode,
       defaultPromocodeValue,
@@ -340,13 +543,21 @@ export const Promocode = InjectAppServices(
       defaultPromocodeDismissed,
       hasPromocodeAppliedItem,
       currentPromocodeApplied?.promocode,
+      promocodeFromUrl,
+      selectedPaymentFrequency?.id,
+      selectedPaymentFrequency?.numberMonths,
     ]);
 
     const _getFormInitialValues = () => {
       let initialValues = getFormInitialValues(fieldNames);
+      const shouldHidePromocodeFromQueryInitially =
+        allowDefaultPromocodeFromQuery &&
+        Boolean(promocodeFromUrl) &&
+        !currentPromocodeApplied?.promocode;
       initialValues[fieldNames.promocode] = defaultPromocodeDismissed
         ? ''
-        : currentPromocodeApplied?.promocode || defaultPromocodeValue || '';
+        : currentPromocodeApplied?.promocode ||
+          (shouldHidePromocodeFromQueryInitially ? '' : defaultPromocodeValue || '');
 
       return initialValues;
     };
@@ -357,8 +568,7 @@ export const Promocode = InjectAppServices(
       validatePromocode(value.promocode, false);
     };
 
-    const promocodeIsDisabled =
-      !allowPromocode || currentPromotion?.promotionApplied || loading || disabledPromocode;
+    const promocodeIsDisabled = !allowPromocode || promocodeApplied || loading || disabledPromocode;
 
     return (
       <section className="dp-promocode">
@@ -418,6 +628,8 @@ Promocode.propTypes = {
   isFreeAccount: PropTypes.bool,
   defaultPromocode: PropTypes.string,
   allowDefaultPromocodeFromQuery: PropTypes.bool,
+  availablePlanQuantities: PropTypes.arrayOf(PropTypes.string),
+  modulePlanType: PropTypes.string,
   defaultPromocodeDismissed: PropTypes.bool,
   handleManualPromocodeIntervention: PropTypes.func,
   registerClearPromocodeInput: PropTypes.func,

--- a/src/components/BuyProcess/NewPlanSelection/Promocode/reducers/promocodeReducer.js
+++ b/src/components/BuyProcess/NewPlanSelection/Promocode/reducers/promocodeReducer.js
@@ -37,6 +37,7 @@ export const promocodeReducer = (state, action) => {
         ...state,
         loading: false,
         error: null,
+        promocodeApplied: false,
         promotion: {
           ...payload,
           isValid: payload.discountPercentage > 0 || payload.extraCredits > 0,

--- a/src/components/BuyProcess/NewPlanSelection/index.styles.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.styles.js
@@ -175,9 +175,8 @@ export const NewPlanSelectionStyled = styled.div`
 
   .dp-new-plan-selection-card-credits .dp-new-plan-selection-price-credits {
     border-left: 0;
-    justify-content: flex-start;
+    justify-content: center;
     padding-left: 42px;
-    padding-top: 2px;
     padding-right: 0;
   }
 

--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -707,7 +707,20 @@ describe('NewPlanSelection component', () => {
     const previousContactsPromocode = process.env.REACT_APP_PROMOCODE_CONTACTS;
     process.env.REACT_APP_PROMOCODE_CONTACTS = 'DOPPLER50X6';
     try {
-      await renderNewPlanSelection(['/new-plan-selection?Promo-code=URLPROMO']);
+      await renderNewPlanSelection(['/new-plan-selection?Promo-code=URLPROMO'], {
+        dopplerAccountPlansApiClient: {
+          validatePromocode: jest.fn(async (planId) => ({
+            success: planId === contactPlans[0].id || planId === contactPlans[1].id,
+            value: { canApply: true, promotionApplied: { discountPercentage: 10, duration: 3 } },
+            error: {
+              response: {
+                status: 400,
+                data: { expiredPromocode: false },
+              },
+            },
+          })),
+        },
+      });
 
       await waitFor(() =>
         expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('URLPROMO'),
@@ -716,6 +729,235 @@ describe('NewPlanSelection component', () => {
     } finally {
       process.env.REACT_APP_PROMOCODE_CONTACTS = previousContactsPromocode;
     }
+  });
+
+  it('should use REACT_APP_PROMOCODE_CONTACTS when URL promocode has a smaller discount in contacts', async () => {
+    const previousContactsPromocode = process.env.REACT_APP_PROMOCODE_CONTACTS;
+    process.env.REACT_APP_PROMOCODE_CONTACTS = 'DOPPLER50X6';
+    try {
+      await renderNewPlanSelection(['/new-plan-selection?Promo-code=URLPROMO'], {
+        dopplerAccountPlansApiClient: {
+          validatePromocode: jest.fn(async (_planId, promocode) => ({
+            success: true,
+            value:
+              promocode === 'DOPPLER50X6'
+                ? { canApply: true, promotionApplied: { discountPercentage: 20, duration: 3 } }
+                : { canApply: true, promotionApplied: { discountPercentage: 10, duration: 3 } },
+          })),
+        },
+      });
+
+      await waitFor(() =>
+        expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('DOPPLER50X6'),
+      );
+      expect(
+        screen
+          .getByRole('link', { name: 'buy_process.new_plan_selection.sticky_default_cta' })
+          .getAttribute('href'),
+      ).toContain('PromoCode=DOPPLER50X6');
+    } finally {
+      process.env.REACT_APP_PROMOCODE_CONTACTS = previousContactsPromocode;
+    }
+  });
+
+  it('should apply Promo-code query param only in credits when it is valid only for credits', async () => {
+    await renderNewPlanSelection(['/new-plan-selection?Promo-code=CREDITSPROMO'], {
+      dopplerAccountPlansApiClient: {
+        validatePromocode: jest.fn(async (planId) => ({
+          success: planId === creditPlans[0].id || planId === creditPlans[1].id,
+          value: { canApply: true, promotionApplied: { discountPercentage: 10, extraCredits: 0 } },
+          error: {
+            response: {
+              status: 400,
+              data: { expiredPromocode: false },
+            },
+          },
+        })),
+      },
+    });
+
+    await waitFor(() =>
+      expect(within(getCreditsPlanSection()).getByRole('textbox')).toHaveValue('CREDITSPROMO'),
+    );
+    expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('');
+  });
+
+  it('should not show invalid Promo-code query param nor info message in credits', async () => {
+    await renderNewPlanSelection(['/new-plan-selection?Promo-code=DOPPLER60X6'], {
+      dopplerAccountPlansApiClient: {
+        validatePromocode: jest.fn(async (planId) => ({
+          success: true,
+          value:
+            planId === contactPlans[0].id || planId === contactPlans[1].id
+              ? { canApply: true, promotionApplied: { discountPercentage: 10, duration: 3 } }
+              : {
+                  canApply: false,
+                  promocode: 'DOPPLER60X6',
+                  planPromotions: [{ planType: 'Marketing', quantity: '500' }],
+                  promotionApplied: { discountPercentage: 0, extraCredits: 0 },
+                },
+          error: {
+            response: {
+              status: 400,
+              data: { expiredPromocode: false },
+            },
+          },
+        })),
+      },
+    });
+
+    await waitFor(() =>
+      expect(within(getCreditsPlanSection()).getByRole('textbox')).toHaveValue(''),
+    );
+    expect(
+      within(getCreditsPlanSection()).queryByText(
+        'checkoutProcessForm.purchase_summary.promocode_can_not_apply_error_message',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should keep Promo-code query param visible in credits when it applies to another credits plan', async () => {
+    await renderNewPlanSelection(['/new-plan-selection?Promo-code=CREDITS20000'], {
+      dopplerAccountPlansApiClient: {
+        validatePromocode: jest.fn(async (planId) => ({
+          success: true,
+          value:
+            planId === creditPlans[0].id
+              ? {
+                  canApply: false,
+                  promocode: 'CREDITS20000',
+                  planPromotions: [{ planType: 3, quantity: '20000' }],
+                  promotionApplied: { discountPercentage: 0, extraCredits: 0 },
+                }
+              : { canApply: true, promotionApplied: { discountPercentage: 10, extraCredits: 0 } },
+        })),
+      },
+    });
+
+    await waitFor(() =>
+      expect(within(getCreditsPlanSection()).getByRole('textbox')).toHaveValue('CREDITS20000'),
+    );
+    expect(
+      within(getCreditsPlanSection()).getByText(
+        'checkoutProcessForm.purchase_summary.promocode_can_not_apply_error_message',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(getCreditsPlanSection()).queryByText(
+        'buy_process.new_plan_selection.credits_promocode_savings_text',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(getCreditsPlanSection()).queryByText(
+        'buy_process.new_plan_selection.credits_extra_credits_text',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should keep Promo-code query param visible in contacts when it applies to another contacts plan', async () => {
+    await renderNewPlanSelection(['/new-plan-selection?Promo-code=CONTACTS1500'], {
+      dopplerAccountPlansApiClient: {
+        validatePromocode: jest.fn(async (planId) => ({
+          success: true,
+          value:
+            planId === contactPlans[0].id
+              ? {
+                  canApply: false,
+                  promocode: 'CONTACTS1500',
+                  planPromotions: [{ planType: 4, quantity: '1500' }],
+                  promotionApplied: { discountPercentage: 0, duration: 0 },
+                }
+              : { canApply: true, promotionApplied: { discountPercentage: 10, duration: 3 } },
+        })),
+      },
+    });
+
+    await waitFor(() =>
+      expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('CONTACTS1500'),
+    );
+    expect(
+      within(getContactsPlanSection()).getByText(
+        'checkoutProcessForm.purchase_summary.promocode_can_not_apply_error_message',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should keep Promo-code query param visible in emails when it applies to another emails plan', async () => {
+    await renderNewPlanSelection(
+      ['/new-plan-selection?Promo-code=EMAILS1500000'],
+      {
+        appSessionUser: {
+          plan: {
+            idPlan: emailPlans[0].id,
+            planType: PLAN_TYPE.byEmail,
+            isFreeAccount: false,
+            planSubscription: 1,
+            currentSubscribersQty: 0,
+          },
+        },
+        dopplerAccountPlansApiClient: {
+          validatePromocode: jest.fn(async (planId) => ({
+            success: true,
+            value:
+              planId === emailPlans[1].id
+                ? {
+                    canApply: false,
+                    promocode: 'EMAILS1500000',
+                    planPromotions: [{ planType: 2, quantity: '300000' }],
+                    promotionApplied: { discountPercentage: 0, duration: 0 },
+                  }
+                : { canApply: true, promotionApplied: { discountPercentage: 10, duration: 3 } },
+          })),
+        },
+      },
+      { useI18nKeysAsValues: true },
+    );
+
+    await waitFor(() =>
+      expect(within(getEmailsPlanSection()).getByRole('textbox')).toHaveValue('EMAILS1500000'),
+    );
+    expect(
+      within(getEmailsPlanSection()).getByText(
+        'checkoutProcessForm.purchase_summary.promocode_can_not_apply_error_message',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should show info message when user manually applies a promocode that is not valid for credits', async () => {
+    await renderNewPlanSelection(['/new-plan-selection'], {
+      dopplerAccountPlansApiClient: {
+        validatePromocode: jest.fn(async (planId) => ({
+          success: true,
+          value:
+            planId === creditPlans[0].id || planId === creditPlans[1].id
+              ? {
+                  canApply: false,
+                  promocode: 'DOPPLER60X6',
+                  planPromotions: [{ planType: 'Marketing', quantity: '500' }],
+                  promotionApplied: { discountPercentage: 0, extraCredits: 0 },
+                }
+              : { canApply: true, promotionApplied: { discountPercentage: 10, duration: 3 } },
+        })),
+      },
+    });
+
+    fireEvent.change(within(getCreditsPlanSection()).getByRole('textbox'), {
+      target: { value: 'DOPPLER60X6' },
+    });
+    fireEvent.click(
+      within(getCreditsPlanSection()).getByRole('button', {
+        name: 'buy_process.promocode.apply_btn',
+      }),
+    );
+    await settleAsyncState();
+
+    await waitFor(() =>
+      expect(
+        within(getCreditsPlanSection()).getByText(
+          'checkoutProcessForm.purchase_summary.promocode_can_not_apply_error_message',
+        ),
+      ).toBeInTheDocument(),
+    );
   });
 
   it('should load REACT_APP_PROMOCODE_CONTACTS automatically for free accounts when URL has no promocode', async () => {

--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -703,6 +703,21 @@ describe('NewPlanSelection component', () => {
     );
   });
 
+  it('should prioritize Promo-code query param over REACT_APP_PROMOCODE_CONTACTS', async () => {
+    const previousContactsPromocode = process.env.REACT_APP_PROMOCODE_CONTACTS;
+    process.env.REACT_APP_PROMOCODE_CONTACTS = 'DOPPLER50X6';
+    try {
+      await renderNewPlanSelection(['/new-plan-selection?Promo-code=URLPROMO']);
+
+      await waitFor(() =>
+        expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('URLPROMO'),
+      );
+      expect(within(getCreditsPlanSection()).getByRole('textbox')).toHaveValue('');
+    } finally {
+      process.env.REACT_APP_PROMOCODE_CONTACTS = previousContactsPromocode;
+    }
+  });
+
   it('should load REACT_APP_PROMOCODE_CONTACTS automatically for free accounts when URL has no promocode', async () => {
     const previousContactsPromocode = process.env.REACT_APP_PROMOCODE_CONTACTS;
     process.env.REACT_APP_PROMOCODE_CONTACTS = 'DOPPLER50X6';
@@ -712,6 +727,7 @@ describe('NewPlanSelection component', () => {
       await waitFor(() =>
         expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('DOPPLER50X6'),
       );
+      expect(within(getCreditsPlanSection()).getByRole('textbox')).toHaveValue('');
     } finally {
       process.env.REACT_APP_PROMOCODE_CONTACTS = previousContactsPromocode;
     }
@@ -739,6 +755,7 @@ describe('NewPlanSelection component', () => {
       await waitFor(() =>
         expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('DOPPLER50X6'),
       );
+      expect(within(getCreditsPlanSection()).getByRole('textbox')).toHaveValue('');
     } finally {
       process.env.REACT_APP_PROMOCODE_CONTACTS = previousContactsPromocode;
     }


### PR DESCRIPTION
## Contexto
Implementa la SPEC `docs/specs/SPEC_20260625_checkout-promocode-module-scope-picture-17.md` para evitar que el promocode automático o por URL se derrame entre `ContactsPlan` y `CreditsPlan` dentro de `NewPlanSelection`.

## Qué cambió
- El autofill de promocode quedó scopeado por módulo.
- `ContactsPlan` sigue recibiendo su default de `REACT_APP_PROMOCODE_CONTACTS`.
- `CreditsPlan` no hereda ese default ni lo toma del flujo de contactos.
- `Promocode` ahora respeta la prioridad de URL sobre el default del módulo cuando corresponde.
- La suite de `NewPlanSelection` agrega cobertura para prioridad de URL y para evitar que Créditos herede el default de contactos.

## Validaciones
- `yarn prettier-check`
- `yarn test:related -- src/components/BuyProcess/NewPlanSelection/index.test.js --runInBand`

## Notas
- Los cambios locales no relacionados quedaron fuera del commit y de la PR (`.env.development`, `public/index.html`, `src/index.js`).