### PR TITLE
fix: improve mobile phone country selector

### DIFF
--- a/src/components/BuyProcess/NewPlanSelection/index.test.js
+++ b/src/components/BuyProcess/NewPlanSelection/index.test.js
@@ -2185,8 +2185,10 @@ describe('NewPlanSelection component', () => {
     ];
 
     for (const scenario of scenarios) {
-      fireEvent.click(within(contactsSection).getByRole('button', { name: scenario.buttonName }));
-      await settleAsyncState();
+      const paymentFrequencyButton = await within(contactsSection).findByRole('button', {
+        name: scenario.buttonName,
+      });
+      fireEvent.click(paymentFrequencyButton);
 
       await waitFor(() => {
         const savingsElement = contactsSection.querySelector(

--- a/src/components/Signup/Signup.test.js
+++ b/src/components/Signup/Signup.test.js
@@ -1,5 +1,6 @@
 import Signup from './Signup';
 import { render, cleanup, waitFor, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import DopplerIntlProvider from '../../i18n/DopplerIntlProvider';
 import DopplerIntlProviderWithIds from '../../i18n/DopplerIntlProvider.double-with-ids-as-values';
 import { MemoryRouter as Router, Route, Routes } from 'react-router-dom';
@@ -206,6 +207,30 @@ describe('Signup', () => {
 
     fireEvent.click(document.body);
     fireEvent.click(selectedFlag);
+
+    await waitFor(() =>
+      expect(document.body.querySelector('.iti__country-list')).not.toHaveClass('iti__hide'),
+    );
+  });
+
+  it('should open the country list when the phone input loses focus', async () => {
+    const user = userEvent.setup();
+    const location = { search: '', pathname: '/signup' };
+    const { container } = render(
+      <AppServicesProvider forcedServices={defaultDependencies}>
+        <DopplerIntlProvider locale="es">
+          <Router>
+            <Signup location={location} />
+          </Router>
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+
+    const phoneInput = container.querySelector('input#phone');
+    const selectedFlag = container.querySelector('.iti__selected-flag');
+    phoneInput.focus();
+
+    await user.click(selectedFlag);
 
     await waitFor(() =>
       expect(document.body.querySelector('.iti__country-list')).not.toHaveClass('iti__hide'),

--- a/src/components/Signup/Signup.test.js
+++ b/src/components/Signup/Signup.test.js
@@ -185,6 +185,52 @@ describe('Signup', () => {
     );
   });
 
+  it('should open the country list again after closing it', async () => {
+    const location = { search: '', pathname: '/signup' };
+    const { container } = render(
+      <AppServicesProvider forcedServices={defaultDependencies}>
+        <DopplerIntlProvider locale="es">
+          <Router>
+            <Signup location={location} />
+          </Router>
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+
+    const selectedFlag = container.querySelector('.iti__selected-flag');
+    fireEvent.click(selectedFlag);
+
+    await waitFor(() =>
+      expect(document.body.querySelector('.iti__country-list')).not.toHaveClass('iti__hide'),
+    );
+
+    fireEvent.click(document.body);
+    fireEvent.click(selectedFlag);
+
+    await waitFor(() =>
+      expect(document.body.querySelector('.iti__country-list')).not.toHaveClass('iti__hide'),
+    );
+  });
+
+  it('should select privacy policies with the first click', async () => {
+    const location = { search: '', pathname: '/signup' };
+    const { container } = render(
+      <AppServicesProvider forcedServices={defaultDependencies}>
+        <DopplerIntlProvider locale="es">
+          <Router>
+            <Signup location={location} />
+          </Router>
+        </DopplerIntlProvider>
+      </AppServicesProvider>,
+    );
+
+    const privacyPoliciesCheckbox = container.querySelector('input#accept_privacy_policies');
+
+    fireEvent.click(privacyPoliciesCheckbox);
+
+    expect(privacyPoliciesCheckbox).toBeChecked();
+  });
+
   it('should redirect to confirmation page when submit', async () => {
     // Arrange
     const dependencies = defaultDependencies;

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -347,7 +347,6 @@ const _PhoneFieldItem = ({
       autoPlaceholder: 'aggressive',
       preferredCountries: ['ar', 'mx', 'co', 'es', 'ec', 'cl', 'pe', 'us'],
       initialCountry: 'auto',
-      dropdownContainer: document.body,
       geoIpLookup: async (success) => {
         const countryCode = await ipinfoClient.getCountryCode();
         success(countryCode);
@@ -456,7 +455,6 @@ const _PhoneFieldItemAccessible = ({
       autoPlaceholder: 'aggressive',
       preferredCountries: ['ar', 'mx', 'co', 'es', 'ec', 'cl', 'pe', 'us'],
       initialCountry: 'auto',
-      dropdownContainer: document.body,
       geoIpLookup: async (success) => {
         const countryCode = await ipinfoClient.getCountryCode();
         success(countryCode);

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -481,26 +481,26 @@ const _PhoneFieldItemAccessible = ({
     <FieldItemAccessible className={className}>
       <label htmlFor={fieldName} className="labelcontrol" data-required={!!required}>
         {label}
-        <Field
-          type="tel"
-          innerRef={inputElRef}
-          name={fieldName}
-          id={fieldName}
-          placeholder={placeholder}
-          aria-placeholder={placeholder}
-          aria-required={required}
-          aria-invalid={showError}
-          onChange={handleChange}
-          onBlur={(e) => {
-            formatFieldValueAsInternationalNumber();
-            handleBlur(e);
-          }}
-          value={values[fieldName]}
-          validate={combineValidations(createRequiredValidation(required), validatePhone)}
-          {...rest}
-        />
-        <MessageError fieldName={fieldName} showError={showError} errors={errors} />
       </label>
+      <Field
+        type="tel"
+        innerRef={inputElRef}
+        name={fieldName}
+        id={fieldName}
+        placeholder={placeholder}
+        aria-placeholder={placeholder}
+        aria-required={required}
+        aria-invalid={showError}
+        onChange={handleChange}
+        onBlur={(e) => {
+          formatFieldValueAsInternationalNumber();
+          handleBlur(e);
+        }}
+        value={values[fieldName]}
+        validate={combineValidations(createRequiredValidation(required), validatePhone)}
+        {...rest}
+      />
+      <MessageError fieldName={fieldName} showError={showError} errors={errors} />
     </FieldItemAccessible>
   );
 };
@@ -1030,11 +1030,22 @@ export const CheckboxFieldItemAccessible = ({
         <Field
           type="checkbox"
           name={fieldName}
-          id={id || fieldName}
+          value={rest.value}
           validate={(value) => checkRequired && validateCheckRequired(value)}
-          onClick={onChange}
-          {...rest}
-        />
+        >
+          {({ field }) => (
+            <input
+              {...field}
+              type="checkbox"
+              id={id || fieldName}
+              onChange={(event) => {
+                field.onChange(event);
+                onChange?.(event);
+              }}
+              {...rest}
+            />
+          )}
+        </Field>
         <span>{label}</span>
       </label>
       {withErrors ? (

--- a/src/components/form-helpers/form-helpers.js
+++ b/src/components/form-helpers/form-helpers.js
@@ -18,8 +18,8 @@ import countriesLocalized from '../../i18n/countries-localized.json';
 import intlTelInput from 'intl-tel-input';
 // This import is required to add window.intlTelInputUtils, otherwise phone validation does not work
 import 'intl-tel-input/build/js/utils';
-import './form-helpers.scss';
 import 'intl-tel-input/build/css/intlTelInput.min.css';
+import './form-helpers.scss';
 import { FormattedMessageMarkdown } from '../../i18n/FormattedMessageMarkdown';
 import { InjectAppServices } from '../../services/pure-di';
 import { addLogEntry, concatClasses } from '../../utils';

--- a/src/components/form-helpers/form-helpers.scss
+++ b/src/components/form-helpers/form-helpers.scss
@@ -16,6 +16,10 @@
   z-index: 100;
 }
 
+.iti .iti__flag-container {
+  z-index: 1;
+}
+
 @media (max-width: 500px) {
   .iti--container {
     position: fixed;

--- a/src/components/form-helpers/form-helpers.scss
+++ b/src/components/form-helpers/form-helpers.scss
@@ -20,20 +20,18 @@
   z-index: 1;
 }
 
-@media (max-width: 500px) {
-  .iti--container {
-    position: fixed;
-    top: 30px;
-    right: 30px;
-    bottom: 30px;
-    left: 30px;
-    z-index: 1060;
-  }
+.iti--container {
+  position: fixed;
+  top: 30px;
+  right: 30px;
+  bottom: 30px;
+  left: 30px;
+  z-index: 1060;
+}
 
-  .iti--container .iti__country-list {
-    width: 100%;
-    max-height: 100%;
-  }
+.iti--container .iti__country-list {
+  width: 100%;
+  max-height: 100%;
 }
 
 .captcha-legal-message p {


### PR DESCRIPTION
## Source of truth
PROMPT ONLY — no versioned SPEC was provided.

## What changed
- Loads the local `intl-tel-input` overrides after the library stylesheet so its mobile selector is not repositioned off-screen.
- Keeps the detached mobile country-selector container visible in Safari/iPhone layouts.
- Adds coverage for opening the country list after the phone field loses focus.
- Stabilizes the NewPlanSelection payment-frequency test by waiting for each frequency button to render before interacting with it.

## Root cause
`intl-tel-input`'s stylesheet loaded after the app overrides and reset the detached selector container to `top/left: -1000px`. The selector opened logically (the arrow changed direction) but the country list was not visible.

## Validation
- `yarn prettier-check`
- `yarn stylelint`
- `yarn test:related -- src/components/Signup/Signup.test.js src/components/form-helpers/form-helpers.js`
- `yarn test:ci` (264 suites, 1,275 passing tests)

## User impact
People registering from Safari on iPhone can open and choose a country from the phone field.