### PR TITLE
[DOI-3330] Change modal title add collaborator

### DIFF
--- a/src/components/ControlPanel/CollaboratorsSections/index.js
+++ b/src/components/ControlPanel/CollaboratorsSections/index.js
@@ -259,7 +259,7 @@ export const CollaboratorsSections = InjectAppServices(
               className="dp-button button-medium primary-green ng-binding"
               onClick={() => handleModalOpen(true)}
             >
-              {_('collaborators.add_collaborator')}
+              {_('collaborators.add_collaborator_button')}
             </button>
           </div>
         </HeaderSection>

--- a/src/components/ControlPanel/CollaboratorsSections/index.test.js
+++ b/src/components/ControlPanel/CollaboratorsSections/index.test.js
@@ -92,7 +92,7 @@ const renderComponent = (dopplerUserApiClient) =>
   );
 
 const openModalAndGoToPermissionsStep = async (user) => {
-  await user.click(screen.getByRole('button', { name: 'collaborators.add_collaborator' }));
+  await user.click(screen.getByRole('button', { name: 'collaborators.add_collaborator_button' }));
   await user.type(
     screen.getByLabelText('collaborators.form_modal.email'),
     'new.collaborator@fromdoppler.com',
@@ -162,7 +162,9 @@ describe('CollaboratorsSections', () => {
     const loader = screen.getByTestId('wrapper-loading');
     await waitForElementToBeRemoved(loader);
 
-    await user.click(screen.getByRole('button', { name: 'collaborators.add_collaborator' }));
+    await user.click(
+      screen.getByRole('button', { name: 'collaborators.add_collaborator_button' }),
+    );
     await user.type(
       screen.getByLabelText('collaborators.form_modal.email'),
       'new.collaborator@fromdoppler.com',

--- a/src/components/ControlPanel/CollaboratorsSections/index.test.js
+++ b/src/components/ControlPanel/CollaboratorsSections/index.test.js
@@ -162,9 +162,7 @@ describe('CollaboratorsSections', () => {
     const loader = screen.getByTestId('wrapper-loading');
     await waitForElementToBeRemoved(loader);
 
-    await user.click(
-      screen.getByRole('button', { name: 'collaborators.add_collaborator_button' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'collaborators.add_collaborator_button' }));
     await user.type(
       screen.getByLabelText('collaborators.form_modal.email'),
       'new.collaborator@fromdoppler.com',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -753,6 +753,7 @@ Payment details will be included in the invoice sent to the recipient you have i
     new_password: 'New password',
   },
   collaborators: {
+    add_collaborator_button: 'Add Collaborator',
     add_collaborator: 'Add new collaborator',
     edition_subtitle: 'Edit your data to keep using your account. Do not forget to save before leaving!',
     form_modal: {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -753,8 +753,8 @@ Payment details will be included in the invoice sent to the recipient you have i
     new_password: 'New password',
   },
   collaborators: {
-    add_collaborator_button: 'Add Collaborator',
     add_collaborator: 'Add new collaborator',
+    add_collaborator_button: 'Add Collaborator',
     edition_subtitle: 'Edit your data to keep using your account. Do not forget to save before leaving!',
     form_modal: {
       description: `The collaborator will have access to manage your Doppler account. It will be able to send campaigns,

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -753,7 +753,7 @@ Payment details will be included in the invoice sent to the recipient you have i
     new_password: 'New password',
   },
   collaborators: {
-    add_collaborator: 'New Collaborator',
+    add_collaborator: 'Add new collaborator',
     edition_subtitle: 'Edit your data to keep using your account. Do not forget to save before leaving!',
     form_modal: {
       description: `The collaborator will have access to manage your Doppler account. It will be able to send campaigns,

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -752,7 +752,8 @@ other {}}}}}}}}}}
     new_password: 'Nueva contraseña',
   },
   collaborators: {
-    add_collaborator: 'A\u00f1adir nuevo Colaborador',
+    add_collaborator_button: 'Añadir Colaborador',
+    add_collaborator: 'A\u00f1adir nuevo colaborador',
     edition_subtitle: `Edita los datos que necesitas para poder continuar utilizando tu cuenta.
     ¡No olvides guardar tu información!`,
     form_modal: {

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -752,14 +752,38 @@ other {}}}}}}}}}}
     new_password: 'Nueva contraseña',
   },
   collaborators: {
-    add_collaborator: 'Nuevo Colaborador',
+    add_collaborator: 'A\u00f1adir nuevo Colaborador',
     edition_subtitle: `Edita los datos que necesitas para poder continuar utilizando tu cuenta.
     ¡No olvides guardar tu información!`,
     form_modal: {
       description: `El colaborador tendrá acceso a gestionar tu cuenta de Doppler. Podrá realizar envio de campañas,
       gestión de listas, edición de automations y demás funcionalidades`,
+      edit_permissions_title: 'Editar Permisos',
+      edit_success_acknowledge: 'Entendido',
+      edit_success_subtitle: 'Editaste los permisos de tu colaborador con éxito.',
+      edit_success_title: 'Los cambios se guardaron',
       email: 'Email',
       email_placeholder: 'usuario_owner@ejemplo.com',
+      permissions_description: 'Elige los accesos de tu cuenta que le otorgarás.',
+      permissions_error: '¡Ouch! Tienes que seleccionar al menos un permiso.',
+      permissions_labels: {
+        section_01: 'Reportes',
+        section_02: 'Campañas',
+        section_03: 'Listas',
+        section_04: 'Panel de control',
+        section_05: 'Centro de descargas',
+        section_08: 'Pasos',
+        section_10: 'Automation',
+        section_11: 'Integraciones',
+        section_12: 'Plantillas',
+        section_13: 'Aprobador',
+        section_14: 'Dashboard',
+        section_15: 'Conversaciones',
+        section_16: 'OnSite',
+        section_18: 'Landings',
+      },
+      permissions_legend: 'Selecciona los permisos que desea asignar:',
+      permissions_title: 'Añadir nuevo colaborador',
       success_subtitle: `Tu Colaborador recibirá la invitación en su casilla de correo electrónico.
     Una vez aceptada la invitación, podrá comenzar a gestionar tu cuenta.`,
       success_title: 'Has añadido a tu Colaborador con éxito',
@@ -2600,42 +2624,6 @@ Con Doppler puedes generar Segmentos con intereses o características comunes, c
     warning_ip_validation_notification_SignUp: `Doppler no reconoce este dispositivo. Primero prueba iniciando sesión en la cuenta!`,
     warning_user_access_denied: `¡Ouch! Tu inicio de sesión ha sido rechazado.`,
   },
-};
-
-messages_es.collaborators.form_modal.permissions_title = 'Añadir nuevo colaborador';
-messages_es.collaborators.form_modal.permissions_description = 'Elige los accesos de tu cuenta que le otorgarás.';
-messages_es.collaborators.form_modal.permissions_legend = 'Selecciona los permisos que desea asignar:';
-messages_es.collaborators.form_modal.permissions_error = '¡Ouch! Tienes que seleccionar al menos un permiso.';
-messages_es.collaborators.form_modal = {
-  description: messages_es.collaborators.form_modal.description,
-  edit_permissions_title: 'Editar Permisos',
-  edit_success_acknowledge: 'Entendido',
-  edit_success_subtitle: 'Editaste los permisos de tu colaborador con éxito.',
-  edit_success_title: 'Los cambios se guardaron',
-  email: messages_es.collaborators.form_modal.email,
-  email_placeholder: messages_es.collaborators.form_modal.email_placeholder,
-  permissions_description: 'Elige los accesos de tu cuenta que le otorgar\u00e1s.',
-  permissions_error: '\u00a1Ouch! Tienes que seleccionar al menos un permiso.',
-  permissions_labels: {
-    section_01: 'Reportes',
-    section_02: 'Campa\u00f1as',
-    section_03: 'Listas',
-    section_04: 'Panel de control',
-    section_05: 'Centro de descargas',
-    section_08: 'Pasos',
-    section_10: 'Automation',
-    section_11: 'Integraciones',
-    section_12: 'Plantillas',
-    section_13: 'Aprobador',
-    section_14: 'Dashboard',
-    section_15: 'Conversaciones',
-    section_16: 'OnSite',
-    section_18: 'Landings',
-  },
-  permissions_legend: 'Selecciona los permisos que desea asignar:',
-  permissions_title: 'A\u00f1adir nuevo colaborador',
-  success_subtitle: messages_es.collaborators.form_modal.success_subtitle,
-  success_title: messages_es.collaborators.form_modal.success_title,
 };
 
 export default messages_es;

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -752,8 +752,8 @@ other {}}}}}}}}}}
     new_password: 'Nueva contraseña',
   },
   collaborators: {
+    add_collaborator: 'Añadir nuevo colaborador',
     add_collaborator_button: 'Añadir Colaborador',
-    add_collaborator: 'A\u00f1adir nuevo colaborador',
     edition_subtitle: `Edita los datos que necesitas para poder continuar utilizando tu cuenta.
     ¡No olvides guardar tu información!`,
     form_modal: {


### PR DESCRIPTION
## Descripción

Este PR ajusta los textos y el uso de traducciones en la sección de colaboradores.

### Cambios realizados

- Se corrigió la estructura de `collaborators.form_modal` en `src/i18n/es.js` para que quede alineada con `src/i18n/en.js`.
- Se movieron dentro de `collaborators.form_modal` las claves relacionadas con permisos y edición que habían quedado redefinidas al final de `es.js`.
- Se eliminó la reasignación tardía de `messages_es.collaborators.form_modal`, dejando la definición inline dentro del objeto principal.
- Se creó una nueva clave de traducción `collaborators.add_collaborator_button` para desacoplar el texto del botón del texto usado en otros contextos.
- Se actualizó el botón de alta de colaboradores para que use `collaborators.add_collaborator_button`.
- Se actualizaron los tests de `CollaboratorsSections` para reflejar la nueva clave de traducción.

### Resultado

- El modal de colaboradores en español queda estructurado de forma consistente con inglés.
- El botón principal de alta de colaboradores deja de reutilizar `collaborators.add_collaborator` y pasa a usar una clave específica.
- Se mejora la claridad semántica de las traducciones y se evita comportamiento inconsistente en `es.js`.