### PR TITLE
fix: evitar la reaplicación automática de promocodes en NewPlanSelection

### DIFF
--- a/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js
@@ -123,6 +123,7 @@ export const ContactsPlan = InjectAppServices(
     const [amountDetailsData, setAmountDetailsData] = useState(null);
     const [promocodeApplied, setPromocodeApplied] = useState(null);
     const [defaultPromocodeDismissed, setDefaultPromocodeDismissed] = useState(false);
+    const [ignoreSessionPromocode, setIgnoreSessionPromocode] = useState(false);
     const clearPromocodeInputRef = useRef(null);
     const sessionPromocodeApplied = useMemo(
       () => getSessionPromocodeApplied(sessionPlan),
@@ -137,8 +138,9 @@ export const ContactsPlan = InjectAppServices(
       const isCreditPlan = sessionPlan?.plan?.planType === PLAN_TYPE.byCredit;
       return isFreeAccount || isCreditPlan ? rawValue : '';
     }, [isFreeAccount, sessionPlan?.plan?.planType]);
-    const effectivePromocodeApplied =
-      promocodeApplied ?? (!defaultPromocodeDismissed ? sessionPromocodeApplied : null);
+    const effectivePromocodeApplied = ignoreSessionPromocode
+      ? promocodeApplied
+      : (promocodeApplied ?? (!defaultPromocodeDismissed ? sessionPromocodeApplied : null));
 
     const paymentFrequencies = useMemo(
       () => selectedPlan?.billingCycleDetails?.map(mapDiscount).sort(orderAscendingDiscount) ?? [],
@@ -175,13 +177,17 @@ export const ContactsPlan = InjectAppServices(
     }, []);
 
     const handlePromocodeApplied = useCallback((promotion) => {
+      if (promotion && typeof promotion === 'object') {
+        setIgnoreSessionPromocode(true);
+      }
       setPromocodeApplied(promotion && typeof promotion === 'object' ? promotion : null);
     }, []);
 
     const handleRemovePromocodeApplied = useCallback(() => {
-      clearPromocodeInputRef.current?.();
       setDefaultPromocodeDismissed(true);
+      setIgnoreSessionPromocode(true);
       setPromocodeApplied(null);
+      clearPromocodeInputRef.current?.();
     }, []);
 
     const handleManualPromocodeIntervention = useCallback(() => {

--- a/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js
@@ -52,7 +52,9 @@ export const CreditsPlan = InjectAppServices(
     const [amountDetailsData, setAmountDetailsData] = useState(null);
     const [promocodeApplied, setPromocodeApplied] = useState(null);
     const [defaultPromocodeDismissed, setDefaultPromocodeDismissed] = useState(false);
+    const [ignoreSessionPromocode, setIgnoreSessionPromocode] = useState(false);
     const clearPromocodeInputRef = useRef(null);
+    const effectivePromocodeApplied = ignoreSessionPromocode ? promocodeApplied : promocodeApplied;
 
     useEffect(() => {
       const fetchAmountDetails = async () => {
@@ -61,7 +63,7 @@ export const CreditsPlan = InjectAppServices(
             selectedPlan.id,
             'Marketing',
             0,
-            promocodeApplied?.canApply ? promocodeApplied.promocode : '',
+            effectivePromocodeApplied?.canApply ? effectivePromocodeApplied.promocode : '',
           );
           setAmountDetailsData(amountDetails);
         } catch (error) {
@@ -72,16 +74,20 @@ export const CreditsPlan = InjectAppServices(
       if (selectedPlan?.id) {
         fetchAmountDetails();
       }
-    }, [dopplerAccountPlansApiClient, promocodeApplied, selectedPlan]);
+    }, [dopplerAccountPlansApiClient, effectivePromocodeApplied, selectedPlan]);
 
     const handlePromocodeApplied = useCallback((promotion) => {
+      if (promotion && typeof promotion === 'object') {
+        setIgnoreSessionPromocode(true);
+      }
       setPromocodeApplied(promotion && typeof promotion === 'object' ? promotion : null);
     }, []);
 
     const handleRemovePromocodeApplied = useCallback(() => {
-      clearPromocodeInputRef.current?.();
       setDefaultPromocodeDismissed(true);
+      setIgnoreSessionPromocode(true);
       setPromocodeApplied(null);
+      clearPromocodeInputRef.current?.();
     }, []);
 
     const handleManualPromocodeIntervention = useCallback(() => {
@@ -99,20 +105,20 @@ export const CreditsPlan = InjectAppServices(
     const promocodeDiscount = amountDetailsData?.value?.discountPromocode ?? null;
     const promocodeDiscountPercentage = promocodeDiscount?.discountPercentage ?? 0;
     const extraCredits = Math.max(
-      promocodeApplied?.promotionApplied?.extraCredits ?? 0,
+      effectivePromocodeApplied?.promotionApplied?.extraCredits ?? 0,
       promocodeDiscount?.extraCredits ?? 0,
     );
     const hasPromocodeDiscount = Boolean(
-      promocodeApplied?.canApply && promocodeDiscountPercentage > 0,
+      effectivePromocodeApplied?.canApply && promocodeDiscountPercentage > 0,
     );
-    const hasExtraCredits = Boolean(promocodeApplied?.canApply && extraCredits > 0);
+    const hasExtraCredits = Boolean(effectivePromocodeApplied?.canApply && extraCredits > 0);
     const displayedPrice =
       hasPromocodeDiscount && typeof amountDetailsData?.value?.total === 'number'
         ? amountDetailsData.value.total
         : planFee;
     const pricePerCredit = creditsAmount > 0 ? displayedPrice / creditsAmount : 0;
     const checkoutUrl = selectedPlan
-      ? getCheckoutUrl({ search, selectedPlan, promocodeApplied })
+      ? getCheckoutUrl({ search, selectedPlan, promocodeApplied: effectivePromocodeApplied })
       : '#';
 
     return (
@@ -172,7 +178,7 @@ export const CreditsPlan = InjectAppServices(
                     amountDetailsData={amountDetailsData}
                     selectedPaymentFrequency={undefined}
                     callback={handlePromocodeApplied}
-                    hasPromocodeAppliedItem={Boolean(promocodeApplied?.promocode)}
+                    hasPromocodeAppliedItem={Boolean(effectivePromocodeApplied?.promocode)}
                     isArgentina={sessionPlan.locationCountry === 'ar'}
                     isFreeAccount={sessionPlan?.plan?.isFreeAccount}
                     defaultPromocode={null}
@@ -181,7 +187,7 @@ export const CreditsPlan = InjectAppServices(
                     modulePlanType={PLAN_TYPE.byCredit}
                     disabledPromocode={false}
                     handleRemovePromocodeApplied={handleRemovePromocodeApplied}
-                    currentPromocodeApplied={promocodeApplied}
+                    currentPromocodeApplied={effectivePromocodeApplied}
                     registerClearPromocodeInput={registerClearPromocodeInput}
                     defaultPromocodeDismissed={defaultPromocodeDismissed}
                     handleManualPromocodeIntervention={handleManualPromocodeIntervention}

--- a/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js
@@ -78,13 +78,15 @@ export const EmailsPlan = InjectAppServices(
     const [amountDetailsData, setAmountDetailsData] = useState(null);
     const [promocodeApplied, setPromocodeApplied] = useState(null);
     const [defaultPromocodeDismissed, setDefaultPromocodeDismissed] = useState(false);
+    const [ignoreSessionPromocode, setIgnoreSessionPromocode] = useState(false);
     const clearPromocodeInputRef = useRef(null);
     const sessionPromocodeApplied = useMemo(
       () => getSessionPromocodeApplied(sessionPlan),
       [sessionPlan],
     );
-    const effectivePromocodeApplied =
-      promocodeApplied ?? (!defaultPromocodeDismissed ? sessionPromocodeApplied : null);
+    const effectivePromocodeApplied = ignoreSessionPromocode
+      ? promocodeApplied
+      : (promocodeApplied ?? (!defaultPromocodeDismissed ? sessionPromocodeApplied : null));
 
     useEffect(() => {
       const fetchAmountDetails = async () => {
@@ -107,13 +109,17 @@ export const EmailsPlan = InjectAppServices(
     }, [dopplerAccountPlansApiClient, effectivePromocodeApplied, selectedPlan]);
 
     const handlePromocodeApplied = useCallback((promotion) => {
+      if (promotion && typeof promotion === 'object') {
+        setIgnoreSessionPromocode(true);
+      }
       setPromocodeApplied(promotion && typeof promotion === 'object' ? promotion : null);
     }, []);
 
     const handleRemovePromocodeApplied = useCallback(() => {
-      clearPromocodeInputRef.current?.();
       setDefaultPromocodeDismissed(true);
+      setIgnoreSessionPromocode(true);
       setPromocodeApplied(null);
+      clearPromocodeInputRef.current?.();
     }, []);
 
     const handleManualPromocodeIntervention = useCallback(() => {

--- a/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
+++ b/src/components/BuyProcess/NewPlanSelection/Promocode/index.js
@@ -139,6 +139,7 @@ export const Promocode = InjectAppServices(
     const promocodeInputRef = useRef(null);
     const alreadyInitializedRef = useRef(null);
     const autoInitializationSuppressedRef = useRef(false);
+    const suppressValidationUntilPromocodeClearedRef = useRef(false);
     const autoInitializedValidationKeyRef = useRef('');
     const planValidationKeyRef = useRef('');
     const validationRequestIdRef = useRef(0);
@@ -166,6 +167,7 @@ export const Promocode = InjectAppServices(
       resetPromocodeState();
       setManualPromocodeApplied(false);
       autoInitializationSuppressedRef.current = true;
+      suppressValidationUntilPromocodeClearedRef.current = true;
       autoInitializedValidationKeyRef.current = '__dismissed__';
       planValidationKeyRef.current = '';
       // Ignore async validate responses started before manual remove.
@@ -427,6 +429,14 @@ export const Promocode = InjectAppServices(
     useEffect(() => {
       // In this case the user selects a payment frequency or an email marketing plan
       const currentPromocode = promocodeInputRef.current?.values[fieldNames.promocode];
+      if (suppressValidationUntilPromocodeClearedRef.current) {
+        if (!currentPromocode) {
+          suppressValidationUntilPromocodeClearedRef.current = false;
+        }
+
+        return;
+      }
+
       const shouldValidatePromocode =
         (selectedPaymentFrequency === undefined || selectedPaymentFrequency?.numberMonths === 1) &&
         currentPromocode;
@@ -473,6 +483,10 @@ export const Promocode = InjectAppServices(
     useEffect(() => {
       // In this case there is a promocode by default (By URL)
       if (defaultPromocodeDismissed) {
+        return;
+      }
+
+      if (suppressValidationUntilPromocodeClearedRef.current) {
         return;
       }
 

--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -992,11 +992,13 @@ describe('NewPlanSelection component', () => {
     await waitFor(() =>
       expect(within(getContactsPlanSection()).getByRole('textbox')).toHaveValue('CONTACTS1500'),
     );
-    expect(
-      within(getContactsPlanSection()).getByText(
-        'checkoutProcessForm.purchase_summary.promocode_can_not_apply_error_message',
-      ),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        within(getContactsPlanSection()).getByText(
+          'checkoutProcessForm.purchase_summary.promocode_can_not_apply_error_message',
+        ),
+      ).toBeInTheDocument(),
+    );
   });
 
   it('should keep Promo-code query param visible in emails when it applies to another emails plan', async () => {

--- a/src/components/Conversations/index.test.js
+++ b/src/components/Conversations/index.test.js
@@ -91,6 +91,7 @@ describe('Conversations component', () => {
         },
       },
     };
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // Act
     renderConversations(dependencies);
@@ -101,6 +102,11 @@ describe('Conversations component', () => {
     expect(
       screen.getByText('validation_messages.error_unexpected_register_MD'),
     ).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'activateConversationPlan failed: the backend returned an unsuccessful response',
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('should activate the plan automatically and redirect for a free account with expired trial (case 4)', async () => {


### PR DESCRIPTION
## Resumen

Este PR corrige el flujo de `PromoCode` en `NewPlanSelection` para que un código removido manualmente no vuelva a aplicarse de forma automática en los planes de Contactos, Emails y Créditos.

También deja cubierta una regresión de testing en `Conversations`, donde ahora se afirma explícitamente el `console.error` esperado cuando la activación del plan falla con una respuesta no exitosa del backend.

## Cambio principal a revisar

El punto más importante de este PR es el comportamiento de remoción del promocode en `NewPlanSelection`:

- si el usuario elimina el promocode, el código ya no debe reaparecer solo;
- el sticky summary y la URL de checkout deben quedar sincronizados con ese estado;
- los promocodes inicializados desde sesión o desde query params no deben pisar una remoción manual posterior.

## Root cause

Había una carrera entre tres cosas:

- la limpieza manual del input,
- la rehidratación del promocode desde sesión,
- la revalidación automática que corría mientras Formik todavía no había terminado de vaciar el campo.

Ese orden permitía que, después de borrar el promocode, el valor anterior reapareciera en el estado aplicado y volviera a propagarse a:

- la CTA de checkout,
- el sticky summary,
- y el parámetro `PromoCode` de la URL.

## Qué cambia en código

- Se agrega un estado explícito para ignorar el promocode de sesión después de una intervención manual en Contactos, Emails y Créditos.
- Se reordena el flujo de remoción para marcar el promocode como descartado antes de cualquier rehidratación posterior.
- Se bloquea temporalmente la revalidación automática mientras el input todavía se está limpiando, evitando la re-aplicación por carrera de estado.
- Se ajustan los tests de `NewPlanSelection` para cubrir mejor los escenarios con `Promo-code` por query string y los mensajes asíncronos de "no aplica".
- Se actualiza `Conversations/index.test.js` para absorber el warning de consola esperado y dejar esa expectativa explícita en la suite.

## Archivos incluidos

- `src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js`
- `src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js`
- `src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js`
- `src/components/BuyProcess/NewPlanSelection/Promocode/index.js`
- `src/components/BuyProcess/NewPlanSelection/index.test.js`
- `src/components/Conversations/index.test.js`

## Qué conviene validar en review

- Remover un promocode aplicado en Contactos y confirmar que no reaparece en el sticky ni en la URL.
- Cambiar entre planes con `Promo-code` inicializado por query param y confirmar que el comportamiento sigue siendo consistente.
- Verificar que el mensaje de "promocode no aplica" siga apareciendo cuando corresponde en cada módulo.
- Confirmar que el ajuste de `Conversations` solo reduce ruido de testing y no cambia comportamiento productivo.

## Validación ejecutada

- `yarn test:related -- src/components/BuyProcess/NewPlanSelection/index.test.js src/components/BuyProcess/NewPlanSelection/ContactsPlan/index.js src/components/BuyProcess/NewPlanSelection/CreditsPlan/index.js src/components/BuyProcess/NewPlanSelection/EmailsPlan/index.js src/components/BuyProcess/NewPlanSelection/Promocode/index.js src/components/Conversations/index.test.js`

Resultado:
- `PASS src/components/Conversations/index.test.js`
- `PASS src/components/BuyProcess/NewPlanSelection/index.test.js`
- `PASS src/App.test.js`

## Nota

El `prettier-check` global del repositorio sigue reportando un archivo no relacionado a este PR:
- `src/services/control-panel-service.ts`
