### PR TITLE
[DOI-3334] Render signup subtitle link in collaboration invite

### DIFF
--- a/src/components/CollaborationInvite/index.js
+++ b/src/components/CollaborationInvite/index.js
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { extractParameter, getFormInitialValues } from '../../utils';
 import queryString from 'query-string';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import LanguageSelector from '../shared/LanguageSelector/LanguageSelector';
 import {
   CheckboxFieldItemAccessible,
@@ -150,6 +150,15 @@ export const CollaboratorsInvite = InjectAppServices(
               <FormattedMessage
                 id={`signup.sign_up_sub`}
                 values={{
+                  Link: (chunk) => (
+                    <Link
+                      to={{ pathname: '/login', search: location.search }}
+                      className="link--title"
+                    >
+                      {chunk}
+                    </Link>
+                  ),
+                  Bold: (chunk) => <strong>{chunk}</strong>,
                   br: <br />,
                 }}
               />


### PR DESCRIPTION
## Descripción

- Se corrigió la pantalla de aceptación de invitación para que el subtítulo renderice correctamente el contenido enriquecido de `signup.sign_up_sub`.
- `CollaborationInvite` ahora pasa a `FormattedMessage` todos los valores que la traducción necesita (`Link`, `Bold` y `br`), alineando su implementación con `Signup`.
- Con este ajuste, deja de mostrarse el placeholder literal `<Link>Inicia sesión</Link>` y el enlace se renderiza correctamente.

FYI: Esto forma parte de un fix del commit `3a6cb8246`. @jhoffman-ms aca modificaste los translates y afecto justo a la parte de colaboradores.

## Archivos afectados

- `src/components/CollaborationInvite/index.js`
- `src/components/CollaborationInvite/index.test.js`

## Cómo se probó

- `yarn test:related -- src/components/CollaborationInvite/index.js src/components/CollaborationInvite/index.test.js`
- `yarn prettier-check`

## Notas

- No hubo SPEC versionada para este cambio, por lo que la trazabilidad queda limitada al requerimiento del prompt.
- La diferencia entre ambientes se explicaba porque la traducción nueva de `signup.sign_up_sub` ya incluye `Link` y `br`, pero `CollaborationInvite` no los estaba proveyendo al render.