### PR TITLE
[DOI-1680] Manage control panel section filtering for cm and collaborator

### DIFF
--- a/src/services/control-panel-service.test.ts
+++ b/src/services/control-panel-service.test.ts
@@ -88,4 +88,32 @@ describe('Control Panel Service', () => {
     expect(result[0].boxes[3].disabled).toBe(true);
     expect(result[0].boxes[4].disabled).toBe(true);
   });
+
+  it('should only show collaborator edition box for collaborators', async () => {
+    // Arrange
+    const userData = {
+      user: {
+        hasClientManager: false,
+        plan: {
+          isFreeAccount: false,
+        },
+      },
+      userAccount: {
+        userProfileType: 'COLLABORATOR',
+      },
+    };
+
+    const controlPanelService = createControlPanelService(userData);
+
+    // Act
+    const result = controlPanelService.getControlPanelSections((x) => x);
+    const visibleBoxes = result[0].boxes.filter((box) => !box.hidden);
+
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(result[0].anchorLink).toBe('account-preferences');
+    expect(visibleBoxes).toHaveLength(1);
+    expect(visibleBoxes[0].linkUrl).toBe('/control-panel/collaborator-edition');
+    expect(visibleBoxes[0].hidden).toBe(false);
+  });
 });

--- a/src/services/control-panel-service.ts
+++ b/src/services/control-panel-service.ts
@@ -119,9 +119,8 @@ export class ControlPanelService implements ControlPanelService {
         : 'none';
     const isClientManager = account !== 'none' ? account.user.hasClientManager : false;
     const isFreeAccount = account !== 'none' ? account.user.plan.isFreeAccount : false;
-    const isCollaborator = account !== 'none'
-      ? account.userAccount?.userProfileType === 'COLLABORATOR'
-      : false;
+    const isCollaborator =
+      account !== 'none' ? account.userAccount?.userProfileType === 'COLLABORATOR' : false;
     const hiddeCollaboratorsBox = !(account !== 'none'
       ? (account.userAccount?.userProfileType !== undefined
           ? account.userAccount.userProfileType === 'USER'

--- a/src/services/control-panel-service.ts
+++ b/src/services/control-panel-service.ts
@@ -72,6 +72,7 @@ const urlCampaignsPreferences = `${urlControlPanel}/CampaignsPreferences`;
 const urlSocialPreferences = `${urlControlPanel}/SocialPreferences`;
 const urlAdvancedPreferences = `${urlControlPanel}/AdvancedPreferences`;
 const urlSitesHelp = process.env.REACT_APP_DOPPLER_HELP_URL;
+const collaboratorEditionLinkUrl = '/control-panel/collaborator-edition';
 
 export interface ControlPanelService {
   getControlPanelSections(
@@ -118,6 +119,9 @@ export class ControlPanelService implements ControlPanelService {
         : 'none';
     const isClientManager = account !== 'none' ? account.user.hasClientManager : false;
     const isFreeAccount = account !== 'none' ? account.user.plan.isFreeAccount : false;
+    const isCollaborator = account !== 'none'
+      ? account.userAccount?.userProfileType === 'COLLABORATOR'
+      : false;
     const hiddeCollaboratorsBox = !(account !== 'none'
       ? (account.userAccount?.userProfileType !== undefined
           ? account.userAccount.userProfileType === 'USER'
@@ -462,7 +466,7 @@ export class ControlPanelService implements ControlPanelService {
       ];
     }
 
-    return [
+    const sections = [
       {
         title: _('control_panel.account_preferences.title'),
         anchorLink: 'account-preferences',
@@ -517,7 +521,7 @@ export class ControlPanelService implements ControlPanelService {
             hidden: hiddeCollaboratorsBox,
           },
           {
-            linkUrl: '/control-panel/collaborator-edition',
+            linkUrl: collaboratorEditionLinkUrl,
             imgSrc: collaborators_icon,
             imgAlt: _('control_panel.account_preferences.collaborator_edition_title'),
             iconName: _('control_panel.account_preferences.collaborator_edition_title'),
@@ -641,5 +645,19 @@ export class ControlPanelService implements ControlPanelService {
         ],
       },
     ];
+
+    if (isCollaborator) {
+      return sections
+        .map((section) => ({
+          ...section,
+          boxes: section.boxes.map((box) => ({
+            ...box,
+            hidden: box.linkUrl !== collaboratorEditionLinkUrl,
+          })),
+        }))
+        .filter((section) => section.boxes.some((box) => !box.hidden));
+    }
+
+    return sections;
   }
 }


### PR DESCRIPTION
<img width="1366" height="646" alt="image" src="https://github.com/user-attachments/assets/0de63f7c-9375-409b-a903-dfffb7dcd0a8" />

## Qué cambió

- Se agregó lógica en `ControlPanelService` para detectar cuando el usuario autenticado tiene `userAccount.userProfileType === 'COLLABORATOR'`.
- En ese caso, el Control Panel ahora muestra únicamente la box de edición del colaborador (`/control-panel/collaborator-edition`).
- Se ocultan el resto de las boxes del Control Panel para ese perfil.
- Además, se filtran las secciones que no tengan ninguna box visible, para evitar renderizar contenedores vacíos.
- Se unificó la URL de la box de edición de colaborador en una constante interna para evitar duplicación.

## Cobertura agregada

- Se agregó un test unitario en `src/services/control-panel-service.test.ts` para validar que, si el usuario es colaborador, solo se renderiza la box de `collaborator-edition`.

## Impacto esperado

- Los usuarios colaboradores ya no ven opciones del Control Panel que no les corresponden.
- El comportamiento para usuarios no colaboradores se mantiene sin cambios.