### PR TITLE
[DOI-3338] Delete p

### DIFF
--- a/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.js
+++ b/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.js
@@ -91,7 +91,7 @@ export const CollaboratorPermissionsForm = ({
               <div className="dp-wrap-message dp-wrap-cancel m-b-12" role="alert">
                 <span className="dp-message-icon" />
                 <div className="dp-content-message">
-                    <FormattedMessage id={errors[fieldNames.permissions]} />
+                  <FormattedMessage id={errors[fieldNames.permissions]} />
                 </div>
               </div>
             ) : null}

--- a/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.js
+++ b/src/components/ControlPanel/CollaboratorsSections/Forms/CollaboratorPermissionsForm.js
@@ -91,9 +91,7 @@ export const CollaboratorPermissionsForm = ({
               <div className="dp-wrap-message dp-wrap-cancel m-b-12" role="alert">
                 <span className="dp-message-icon" />
                 <div className="dp-content-message">
-                  <p>
                     <FormattedMessage id={errors[fieldNames.permissions]} />
-                  </p>
                 </div>
               </div>
             ) : null}


### PR DESCRIPTION
Para que la alerta no se vea descentrada hay que quitar la etiqueta <p> ya que esta heredando del modal un margin aplicado a todos los <p>. Es la mejor opción para no caer en estilos in-line o tocar estilos de modales que pueden afectar otros lugares.